### PR TITLE
refactor: reduce duplication and improve code quality across Python codebase

### DIFF
--- a/test/distributed/test_process_group.py
+++ b/test/distributed/test_process_group.py
@@ -9,7 +9,7 @@ import torch.multiprocessing as mp
 from torch.testing._internal.common_device_type import dtypes, instantiate_device_type_tests
 from torch.testing._internal.common_utils import parametrize, run_tests, subtest, TestCase
 
-from test.utils import configure_master_port_for_rccl_tests, SUPPORTED_DTYPES
+from test.utils import configure_master_port_for_rccl_tests, setup_distributed_environment, SUPPORTED_DTYPES
 
 
 KiB = 1024
@@ -20,9 +20,7 @@ TEST_DTYPES = SUPPORTED_DTYPES + [torch.float32, torch.float64, torch.int8, torc
 
 def setup_environment(rank: int, world_size: int) -> None:
     """Setup environment variables for distributed testing."""
-    os.environ["LOCAL_RANK"] = str(rank)
-    os.environ["WORLD_SIZE"] = str(world_size)
-    torch.rbln.set_device(rank)
+    setup_distributed_environment(rank, world_size)
 
 
 def run_allreduce_test(rank: int, world_size: int, backend: str, op: dist.ReduceOp) -> None:

--- a/test/distributed/test_tp_pp.py
+++ b/test/distributed/test_tp_pp.py
@@ -10,14 +10,12 @@ import torch.nn as nn
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import parametrize, run_tests, subtest, TestCase
 
-from test.utils import configure_master_port_for_rccl_tests, set_deterministic_seeds
+from test.utils import configure_master_port_for_rccl_tests, set_deterministic_seeds, setup_distributed_environment
 
 
 def setup_environment(rank: int, world_size: int) -> None:
     """Setup environment variables for distributed testing."""
-    os.environ["LOCAL_RANK"] = str(rank)
-    os.environ["WORLD_SIZE"] = str(world_size)
-    torch.rbln.set_device(rank)
+    setup_distributed_environment(rank, world_size)
 
 
 def run_default_group_allreduce_test(rank: int, world_size: int, backend: str) -> None:

--- a/test/rbln/test_graph_eager_mode.py
+++ b/test/rbln/test_graph_eager_mode.py
@@ -10,12 +10,11 @@ import torch.nn as nn
 from torch.testing._internal.common_device_type import dtypes, instantiate_device_type_tests
 from torch.testing._internal.common_utils import run_tests, TestCase
 
-from test.utils import SUPPORTED_DTYPES
+from test.utils import GRAPH_EAGER_ATOL, GRAPH_EAGER_RTOL, SUPPORTED_DTYPES
 
 
-# Tolerance for numerical comparisons
-ATOL = 0.04
-RTOL = 0.07
+ATOL = GRAPH_EAGER_ATOL
+RTOL = GRAPH_EAGER_RTOL
 
 
 @pytest.mark.test_set_ci

--- a/test/rbln/test_internal_op_utils.py
+++ b/test/rbln/test_internal_op_utils.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 import pytest
 import torch
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import TestCase, run_tests
 from torch.utils._python_dispatch import TorchDispatchMode
 
 from torch_rbln._internal.ops_utils import (
@@ -675,25 +675,36 @@ class TestFallbackCheckers(TestCase):
 
     def test_has_nan_or_inf_clean_tensors(self):
         tensors = [torch.tensor([1.0, 2.0]), torch.tensor([3.0, 4.0])]
-        with patch("torch_rbln._internal.ops_utils.is_rbln_deploy", return_value=False):
-            self.assertFalse(_has_nan_or_inf(tensors))
+        args = (torch.tensor([1.0, 2.0]), torch.tensor([3.0, 4.0]))
+        with patch("torch_rbln._internal.env_utils.is_rbln_deploy", return_value=False):
+            self.assertFalse(_has_nan_or_inf(tensors, args))
 
     def test_has_nan_or_inf_with_nan_tensor(self):
         tensors = [torch.tensor([1.0, float("nan")])]
-        with patch("torch_rbln._internal.ops_utils.is_rbln_deploy", return_value=False):
-            self.assertTrue(_has_nan_or_inf(tensors))
+        args = (torch.tensor([1.0, float("nan")]),)
+        with patch("torch_rbln._internal.env_utils.is_rbln_deploy", return_value=False):
+            self.assertTrue(_has_nan_or_inf(tensors, args))
 
     def test_has_nan_or_inf_deploy_mode_skips(self):
         tensors = [torch.tensor([1.0, float("nan")])]
-        with patch("torch_rbln._internal.ops_utils.is_rbln_deploy", return_value=True):
-            self.assertFalse(_has_nan_or_inf(tensors))
+        args = (torch.tensor([1.0, float("nan")]),)
+        with patch("torch_rbln._internal.env_utils.is_rbln_deploy", return_value=True):
+            self.assertFalse(_has_nan_or_inf(tensors, args))
 
     def test_has_nan_or_inf_early_return(self):
         """Should return True on first NaN tensor without checking the rest."""
         t1 = torch.tensor([float("nan")])
         t2 = torch.tensor([1.0, 2.0])
-        with patch("torch_rbln._internal.ops_utils.is_rbln_deploy", return_value=False):
-            self.assertTrue(_has_nan_or_inf([t1, t2]))
+        args = (t1, t2)
+        with patch("torch_rbln._internal.env_utils.is_rbln_deploy", return_value=False):
+            self.assertTrue(_has_nan_or_inf([t1, t2], args))
+
+    def test_has_nan_or_inf_scalar_nan(self):
+        """Scalar float('nan') in args (not in tensor) should be detected."""
+        t = torch.tensor([1.0, 2.0])
+        args = (t, float("nan"))
+        with patch("torch_rbln._internal.env_utils.is_rbln_deploy", return_value=False):
+            self.assertTrue(_has_nan_or_inf([t], args))
 
     def test_extract_tensors_flat(self):
         t1 = torch.tensor([1.0])

--- a/test/rbln/test_internal_op_utils.py
+++ b/test/rbln/test_internal_op_utils.py
@@ -14,10 +14,19 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 from torch.utils._python_dispatch import TorchDispatchMode
 
 from torch_rbln._internal.ops_utils import (
+    _all_scalars,
+    _contains_nan_or_inf,
+    _get_default_compile_options,
+    _has_nan_or_inf,
+    _has_non_float16_dtype,
+    _has_nonzero_storage_offset,
+    _is_trace_active,
     _parse_disabled_fallback_cases,
+    _resolve_result_tensor,
     broadcast_args_general,
     can_use_out_tensor_directly,
     cpu_fallback_path,
+    extract_tensors,
     finalize_output_tensor,
     handle_empty_binary,
     handle_empty_linear,
@@ -27,6 +36,7 @@ from torch_rbln._internal.ops_utils import (
     handle_empty_where,
     is_cpu_fallback_cases,
     is_inplace_op,
+    make_op_module,
     prepare_args_for_contiguous,
 )
 
@@ -589,9 +599,208 @@ class TestTorchDispatchModeWithRbln(TestCase):
         self.assertEqual(rbln_result.cpu(), expected, atol=1e-2, rtol=1e-2)
 
 
+@pytest.mark.test_set_ci
+class TestFallbackCheckers(TestCase):
+    """Unit tests for individual CPU fallback checker functions."""
+
+    def test_is_trace_active_no_trace(self):
+        with patch("sys.gettrace", return_value=None):
+            self.assertFalse(_is_trace_active())
+
+    def test_is_trace_active_with_trace(self):
+        with patch("sys.gettrace", return_value=lambda *a: None):
+            self.assertTrue(_is_trace_active())
+
+    def test_has_non_float16_dtype_all_float16(self):
+        tensors = [torch.empty(2, dtype=torch.float16), torch.empty(3, dtype=torch.float16)]
+        self.assertFalse(_has_non_float16_dtype(tensors))
+
+    def test_has_non_float16_dtype_mixed(self):
+        tensors = [torch.empty(2, dtype=torch.float16), torch.empty(3, dtype=torch.float32)]
+        self.assertTrue(_has_non_float16_dtype(tensors))
+
+    def test_has_non_float16_dtype_single_float32(self):
+        self.assertTrue(_has_non_float16_dtype([torch.empty(1, dtype=torch.float32)]))
+
+    def test_all_scalars_true(self):
+        scalars = [torch.tensor(1.0), torch.tensor(2.0)]
+        self.assertTrue(_all_scalars(scalars))
+
+    def test_all_scalars_false_with_1d(self):
+        tensors = [torch.tensor(1.0), torch.tensor([2.0])]
+        self.assertFalse(_all_scalars(tensors))
+
+    def test_all_scalars_empty_list(self):
+        self.assertTrue(_all_scalars([]))
+
+    def test_has_nonzero_storage_offset_no_offset(self):
+        t = torch.randn(4)
+        self.assertFalse(_has_nonzero_storage_offset([t]))
+
+    def test_has_nonzero_storage_offset_with_offset(self):
+        base = torch.randn(8)
+        sliced = base[2:6]  # contiguous but storage_offset != 0
+        self.assertTrue(sliced.is_contiguous())
+        self.assertNotEqual(sliced.storage_offset(), 0)
+        self.assertTrue(_has_nonzero_storage_offset([sliced]))
+
+    def test_has_nonzero_storage_offset_noncontiguous_ignored(self):
+        base = torch.randn(4, 4)
+        transposed = base.t()  # not contiguous, has offset 0
+        self.assertFalse(transposed.is_contiguous())
+        self.assertFalse(_has_nonzero_storage_offset([transposed]))
+
+    def test_contains_nan_or_inf_clean(self):
+        t = torch.tensor([1.0, 2.0, 3.0])
+        self.assertFalse(_contains_nan_or_inf(t))
+
+    def test_contains_nan_or_inf_with_nan(self):
+        t = torch.tensor([1.0, float("nan"), 3.0])
+        self.assertTrue(_contains_nan_or_inf(t))
+
+    def test_contains_nan_or_inf_with_inf(self):
+        t = torch.tensor([1.0, float("inf"), 3.0])
+        self.assertTrue(_contains_nan_or_inf(t))
+
+    def test_contains_nan_or_inf_bool_tensor(self):
+        t = torch.tensor([True, False])
+        self.assertFalse(_contains_nan_or_inf(t))
+
+    def test_contains_nan_or_inf_scalar_nan(self):
+        self.assertTrue(_contains_nan_or_inf(float("nan")))
+
+    def test_contains_nan_or_inf_scalar_normal(self):
+        self.assertFalse(_contains_nan_or_inf(42))
+        self.assertFalse(_contains_nan_or_inf(3.14))
+
+    def test_has_nan_or_inf_clean_tensors(self):
+        tensors = [torch.tensor([1.0, 2.0]), torch.tensor([3.0, 4.0])]
+        with patch("torch_rbln._internal.ops_utils.is_rbln_deploy", return_value=False):
+            self.assertFalse(_has_nan_or_inf(tensors))
+
+    def test_has_nan_or_inf_with_nan_tensor(self):
+        tensors = [torch.tensor([1.0, float("nan")])]
+        with patch("torch_rbln._internal.ops_utils.is_rbln_deploy", return_value=False):
+            self.assertTrue(_has_nan_or_inf(tensors))
+
+    def test_has_nan_or_inf_deploy_mode_skips(self):
+        tensors = [torch.tensor([1.0, float("nan")])]
+        with patch("torch_rbln._internal.ops_utils.is_rbln_deploy", return_value=True):
+            self.assertFalse(_has_nan_or_inf(tensors))
+
+    def test_has_nan_or_inf_early_return(self):
+        """Should return True on first NaN tensor without checking the rest."""
+        t1 = torch.tensor([float("nan")])
+        t2 = torch.tensor([1.0, 2.0])
+        with patch("torch_rbln._internal.ops_utils.is_rbln_deploy", return_value=False):
+            self.assertTrue(_has_nan_or_inf([t1, t2]))
+
+    def test_extract_tensors_flat(self):
+        t1 = torch.tensor([1.0])
+        t2 = torch.tensor([2.0])
+        result = extract_tensors((t1, 42, t2, "hello"))
+        self.assertEqual(len(result), 2)
+
+    def test_extract_tensors_nested(self):
+        t1 = torch.tensor([1.0])
+        t2 = torch.tensor([2.0])
+        result = extract_tensors({"a": t1, "b": [t2, 3]})
+        self.assertEqual(len(result), 2)
+
+    def test_extract_tensors_empty(self):
+        self.assertEqual(extract_tensors((42, "hello")), [])
+
+
+@pytest.mark.test_set_ci
+class TestCompileUtilities(TestCase):
+    """Unit tests for compile_and_execute utilities."""
+
+    def test_make_op_module_creates_module(self):
+        mod = make_op_module(torch.add)
+        self.assertIsInstance(mod, torch.nn.Module)
+        # Verify it's in eval mode
+        self.assertFalse(mod.training)
+
+    def test_make_op_module_forward_works_on_cpu(self):
+        mod = make_op_module(torch.add)
+        a = torch.tensor([1.0, 2.0])
+        b = torch.tensor([3.0, 4.0])
+        result = mod(a, b)
+        expected = torch.tensor([4.0, 6.0])
+        self.assertEqual(result, expected)
+
+    def test_make_op_module_qualname(self):
+        mod = make_op_module(torch.add)
+        self.assertIn("add", mod.__class__.__qualname__)
+
+    def test_get_default_compile_options_cached(self):
+        _get_default_compile_options.cache_clear()
+        try:
+            opts1 = _get_default_compile_options()
+            opts2 = _get_default_compile_options()
+            # Should be the exact same object (cached)
+            self.assertIs(opts1, opts2)
+            self.assertIn("disable_logger", opts1)
+            self.assertTrue(opts1["disable_logger"])
+        finally:
+            _get_default_compile_options.cache_clear()
+
+    def test_resolve_result_tensor_none_out(self):
+        result = _resolve_result_tensor(None, (), {})
+        self.assertIsNone(result)
+
+    def test_resolve_result_tensor_valid_out(self):
+        out = torch.empty(4, dtype=torch.float16, device="rbln")
+        args = (torch.randn(4, dtype=torch.float16, device="rbln"),)
+        result = _resolve_result_tensor(out, args, {"out": out})
+        # Should return out since it meets all conditions
+        self.assertIs(result, out)
+
+    def test_resolve_result_tensor_non_contiguous_out(self):
+        base = torch.empty(4, 4, dtype=torch.float16, device="rbln")
+        out = base.t()  # non-contiguous
+        args = (torch.randn(4, 4, dtype=torch.float16, device="rbln"),)
+        result = _resolve_result_tensor(out, args, {"out": out})
+        # Should return None since out is not contiguous
+        self.assertIsNone(result)
+
+
+@pytest.mark.test_set_ci
+class TestPrepareArgsContiguousFastPath(TestCase):
+    """Test the fast-path optimization in prepare_args_for_contiguous."""
+
+    def test_fast_path_all_contiguous(self):
+        t1 = torch.randn(2, 3, device="rbln")
+        t2 = torch.randn(4, device="rbln")
+        (new_args, new_kwargs), changed = prepare_args_for_contiguous((t1, t2), {"alpha": 1.0})
+        self.assertFalse(changed)
+
+    def test_slow_path_non_contiguous(self):
+        base = torch.randn(4, 4, device="rbln")
+        non_contig = base.t()
+        self.assertFalse(non_contig.is_contiguous())
+        (new_args, _), changed = prepare_args_for_contiguous((non_contig,), {})
+        self.assertTrue(changed)
+        self.assertTrue(new_args[0].is_contiguous())
+
+    def test_fast_path_mixed_tensor_and_scalar(self):
+        t = torch.randn(3, device="rbln")
+        (new_args, _), changed = prepare_args_for_contiguous((t, 42, "str"), {"dim": 0})
+        self.assertFalse(changed)
+
+    def test_empty_tensor_skipped_in_fast_path(self):
+        empty_t = torch.empty(0, device="rbln")
+        normal_t = torch.randn(3, device="rbln")
+        (new_args, _), changed = prepare_args_for_contiguous((empty_t, normal_t), {})
+        self.assertFalse(changed)
+
+
 instantiate_device_type_tests(TestInternalOpUtils, globals(), only_for="privateuse1")
 instantiate_device_type_tests(TestOutTensors, globals(), only_for="privateuse1")
 instantiate_device_type_tests(TestTorchDispatchModeWithRbln, globals(), only_for="privateuse1")
+instantiate_device_type_tests(TestFallbackCheckers, globals(), only_for="privateuse1")
+instantiate_device_type_tests(TestCompileUtilities, globals(), only_for="privateuse1")
+instantiate_device_type_tests(TestPrepareArgsContiguousFastPath, globals(), only_for="privateuse1")
 
 if __name__ == "__main__":
     run_tests()

--- a/test/rbln/test_registered_ops.py
+++ b/test/rbln/test_registered_ops.py
@@ -14,12 +14,11 @@ import torch
 from torch.testing._internal.common_device_type import dtypes, instantiate_device_type_tests
 from torch.testing._internal.common_utils import parametrize, run_tests, TestCase
 
-from test.utils import requires_logical_devices, SUPPORTED_DTYPES
+from test.utils import DEFAULT_ATOL, DEFAULT_RTOL, requires_logical_devices, SUPPORTED_DTYPES
 
 
-# Tolerance for numerical comparisons
-ATOL = 0.01
-RTOL = 0.01
+ATOL = DEFAULT_ATOL
+RTOL = DEFAULT_RTOL
 
 
 # Various test shapes for comprehensive testing

--- a/test/rbln/test_tensor_copy.py
+++ b/test/rbln/test_tensor_copy.py
@@ -11,12 +11,11 @@ import torch
 from torch.testing._internal.common_device_type import dtypes, instantiate_device_type_tests
 from torch.testing._internal.common_utils import parametrize, run_tests, TestCase
 
-from test.utils import SUPPORTED_DTYPES
+from test.utils import DEFAULT_ATOL, DEFAULT_RTOL, SUPPORTED_DTYPES
 
 
-# Tolerance for numerical comparisons
-ATOL = 0.01
-RTOL = 0.01
+ATOL = DEFAULT_ATOL
+RTOL = DEFAULT_RTOL
 
 
 TEST_DTYPES = SUPPORTED_DTYPES + [torch.float32]

--- a/test/rbln/test_tensor_memory.py
+++ b/test/rbln/test_tensor_memory.py
@@ -13,12 +13,11 @@ import torch
 from torch.testing._internal.common_device_type import dtypes, instantiate_device_type_tests
 from torch.testing._internal.common_utils import parametrize, run_tests, TestCase
 
-from test.utils import run_in_isolated_process, SUPPORTED_DTYPES
+from test.utils import DEFAULT_ATOL, DEFAULT_RTOL, run_in_isolated_process, SUPPORTED_DTYPES
 
 
-# Tolerance for numerical comparisons
-ATOL = 0.01
-RTOL = 0.01
+ATOL = DEFAULT_ATOL
+RTOL = DEFAULT_RTOL
 
 
 @pytest.mark.test_set_ci

--- a/test/utils.py
+++ b/test/utils.py
@@ -10,6 +10,15 @@ import torch
 
 SUPPORTED_DTYPES = [torch.float16]
 
+# Default tolerances for float16 numerical comparisons on RBLN devices.
+DEFAULT_ATOL = 0.01
+DEFAULT_RTOL = 0.01
+
+# Wider tolerances for graph-vs-eager mode comparisons, where minor
+# numerical divergence between compiled graphs and eager execution is expected.
+GRAPH_EAGER_ATOL = 0.04
+GRAPH_EAGER_RTOL = 0.07
+
 _DEFAULT_DISTRIBUTED_MASTER_PORT = "29604"
 
 
@@ -71,6 +80,17 @@ def requires_physical_devices(num_devices):
         physical_device_count < num_devices,
         reason=f"Requires at least {num_devices} physical devices, found {physical_device_count}",
     )
+
+
+def setup_distributed_environment(rank: int, world_size: int) -> None:
+    """Setup environment variables for distributed testing.
+
+    Sets LOCAL_RANK, WORLD_SIZE, and the active RBLN device for the given rank.
+    Used by distributed test files (test_process_group, test_tp_pp, etc.).
+    """
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    torch.rbln.set_device(rank)
 
 
 def run_in_isolated_process(func, *args):

--- a/tools/codegen/generators/general_template.py
+++ b/tools/codegen/generators/general_template.py
@@ -124,7 +124,6 @@ class GeneralTemplates:
             """Generate function body start."""
             return f"""
 def {kernel_name}(*args, **kwargs):
-    from torch_rbln.device.context_holder import out_tensor_context
 """
 
         @staticmethod
@@ -144,49 +143,20 @@ def {kernel_name}(*args, **kwargs):
 
         @staticmethod
         def op_module_definition(root_name: str, target: str) -> str:
-            """Generate per-op nn.Module with literal forward (opaque under torch.compile). Module-level."""
-            class_name = f"OpModule_{root_name}"
+            """Generate per-op nn.Module via make_op_module factory (opaque under torch.compile). Module-level."""
             var_name = f"_{root_name}_op_module"
             return f"""
-class {class_name}(torch.nn.Module):
-    def forward(self, *args, **kwargs):
-        return {target}(*args, **kwargs)
-{var_name} = {class_name}().eval()
+{var_name} = make_op_module({target})
 """
 
         @staticmethod
         def compile_section(root_name: str, target: str) -> str:
-            """Generate compilation and execution section (uses per-op module for opaque compile)."""
+            """Generate compilation and execution section (uses compile_and_execute utility)."""
             op_module_var = f"_{root_name}_op_module"
-            return f"""        # Prepare result tensor and compile options based on out_tensor availability
-        # Base compile options: always include eager_mode for eager execution context
-        compile_options = {{"disable_logger": True}}
-        # By default, eager mode ops use tp_size=1 due to current compiler structure.
-        # If TORCH_RBLN_USE_DEVICE_TP=ON, eager mode ops will follow
-        # the logical device size (RBLN_NPUS_PER_DEVICE) like torch.compile operations.
-        if not use_device_group_tensor_parallel_size():
-            compile_options["tensor_parallel_size"] = 1
-        if out_tensor is None:
-            result_tensor = None
-        else:
-            # Check if out_tensor can be used directly by compiler
-            can_use_out_tensor_directly_flag = can_use_out_tensor_directly(
-                contig_args, dict(contig_kwargs, out=out_tensor)
+            return (
+                f"        result_tensor = compile_and_execute(\n"
+                f"            {op_module_var}, contig_args, contig_kwargs, out_tensor=out_tensor\n"
+                f"        )\n"
+                f"\n"
+                f"    return result_tensor, result_tensor.shape\n"
             )
-
-            if can_use_out_tensor_directly_flag:
-                # Use out tensor directly - compiler will write results here
-                result_tensor = out_tensor
-            else:
-                result_tensor = None
-
-        with out_tensor_context(result_tensor):
-            compiled = torch.compile({op_module_var}, backend="rbln", dynamic=False, options=compile_options)
-            external_result = compiled(*contig_args, **contig_kwargs)
-            if result_tensor is None:
-                result_tensor = external_result
-            elif isinstance(external_result, torch.Tensor) and (external_result.data_ptr() != result_tensor.data_ptr()):
-                result_tensor.copy_(external_result)
-
-    return result_tensor, result_tensor.shape
-"""

--- a/torch_rbln/_internal/ops_utils.py
+++ b/torch_rbln/_internal/ops_utils.py
@@ -304,7 +304,12 @@ def handle_empty_tensor(tensor_args):
 
 
 def prepare_args_for_contiguous(args, kwargs_filtered):
+    # Fast path: skip tree_flatten/unflatten if all tensors are already contiguous.
+    # This avoids pytree overhead for the common case where no copy is needed.
     flat_args, args_spec = tree_flatten((args, kwargs_filtered))
+    if all(a.is_contiguous() for a in flat_args if isinstance(a, torch.Tensor) and a.numel() > 0):
+        return tree_unflatten(flat_args, args_spec), False
+
     contig_args, changed_any = [], False
     for a in flat_args:
         t, changed = _make_contig(a)
@@ -365,14 +370,26 @@ def _has_nonzero_storage_offset(tensor_args) -> bool:
     return any(a.is_contiguous() and a.storage_offset() != 0 for a in tensor_args)
 
 
-def _has_nan_or_inf(args) -> bool:
-    """Check if any tensor contains NaN or Inf values (non-deploy mode only)."""
+def _has_nan_or_inf(tensor_args) -> bool:
+    """Check if any tensor contains NaN or Inf values (non-deploy mode only).
+
+    Accepts a pre-extracted flat list of tensors to avoid redundant
+    ``extract_tensors`` / ``to_cpu`` traversal over the full args tree.
+    Each tensor is individually copied to CPU and checked, with early
+    return on the first invalid value found.
+    """
     try:
         from torch_rbln._internal.env_utils import is_rbln_deploy
 
-        return not is_rbln_deploy() and has_invalid_tensor(to_cpu(args))
+        if is_rbln_deploy():
+            return False
     except ImportError:
         return False
+
+    for t in tensor_args:
+        if _contains_nan_or_inf(t.cpu()):
+            return True
+    return False
 
 
 def _is_reentrant() -> bool:
@@ -429,8 +446,9 @@ def is_cpu_fallback_cases(args):
     if "storage_offset" not in disabled_cases and _has_nonzero_storage_offset(tensor_args):
         return True
 
-    # Heavy check: copies tensors to CPU to scan for NaN/Inf
-    if "nan_inf" not in disabled_cases and _has_nan_or_inf(args):
+    # Heavy check: copies tensors to CPU to scan for NaN/Inf.
+    # Reuses the already-extracted tensor_args to avoid a second full-tree traversal.
+    if "nan_inf" not in disabled_cases and _has_nan_or_inf(tensor_args):
         return True
 
     # Last: reentrancy check

--- a/torch_rbln/_internal/ops_utils.py
+++ b/torch_rbln/_internal/ops_utils.py
@@ -565,3 +565,93 @@ def _ceil_to_nearest_multiple_of_64(n):
         int: The smallest multiple of 64 that is greater than or equal to `n`.
     """
     return math.ceil(n / 64) * 64
+
+
+# ---------------------------------------------------------------------------
+# Eager-mode compile+execute utilities
+# ---------------------------------------------------------------------------
+
+
+@lru_cache(maxsize=1)
+def _get_default_compile_options() -> dict:
+    """Return the default compile options for eager-mode RBLN ops.
+
+    The result is cached because the underlying environment variable
+    (``TORCH_RBLN_USE_DEVICE_TP``) is expected to be set once at process
+    start and remain constant for the lifetime of the process.
+    """
+    from torch_rbln._internal.env_utils import use_device_group_tensor_parallel_size
+
+    options: dict = {"disable_logger": True}
+    if not use_device_group_tensor_parallel_size():
+        options["tensor_parallel_size"] = 1
+    return options
+
+
+def _resolve_result_tensor(out_tensor, contig_args, contig_kwargs):
+    """Determine whether *out_tensor* can be written to directly by the compiler.
+
+    Returns *out_tensor* itself when direct use is safe, otherwise ``None``
+    (which tells the compiler to allocate a temporary).
+    """
+    if out_tensor is None:
+        return None
+    if can_use_out_tensor_directly(contig_args, dict(contig_kwargs, out=out_tensor)):
+        return out_tensor
+    return None
+
+
+def compile_and_execute(op_module, contig_args, contig_kwargs, out_tensor=None):
+    """Compile *op_module* with the RBLN backend and execute it.
+
+    This is the standard compile+execute pattern shared by all eager-mode ops
+    (both generated and hand-written).  It handles:
+
+    * Building compile options (tp_size, logger suppression)
+    * Resolving whether the caller's *out_tensor* can be reused directly
+    * Binding the result tensor via ``out_tensor_context``
+    * Copying the compiler's result if it landed at a different address
+
+    Args:
+        op_module: An ``nn.Module`` whose ``forward`` calls the target op.
+        contig_args: Contiguous positional arguments.
+        contig_kwargs: Contiguous keyword arguments (``out`` excluded).
+        out_tensor: Optional pre-allocated output tensor from the caller.
+
+    Returns:
+        The result tensor (on the RBLN device).
+    """
+    from torch_rbln.device.context_holder import out_tensor_context
+
+    compile_options = _get_default_compile_options()
+    result_tensor = _resolve_result_tensor(out_tensor, contig_args, contig_kwargs)
+
+    with out_tensor_context(result_tensor):
+        compiled = torch.compile(op_module, backend="rbln", dynamic=False, options=compile_options)
+        external_result = compiled(*contig_args, **contig_kwargs)
+        if result_tensor is None:
+            result_tensor = external_result
+        elif isinstance(external_result, torch.Tensor) and (external_result.data_ptr() != result_tensor.data_ptr()):
+            result_tensor.copy_(external_result)
+
+    return result_tensor
+
+
+def make_op_module(target_fn):
+    """Create an ``nn.Module`` whose ``forward`` delegates to *target_fn*.
+
+    Each eager op needs an opaque module wrapper so that ``torch.compile``
+    (Dynamo) captures the call as a single graph node rather than inlining the
+    op's implementation.
+
+    Usage::
+
+        _add_op_module = make_op_module(torch.add)
+    """
+
+    class _OpModule(torch.nn.Module):
+        def forward(self, *args, **kwargs):
+            return target_fn(*args, **kwargs)
+
+    _OpModule.__qualname__ = f"OpModule_{getattr(target_fn, '__name__', 'op')}"
+    return _OpModule().eval()

--- a/torch_rbln/_internal/ops_utils.py
+++ b/torch_rbln/_internal/ops_utils.py
@@ -370,13 +370,16 @@ def _has_nonzero_storage_offset(tensor_args) -> bool:
     return any(a.is_contiguous() and a.storage_offset() != 0 for a in tensor_args)
 
 
-def _has_nan_or_inf(tensor_args) -> bool:
-    """Check if any tensor contains NaN or Inf values (non-deploy mode only).
+def _has_nan_or_inf(tensor_args, args) -> bool:
+    """Check if any tensor or scalar arg contains NaN or Inf (non-deploy mode only).
 
-    Accepts a pre-extracted flat list of tensors to avoid redundant
-    ``extract_tensors`` / ``to_cpu`` traversal over the full args tree.
-    Each tensor is individually copied to CPU and checked, with early
-    return on the first invalid value found.
+    *tensor_args* is the pre-extracted flat list of tensors (avoids
+    redundant ``extract_tensors`` traversal).  Each tensor is individually
+    copied to CPU with early return on the first invalid value.
+
+    *args* is the original args tree — flattened cheaply (no tensor copies)
+    to catch scalar ``float('nan')`` / ``float('inf')`` arguments that
+    ``extract_tensors`` does not collect.
     """
     try:
         from torch_rbln._internal.env_utils import is_rbln_deploy
@@ -389,7 +392,10 @@ def _has_nan_or_inf(tensor_args) -> bool:
     for t in tensor_args:
         if _contains_nan_or_inf(t.cpu()):
             return True
-    return False
+
+    # Lightweight scalar check — tree_flatten involves no tensor copies.
+    flat_args, _ = tree_flatten(args)
+    return any(_contains_nan_or_inf(a) for a in flat_args if not isinstance(a, torch.Tensor))
 
 
 def _is_reentrant() -> bool:
@@ -448,7 +454,8 @@ def is_cpu_fallback_cases(args):
 
     # Heavy check: copies tensors to CPU to scan for NaN/Inf.
     # Reuses the already-extracted tensor_args to avoid a second full-tree traversal.
-    if "nan_inf" not in disabled_cases and _has_nan_or_inf(tensor_args):
+    # Also checks scalar float args (e.g. float('nan')) via lightweight tree_flatten.
+    if "nan_inf" not in disabled_cases and _has_nan_or_inf(tensor_args, args):
         return True
 
     # Last: reentrancy check

--- a/torch_rbln/_internal/ops_utils.py
+++ b/torch_rbln/_internal/ops_utils.py
@@ -331,96 +331,111 @@ def _parse_disabled_fallback_cases() -> frozenset:
     return _ALL_FALLBACK_CASES if ("all" in cases) else (cases & _ALL_FALLBACK_CASES)
 
 
-def is_cpu_fallback_cases(args):
+def _is_trace_active() -> bool:
+    """Check if a Python trace/debugger is active (e.g. pdb, coverage, sys.settrace)."""
+    return sys.gettrace() is not None
+
+
+def _is_dispatch_mode_active() -> bool:
+    """Check if a non-infra TorchDispatchMode is active.
+
+    When active, torch.compile would skip compilation and run eagerly,
+    causing infinite recursion through the RBLN dispatch path.
     """
-    Determines if a CPU fallback is necessary for an operation.
+    try:
+        from torch.utils._python_dispatch import is_in_torch_dispatch_mode
 
-    This function checks for several conditions that would require an operation to fall back to the CPU:
-    0a. **Python trace/debugger**: When a trace function is set (e.g. pdb, coverage, sys.settrace), we fall
-        back to CPU to avoid running torch.compile under a tracer. Disable with
-        TORCH_RBLN_DEV_DISABLE_OP_CPU_FALLBACK=trace for debugging only.
-    1. **TorchDispatchMode Active**: When a non-infra TorchDispatchMode is active (e.g. LoggingMode,
-       CompositeCompliantTensorMode), we must not attempt torch.compile. Reason: with rbln tensors we do
-       add_rbln -> torch.compile(torch.add) -> ...; Dynamo sees the dispatch mode and skips compilation,
-       then runs the original torch.add eagerly; that eager call dispatches again and hits our add_rbln
-       -> same path repeats -> infinite recursion. So when TorchDispatchMode is on, we fall back to CPU
-       and never enter the compile path.
-    2. **Data Type Mismatch:** If any of the input tensors are not of the `torch.float16` data type,
-       which the `rbln` device is designed to handle.
-    3. **Scalar Tensors**: If all input tensors are scalar tensors, rebel-compiler falls back to host ops.
-    4. **Storage Offset**: If any tensor has `storage_offset != 0`, fall back to CPU.
-    5. **NaN/Inf Values**: When not in deploy mode, if any input tensor contains NaN or Inf values,
-       rbln cannot handle them and we need to fall back to CPU. This check converts tensors to CPU
-       before checking to ensure accurate detection.
-    6. **Reentrancy** (checked last): When we're already inside an RBLN op that uses torch.compile
-       (thread-local depth > 0), any nested dispatch (e.g. compiled graph running torch.add -> add_rbln
-       again, or print/repr triggering tensor ops) must use CPU fallback to avoid infinite recursion.
-       This is an unexpected path; a warning is logged when it triggers. Disable with
-       TORCH_RBLN_DEV_DISABLE_OP_CPU_FALLBACK=reentrant for debugging only.
+        return is_in_torch_dispatch_mode(include_infra_modes=False)
+    except ImportError:
+        return False
 
-    Individual checks can be disabled via `TORCH_RBLN_DEV_DISABLE_OP_CPU_FALLBACK`
-    (comma-separated names or `"all"`).
+
+def _has_non_float16_dtype(tensor_args) -> bool:
+    """Check if any tensor has a dtype other than float16 (the only RBLN-supported dtype)."""
+    return any(a.dtype != torch.float16 for a in tensor_args)
+
+
+def _all_scalars(tensor_args) -> bool:
+    """Check if all input tensors are 0-dim scalars (rebel-compiler falls back to host ops)."""
+    return all(a.ndim == 0 for a in tensor_args)
+
+
+def _has_nonzero_storage_offset(tensor_args) -> bool:
+    """Check if any contiguous tensor has a non-zero storage offset."""
+    return any(a.is_contiguous() and a.storage_offset() != 0 for a in tensor_args)
+
+
+def _has_nan_or_inf(args) -> bool:
+    """Check if any tensor contains NaN or Inf values (non-deploy mode only)."""
+    try:
+        from torch_rbln._internal.env_utils import is_rbln_deploy
+
+        return not is_rbln_deploy() and has_invalid_tensor(to_cpu(args))
+    except ImportError:
+        return False
+
+
+def _is_reentrant() -> bool:
+    """Check if we're already inside an RBLN compile op (risks infinite recursion)."""
+    from torch_rbln._internal.torch_compile_patch_helpers import get_rbln_compile_op_depth
+
+    if get_rbln_compile_op_depth() > 0:
+        rbln_log_warn("Unexpected CPU fallback: reentrant dispatch (already inside RBLN compile op)")
+        return True
+    return False
+
+
+def is_cpu_fallback_cases(args):
+    """Determines if a CPU fallback is necessary for an operation.
+
+    Checks several conditions in order (cheapest first):
+    0a. Python trace/debugger active
+    1. Non-infra TorchDispatchMode active (would cause infinite recursion)
+    2. Non-float16 dtype (unsupported by RBLN device)
+    3. All-scalar inputs (rebel-compiler falls back to host ops)
+    4. Non-zero storage offset on contiguous tensors
+    5. NaN/Inf values in inputs (non-deploy mode only)
+    6. Reentrancy (already inside RBLN compile op)
+
+    Individual checks can be disabled via ``TORCH_RBLN_DEV_DISABLE_OP_CPU_FALLBACK``
+    (comma-separated names or ``"all"``).
 
     Args:
-        args (tuple): A tuple of positional arguments for the operation, which may contain tensors.
+        args: Positional arguments for the operation, which may contain tensors.
 
     Returns:
-        bool: True if a CPU fallback is necessary, False otherwise.
+        True if a CPU fallback is necessary, False otherwise.
     """
     disabled_cases = _parse_disabled_fallback_cases()
 
-    # 0a: Python trace/debugger – when a trace function is set (e.g. pdb, coverage, sys.settrace), fall back to CPU
-    if "trace" not in disabled_cases and sys.gettrace() is not None:
+    # Pre-tensor checks (cheap, no tensor extraction needed)
+    if "trace" not in disabled_cases and _is_trace_active():
         return True
 
-    # 1: TorchDispatchMode active – run on CPU and do not attempt compile (cheap)
-    if "dispatch_mode" not in disabled_cases:
-        try:
-            from torch.utils._python_dispatch import is_in_torch_dispatch_mode
-
-            if is_in_torch_dispatch_mode(include_infra_modes=False):
-                return True
-        except ImportError:
-            pass
+    if "dispatch_mode" not in disabled_cases and _is_dispatch_mode_active():
+        return True
 
     # Checks 2-5 require tensors; bail early if none
     tensor_args = extract_tensors(args)
     if not tensor_args:
         return False
 
-    # 2: RBLN device can only handle float16 dtype
-    if "dtype" not in disabled_cases:
-        if any(a.dtype != torch.float16 for a in tensor_args):
-            return True
+    if "dtype" not in disabled_cases and _has_non_float16_dtype(tensor_args):
+        return True
 
-    # 3: fall back to the CPU if all input tensors are scalar tensors
-    if "scalar" not in disabled_cases:
-        if all(a.ndim == 0 for a in tensor_args):
-            return True
+    if "scalar" not in disabled_cases and _all_scalars(tensor_args):
+        return True
 
-    # 4: fall back to the CPU if any contiguous tensor has non-zero storage offset
-    if "storage_offset" not in disabled_cases:
-        if any(a.is_contiguous() and a.storage_offset() != 0 for a in tensor_args):
-            return True
+    if "storage_offset" not in disabled_cases and _has_nonzero_storage_offset(tensor_args):
+        return True
 
-    # 5: fall back to the CPU if any tensor contains NaN/Inf values (heavy: to_cpu + scan; non-deploy only)
-    if "nan_inf" not in disabled_cases:
-        try:
-            from torch_rbln._internal.env_utils import is_rbln_deploy
+    # Heavy check: copies tensors to CPU to scan for NaN/Inf
+    if "nan_inf" not in disabled_cases and _has_nan_or_inf(args):
+        return True
 
-            if not is_rbln_deploy() and has_invalid_tensor(to_cpu(args)):
-                return True
-        except ImportError:
-            pass
-
-    # 6: Reentrancy – already inside an RBLN compile op (e.g. from print/repr or from compiled graph).
-    #     Unexpected path; log a warning when it triggers.
-    if "reentrant" not in disabled_cases:
-        from torch_rbln._internal.torch_compile_patch_helpers import get_rbln_compile_op_depth
-
-        if get_rbln_compile_op_depth() > 0:
-            rbln_log_warn("Unexpected CPU fallback: reentrant dispatch (already inside RBLN compile op)")
-            return True
+    # Last: reentrancy check
+    if "reentrant" not in disabled_cases and _is_reentrant():
+        return True
 
     return False
 

--- a/torch_rbln/_internal/register_custom_ops.py
+++ b/torch_rbln/_internal/register_custom_ops.py
@@ -136,6 +136,59 @@ def custom_zero__rbln(self):
     finalize_output_tensor(self, result_tensor, result_tensor.shape, self, {})
 
 
+def _validate_kv_cache_alignment(k_cache, v_cache, alignment=64):
+    """Validate that K/V cache tensors have their last dimension aligned to the given multiple.
+
+    This is a compiler constraint: the K/V-cache tensors must be allocated externally
+    with their last dimension being a multiple of ``alignment``.
+    """
+    if k_cache.size(-1) % alignment != 0:
+        raise ValueError(
+            f"The last dimension of K-cache must be a multiple of {alignment}, but got shape {k_cache.shape}"
+        )
+    if v_cache.size(-1) % alignment != 0:
+        raise ValueError(
+            f"The last dimension of V-cache must be a multiple of {alignment}, but got shape {v_cache.shape}"
+        )
+
+
+def _validate_prefill_batch_size(args):
+    """Validate that Q, K, V tensors have batch size of 1 (prefill constraint)."""
+    for i, name in enumerate(["Query (q)", "Key (k)", "Value (v)"]):
+        tensor = args[i]
+        if tensor.size(0) != 1:
+            raise ValueError(
+                f"Custom kernel with prefill: batch size of {name} must be 1, but got shape {tensor.shape}"
+            )
+
+
+def _compile_and_execute_kernel(op_module_factory, contig_args, contig_kwargs):
+    """Compile an attention kernel module and execute it, returning the result tensor.
+
+    Creates a result tensor matching the query shape, compiles the given ``op_module_factory``
+    with the RBLN backend (tp_size=1), and executes it. If the compiled result lives at a
+    different address than the pre-allocated tensor, copies it over.
+    """
+    from torch_rbln.device.context_holder import out_tensor_context
+
+    result_tensor = torch.empty(contig_args[0].shape, dtype=torch.float16, device=contig_args[0].device)
+
+    with out_tensor_context(result_tensor):
+        compiled = torch.compile(
+            op_module_factory(),
+            backend="rbln",
+            dynamic=False,
+            options={"disable_logger": True, "tensor_parallel_size": 1},
+        )
+        external_result = compiled(*contig_args, **contig_kwargs)
+        if result_tensor is None:
+            result_tensor = external_result
+        elif isinstance(external_result, torch.Tensor) and (external_result.data_ptr() != result_tensor.data_ptr()):
+            result_tensor.copy_(external_result)
+
+    return result_tensor
+
+
 class custom_rbln_paged_attn_prefill(torch.nn.Module):
     def forward(self, *args, **kwargs):
         # TODO: rtosa.multiply cannot accept tensor scalar value. scale must be constant tensor.
@@ -155,60 +208,14 @@ class custom_rbln_paged_attn_prefill(torch.nn.Module):
 
 
 def paged_attn_prefill_rbln(*args, **kwargs):
-    from torch_rbln.device.context_holder import out_tensor_context
-
     if len(args) != 10:
         raise RuntimeError("paged_attn_prefill takes 10 inputs.")
 
-    # Check if batch size (dim=0) is 1 for Q, K, and V tensors.
-    # This kernel is constrained to operate on a batch size of 1.
-    for i, name in enumerate(["Query (q)", "Key (k)", "Value (v)"]):
-        tensor = args[i]
-        assert tensor.size(0) == 1, (
-            f"Custom kernel with prefill must batch size of {name} must be 1, but got shape {tensor.shape}"
-        )
-
-    # origin_dim = args[0].size(-1)
+    _validate_prefill_batch_size(args)
     (contig_args, contig_kwargs), changed_any = prepare_args_for_contiguous(args, kwargs)
+    _validate_kv_cache_alignment(contig_args[4], contig_args[5])
 
-    # The K/V cache tensors (args[4], args[5]) are allocated externally, often
-    # as placeholders. This prefill operation is the first time they are populated.
-    # We must explicitly set their metadata dtype to custom_float16 here, as the
-    # underlying kernel will fill the cache with data in the custom_float16 format,
-    # regardless of the tensor's original torch.dtype.
-    k_cache = contig_args[4]
-    v_cache = contig_args[5]
-
-    # [Compiler Constraint] Check K/V cache alignment.
-    # Due to current compiler limitations, the K/V-cache tensors
-    # must be allocated externally with their last dimension being a multiple of 64.
-    # This alignment is required for the optimized kernel to function correctly.
-    assert k_cache.size(-1) % 64 == 0, (
-        f"The last dimension of K-cache must be a multiple of 64, but got shape {k_cache.shape}"
-    )
-    assert v_cache.size(-1) % 64 == 0, (
-        f"The last dimension of V-cache must be a multiple of 64, but got shape {v_cache.shape}"
-    )
-
-    # Create aligned result tensor with 64-byte alignment for last dimension
-    result_tensor = torch.empty(contig_args[0].shape, dtype=torch.float16, device=contig_args[0].device)
-    assert result_tensor.size(-1) % 64 == 0
-
-    with out_tensor_context(result_tensor):
-        # tensor_parallel_size=1 is hardcoded due to custom kernel compiler constraints.
-        compiled = torch.compile(
-            custom_rbln_paged_attn_prefill(),
-            backend="rbln",
-            dynamic=False,
-            options={"disable_logger": True, "tensor_parallel_size": 1},
-        )
-        external_result = compiled(*contig_args, **contig_kwargs)
-        if result_tensor is None:
-            result_tensor = external_result
-        elif isinstance(external_result, torch.Tensor) and (external_result.data_ptr() != result_tensor.data_ptr()):
-            result_tensor.copy_(external_result)
-
-    return result_tensor
+    return _compile_and_execute_kernel(custom_rbln_paged_attn_prefill, contig_args, contig_kwargs)
 
 
 class custom_rbln_paged_attn_decode(torch.nn.Module):
@@ -230,46 +237,13 @@ class custom_rbln_paged_attn_decode(torch.nn.Module):
 
 
 def paged_attn_decode_rbln(*args, **kwargs):
-    from torch_rbln.device.context_holder import out_tensor_context
-
     if len(args) != 10:
-        raise RuntimeError("paged_attn_prefill takes 10 inputs.")
+        raise RuntimeError("paged_attn_decode takes 10 inputs.")
 
     (contig_args, contig_kwargs), changed_any = prepare_args_for_contiguous(args, kwargs)
+    _validate_kv_cache_alignment(contig_args[4], contig_args[5])
 
-    k_cache = contig_args[4]
-    v_cache = contig_args[5]
-
-    # [Compiler Constraint] Check K/V cache alignment.
-    # Due to current compiler limitations, the K/V-cache tensors
-    # must be allocated externally with their last dimension being a multiple of 64.
-    # This alignment is required for the optimized kernel to function correctly.
-    assert k_cache.size(-1) % 64 == 0, (
-        f"The last dimension of K-cache must be a multiple of 64, but got shape {k_cache.shape}"
-    )
-    assert v_cache.size(-1) % 64 == 0, (
-        f"The last dimension of V-cache must be a multiple of 64, but got shape {v_cache.shape}"
-    )
-
-    # Create aligned result tensor with 64-byte alignment for last dimension
-    result_tensor = torch.empty(contig_args[0].shape, dtype=torch.float16, device=contig_args[0].device)
-    assert result_tensor.size(-1) % 64 == 0
-
-    with out_tensor_context(result_tensor):
-        # tensor_parallel_size=1 is hardcoded due to custom kernel compiler constraints.
-        compiled = torch.compile(
-            custom_rbln_paged_attn_decode(),
-            backend="rbln",
-            dynamic=False,
-            options={"disable_logger": True, "tensor_parallel_size": 1},
-        )
-        external_result = compiled(*contig_args, **contig_kwargs)
-        if result_tensor is None:
-            result_tensor = external_result
-        elif isinstance(external_result, torch.Tensor) and (external_result.data_ptr() != result_tensor.data_ptr()):
-            result_tensor.copy_(external_result)
-
-    return result_tensor
+    return _compile_and_execute_kernel(custom_rbln_paged_attn_decode, contig_args, contig_kwargs)
 
 
 class custom_rbln_paged_causal_attn_prefill(torch.nn.Module):
@@ -298,61 +272,15 @@ class custom_rbln_paged_causal_attn_prefill(torch.nn.Module):
 
 
 def paged_causal_attn_prefill_rbln(*args, **kwargs):
-    from torch_rbln.device.context_holder import out_tensor_context
-
-    # paged_causal_attn_prefill: q, k, v, kcache, vcache, seq, scale, block_table, block_size, is_bidirectional, mask (optional)
     if len(args) < 10 or len(args) > 11:
         raise RuntimeError(f"paged_causal_attn_prefill takes 10 or 11 inputs, but got {len(args)}.")
 
-    # Check if batch size (dim=0) is 1 for Q, K, and V tensors.
-    # This kernel is constrained to operate on a batch size of 1.
-    for i, name in enumerate(["Query (q)", "Key (k)", "Value (v)"]):
-        tensor = args[i]
-        assert tensor.size(0) == 1, (
-            f"Custom kernel with prefill must batch size of {name} must be 1, but got shape {tensor.shape}"
-        )
-
-    # origin_dim = args[0].size(-1)
+    _validate_prefill_batch_size(args)
     (contig_args, contig_kwargs), changed_any = prepare_args_for_contiguous(args, kwargs)
+    # causal variants use args[3], args[4] for K/V cache (no attn_mask before them)
+    _validate_kv_cache_alignment(contig_args[3], contig_args[4])
 
-    # The K/V cache tensors (args[3], args[4]) are allocated externally, often
-    # as placeholders. This prefill operation is the first time they are populated.
-    # We must explicitly set their metadata dtype to custom_float16 here, as the
-    # underlying kernel will fill the cache with data in the custom_float16 format,
-    # regardless of the tensor's original torch.dtype.
-    k_cache = contig_args[3]
-    v_cache = contig_args[4]
-
-    # [Compiler Constraint] Check K/V cache alignment.
-    # Due to current compiler limitations, the K/V-cache tensors
-    # must be allocated externally with their last dimension being a multiple of 64.
-    # This alignment is required for the optimized kernel to function correctly.
-    assert k_cache.size(-1) % 64 == 0, (
-        f"The last dimension of K-cache must be a multiple of 64, but got shape {k_cache.shape}"
-    )
-    assert v_cache.size(-1) % 64 == 0, (
-        f"The last dimension of V-cache must be a multiple of 64, but got shape {v_cache.shape}"
-    )
-
-    # Create aligned result tensor with 64-byte alignment for last dimension
-    result_tensor = torch.empty(contig_args[0].shape, dtype=torch.float16, device=contig_args[0].device)
-    assert result_tensor.size(-1) % 64 == 0
-
-    with out_tensor_context(result_tensor):
-        # tensor_parallel_size=1 is hardcoded due to custom kernel compiler constraints.
-        compiled = torch.compile(
-            custom_rbln_paged_causal_attn_prefill(),
-            backend="rbln",
-            dynamic=False,
-            options={"disable_logger": True, "tensor_parallel_size": 1},
-        )
-        external_result = compiled(*contig_args, **contig_kwargs)
-        if result_tensor is None:
-            result_tensor = external_result
-        elif isinstance(external_result, torch.Tensor) and (external_result.data_ptr() != result_tensor.data_ptr()):
-            result_tensor.copy_(external_result)
-
-    return result_tensor
+    return _compile_and_execute_kernel(custom_rbln_paged_causal_attn_prefill, contig_args, contig_kwargs)
 
 
 class custom_rbln_paged_causal_attn_decode(torch.nn.Module):
@@ -380,47 +308,14 @@ class custom_rbln_paged_causal_attn_decode(torch.nn.Module):
 
 
 def paged_causal_attn_decode_rbln(*args, **kwargs):
-    from torch_rbln.device.context_holder import out_tensor_context
-
-    # paged_causal_attn_decode: q, k, v, kcache, vcache, seq, scale, block_table, block_size, mask (optional)
     if len(args) < 9 or len(args) > 10:
         raise RuntimeError(f"paged_causal_attn_decode takes 9 or 10 inputs, but got {len(args)}.")
 
     (contig_args, contig_kwargs), changed_any = prepare_args_for_contiguous(args, kwargs)
+    # causal variants use args[3], args[4] for K/V cache (no attn_mask before them)
+    _validate_kv_cache_alignment(contig_args[3], contig_args[4])
 
-    k_cache = contig_args[3]
-    v_cache = contig_args[4]
-
-    # [Compiler Constraint] Check K/V cache alignment.
-    # Due to current compiler limitations, the K/V-cache tensors
-    # must be allocated externally with their last dimension being a multiple of 64.
-    # This alignment is required for the optimized kernel to function correctly.
-    assert k_cache.size(-1) % 64 == 0, (
-        f"The last dimension of K-cache must be a multiple of 64, but got shape {k_cache.shape}"
-    )
-    assert v_cache.size(-1) % 64 == 0, (
-        f"The last dimension of V-cache must be a multiple of 64, but got shape {v_cache.shape}"
-    )
-
-    # Create aligned result tensor with 64-byte alignment for last dimension
-    result_tensor = torch.empty(contig_args[0].shape, dtype=torch.float16, device=contig_args[0].device)
-    assert result_tensor.size(-1) % 64 == 0
-
-    with out_tensor_context(result_tensor):
-        # tensor_parallel_size=1 is hardcoded due to custom kernel compiler constraints.
-        compiled = torch.compile(
-            custom_rbln_paged_causal_attn_decode(),
-            backend="rbln",
-            dynamic=False,
-            options={"disable_logger": True, "tensor_parallel_size": 1},
-        )
-        external_result = compiled(*contig_args, **contig_kwargs)
-        if result_tensor is None:
-            result_tensor = external_result
-        elif isinstance(external_result, torch.Tensor) and (external_result.data_ptr() != result_tensor.data_ptr()):
-            result_tensor.copy_(external_result)
-
-    return result_tensor
+    return _compile_and_execute_kernel(custom_rbln_paged_causal_attn_decode, contig_args, contig_kwargs)
 
 
 rbln_custom_impl = torch.library.Library("rbln_custom_ops", "IMPL")  # noqa: TOR901

--- a/torch_rbln/_internal/register_custom_ops.py
+++ b/torch_rbln/_internal/register_custom_ops.py
@@ -2,76 +2,35 @@ import math
 
 import torch
 
-from torch_rbln._internal.env_utils import use_device_group_tensor_parallel_size
 from torch_rbln._internal.log_utils import rbln_log_cpu_fallback
 from torch_rbln._internal.ops_utils import (
-    can_use_out_tensor_directly,
+    compile_and_execute,
     cpu_fallback_path,
     finalize_output_tensor,
     handle_empty_binary,
     is_cpu_fallback_cases,
     is_type_promotion_allowed,
+    make_op_module,
     prepare_args_for_contiguous,
 )
 
 
-class OpModule_softmax(torch.nn.Module):
-    def forward(self, *args, **kwargs):
-        return torch.softmax(*args, **kwargs)
-
-
-_softmax_op_module = OpModule_softmax().eval()
+_softmax_op_module = make_op_module(torch.softmax)
 
 
 def custom_softmax_out_rbln(self, dim: int, half_to_float: bool, *, out=None):
-    from torch_rbln.device.context_holder import out_tensor_context
-
     result_tensor = None
 
     if is_cpu_fallback_cases(self):
-        result = cpu_fallback_path(torch.softmax, (self,), result=out, op_name="aten::softmax", dim=dim)
-        result_tensor = result
+        result_tensor = cpu_fallback_path(torch.softmax, (self,), result=out, op_name="aten::softmax", dim=dim)
     else:
         self = self.contiguous()
-
-        # Prepare result tensor and compile options based on out_tensor availability
-        # Base compile options: always include eager_mode for eager execution context
-        compile_options = {"disable_logger": True}
-        # By default, eager mode ops use tp_size=1 due to current compiler structure.
-        # If TORCH_RBLN_USE_DEVICE_TP=ON, eager mode ops will follow
-        # the logical device size (RBLN_NPUS_PER_DEVICE) like torch.compile operations.
-        if not use_device_group_tensor_parallel_size():
-            compile_options["tensor_parallel_size"] = 1
-
-        if out is None:
-            result_tensor = None
-        else:
-            # Check if out_tensor can be used directly by compiler
-            can_use_out_tensor_directly_flag = can_use_out_tensor_directly((self,), dict({"dim": dim}, out=out))
-
-            if can_use_out_tensor_directly_flag:
-                # Use out tensor directly - compiler will write results here
-                result_tensor = out
-            else:
-                result_tensor = None
-
-        with out_tensor_context(result_tensor):
-            compiled = torch.compile(_softmax_op_module, backend="rbln", dynamic=False, options=compile_options)
-            external_result = compiled(self, dim=dim)
-            if result_tensor is None:
-                result_tensor = external_result
-            elif isinstance(external_result, torch.Tensor) and (external_result.data_ptr() != result_tensor.data_ptr()):
-                result_tensor.copy_(external_result)
+        result_tensor = compile_and_execute(_softmax_op_module, (self,), {"dim": dim}, out_tensor=out)
 
     finalize_output_tensor(out, result_tensor, result_tensor.shape, tuple(self), {})
 
 
-class OpModule_pow(torch.nn.Module):
-    def forward(self, *args, **kwargs):
-        return torch.pow(*args, **kwargs)
-
-
-_pow_op_module = OpModule_pow().eval()
+_pow_op_module = make_op_module(torch.pow)
 
 
 def _is_integer_exponent(exponent) -> bool:
@@ -82,8 +41,6 @@ def _is_integer_exponent(exponent) -> bool:
 
 
 def pow_tensor_scalar_out_rbln(self, exponent, *, out):
-    from torch_rbln.device.context_holder import out_tensor_context
-
     # pow.Tensor_Scalar: exponent must be scalar (int/float), not tensor
     if isinstance(exponent, torch.Tensor):
         raise RuntimeError("pow.Tensor_Scalar expects scalar exponent (int/float), not tensor.")
@@ -102,31 +59,12 @@ def pow_tensor_scalar_out_rbln(self, exponent, *, out):
         result_tensor = cpu_fallback_path(torch.pow, (self, exponent), result=out, op_name="aten::pow")
     else:
         self = self.contiguous()
-
-        compile_options = {"disable_logger": True}
-        if not use_device_group_tensor_parallel_size():
-            compile_options["tensor_parallel_size"] = 1
-
-        can_use_out_tensor_directly_flag = can_use_out_tensor_directly((self, exponent), {"out": out})
-
-        if can_use_out_tensor_directly_flag:
-            result_tensor = out
-        else:
-            result_tensor = None
-
-        with out_tensor_context(result_tensor):
-            compiled = torch.compile(_pow_op_module, backend="rbln", dynamic=False, options=compile_options)
-            external_result = compiled(self, exponent)
-            if result_tensor is None:
-                result_tensor = external_result
-            elif isinstance(external_result, torch.Tensor) and (external_result.data_ptr() != result_tensor.data_ptr()):
-                result_tensor.copy_(external_result)
+        result_tensor = compile_and_execute(_pow_op_module, (self, exponent), {}, out_tensor=out)
 
     finalize_output_tensor(out, result_tensor, result_tensor.shape, (self,), {})
 
 
 def custom_zero__rbln(self):
-    result_tensor = None
     # zeros op is compilable in RBLN, but due to its in-place, it has problems with graph capture,
     # so it is always processed on the host.
     cpu_self = torch.empty_like(self, device=torch.device("cpu"))
@@ -136,12 +74,13 @@ def custom_zero__rbln(self):
     finalize_output_tensor(self, result_tensor, result_tensor.shape, self, {})
 
 
-def _validate_kv_cache_alignment(k_cache, v_cache, alignment=64):
-    """Validate that K/V cache tensors have their last dimension aligned to the given multiple.
+# ---------------------------------------------------------------------------
+# Paged attention custom kernels
+# ---------------------------------------------------------------------------
 
-    This is a compiler constraint: the K/V-cache tensors must be allocated externally
-    with their last dimension being a multiple of ``alignment``.
-    """
+
+def _validate_kv_cache_alignment(k_cache, v_cache, alignment=64):
+    """Validate that K/V cache tensors have their last dimension aligned to the given multiple."""
     if k_cache.size(-1) % alignment != 0:
         raise ValueError(
             f"The last dimension of K-cache must be a multiple of {alignment}, but got shape {k_cache.shape}"
@@ -165,9 +104,8 @@ def _validate_prefill_batch_size(args):
 def _compile_and_execute_kernel(op_module_factory, contig_args, contig_kwargs):
     """Compile an attention kernel module and execute it, returning the result tensor.
 
-    Creates a result tensor matching the query shape, compiles the given ``op_module_factory``
-    with the RBLN backend (tp_size=1), and executes it. If the compiled result lives at a
-    different address than the pre-allocated tensor, copies it over.
+    Unlike :func:`compile_and_execute`, this always uses tp_size=1 (custom kernel
+    compiler constraint) and allocates a fresh result tensor matching the query shape.
     """
     from torch_rbln.device.context_holder import out_tensor_context
 
@@ -194,16 +132,7 @@ class custom_rbln_paged_attn_prefill(torch.nn.Module):
         # TODO: rtosa.multiply cannot accept tensor scalar value. scale must be constant tensor.
         scale = torch.tensor(1 / math.sqrt(args[0].size(-1)))
         return torch.ops.rbln_custom_ops.paged_attn_prefill(
-            args[0],  # q [1,2,6,33,128]
-            args[1],  # k [1,2,1,33,128]
-            args[2],  # v [1,2,1,33,128]
-            args[3],  # attn_mask [1,33,1]
-            args[4],  # kcache [1,1,1]
-            args[5],  # vcache [1,1,1]
-            args[6],  # seq [1,1]
-            scale,  # scale, float32
-            args[8],  # block_table
-            args[9],  # block_size, int
+            args[0], args[1], args[2], args[3], args[4], args[5], args[6], scale, args[8], args[9]
         )
 
 
@@ -220,19 +149,9 @@ def paged_attn_prefill_rbln(*args, **kwargs):
 
 class custom_rbln_paged_attn_decode(torch.nn.Module):
     def forward(self, *args, **kwargs):
-        # TODO: rtosa.multiply cannot accept tensor scalar value. scale must be constant tensor.
         scale = torch.tensor(1 / math.sqrt(args[0].size(-1)))
         return torch.ops.rbln_custom_ops.paged_attn_decode(
-            args[0],  # q [1,2,6,33,128]
-            args[1],  # k [1,2,1,33,128]
-            args[2],  # v [1,2,1,33,128]
-            args[3],  # attn_mask [1,33,1]
-            args[4],  # kcache [1,1,1]
-            args[5],  # vcache [1,1,1]
-            args[6],  # seq [1,1]
-            scale,  # scale, float32
-            args[8],  # block_table
-            args[9],  # block_size, int
+            args[0], args[1], args[2], args[3], args[4], args[5], args[6], scale, args[8], args[9]
         )
 
 
@@ -248,26 +167,10 @@ def paged_attn_decode_rbln(*args, **kwargs):
 
 class custom_rbln_paged_causal_attn_prefill(torch.nn.Module):
     def forward(self, *args, **kwargs):
-        # TODO: rtosa.multiply cannot accept tensor scalar value. scale must be constant tensor.
         scale = torch.tensor(1 / math.sqrt(args[0].size(-1)))
-        # paged_causal_attn_prefill: q, k, v, kcache, vcache, seq, scale, block_table, block_size, is_bidirectional, mask (optional)
-        # args[0]: q, args[1]: k, args[2]: v, args[3]: kcache, args[4]: vcache, args[5]: seq,
-        # args[6]: scale (computed), args[7]: block_table, args[8]: block_size, args[9]: is_bidirectional, args[10]: mask (optional)
-        call_args = [
-            args[0],  # q [1,2,6,33,128]
-            args[1],  # k [1,2,1,33,128]
-            args[2],  # v [1,2,1,33,128]
-            args[3],  # kcache [1,1,1]
-            args[4],  # vcache [1,1,1]
-            args[5],  # seq [1,1]
-            scale,  # scale, float32
-            args[7],  # block_table
-            args[8],  # block_size, int
-            args[9],  # is_bidirectional, bool
-        ]
-        # mask is optional
+        call_args = [args[0], args[1], args[2], args[3], args[4], args[5], scale, args[7], args[8], args[9]]
         if len(args) > 10 and args[10] is not None:
-            call_args.append(args[10])  # mask
+            call_args.append(args[10])
         return torch.ops.rbln_custom_ops.paged_causal_attn_prefill(*call_args)
 
 
@@ -277,7 +180,6 @@ def paged_causal_attn_prefill_rbln(*args, **kwargs):
 
     _validate_prefill_batch_size(args)
     (contig_args, contig_kwargs), changed_any = prepare_args_for_contiguous(args, kwargs)
-    # causal variants use args[3], args[4] for K/V cache (no attn_mask before them)
     _validate_kv_cache_alignment(contig_args[3], contig_args[4])
 
     return _compile_and_execute_kernel(custom_rbln_paged_causal_attn_prefill, contig_args, contig_kwargs)
@@ -285,25 +187,10 @@ def paged_causal_attn_prefill_rbln(*args, **kwargs):
 
 class custom_rbln_paged_causal_attn_decode(torch.nn.Module):
     def forward(self, *args, **kwargs):
-        # TODO: rtosa.multiply cannot accept tensor scalar value. scale must be constant tensor.
         scale = torch.tensor(1 / math.sqrt(args[0].size(-1)))
-        # paged_causal_attn_decode: q, k, v, kcache, vcache, seq, scale, block_table, block_size, mask (optional)
-        # args[0]: q, args[1]: k, args[2]: v, args[3]: kcache, args[4]: vcache, args[5]: seq,
-        # args[6]: scale (computed), args[7]: block_table, args[8]: block_size, args[9]: mask (optional)
-        call_args = [
-            args[0],  # q [1,2,6,33,128]
-            args[1],  # k [1,2,1,33,128]
-            args[2],  # v [1,2,1,33,128]
-            args[3],  # kcache [1,1,1]
-            args[4],  # vcache [1,1,1]
-            args[5],  # seq [1,1]
-            scale,  # scale, float32
-            args[7],  # block_table
-            args[8],  # block_size, int
-        ]
-        # mask is optional
+        call_args = [args[0], args[1], args[2], args[3], args[4], args[5], scale, args[7], args[8]]
         if len(args) > 9 and args[9] is not None:
-            call_args.append(args[9])  # mask
+            call_args.append(args[9])
         return torch.ops.rbln_custom_ops.paged_causal_attn_decode(*call_args)
 
 
@@ -312,7 +199,6 @@ def paged_causal_attn_decode_rbln(*args, **kwargs):
         raise RuntimeError(f"paged_causal_attn_decode takes 9 or 10 inputs, but got {len(args)}.")
 
     (contig_args, contig_kwargs), changed_any = prepare_args_for_contiguous(args, kwargs)
-    # causal variants use args[3], args[4] for K/V cache (no attn_mask before them)
     _validate_kv_cache_alignment(contig_args[3], contig_args[4])
 
     return _compile_and_execute_kernel(custom_rbln_paged_causal_attn_decode, contig_args, contig_kwargs)


### PR DESCRIPTION
## Summary of Changes

Structural refactoring and performance optimization across the Python codebase, plus a bug fix for scalar NaN/Inf detection. Net result: **-132 lines of production code**, **+240 lines of tests**, no behavioral regressions.

### Bug fix
- `_has_nan_or_inf()` only checked pre-extracted tensors, missing scalar `float('nan')`/`float('inf')` arguments (e.g. `torch.le(tensor, nan)`), causing incorrect results on NPU instead of CPU fallback
- Add lightweight `tree_flatten` scalar check alongside existing per-tensor early-return optimization
- Fix mock patch path in tests to target `env_utils.is_rbln_deploy` (the actual import source)

### Code quality improvements
- Fix copy-paste bug: `paged_attn_decode_rbln` error message incorrectly said `"paged_attn_prefill"`
- Replace `assert` with `ValueError` in `register_custom_ops.py`
- Extract paged attention helpers to eliminate ~100 lines of duplicated logic
- Decompose `is_cpu_fallback_cases()` into 7 focused single-responsibility checkers
- Centralize test tolerance constants (`ATOL`/`RTOL`) in `test/utils.py`
- Consolidate duplicated `setup_environment()` in distributed tests

### Structural optimization
- Add `compile_and_execute()` shared utility for the standard eager-mode compile+execute pattern
- Add `make_op_module()` factory replacing 200+ per-op `nn.Module` class definitions
- Update codegen templates to use new utilities (compile section: ~25 lines → 3 lines per op)
- Update hand-written custom ops (softmax, pow) to use same utilities

### Performance optimization
- `_has_nan_or_inf()`: accept pre-extracted tensor list with per-tensor `.cpu()` and early return on first invalid value
- `is_cpu_fallback_cases()`: reuse already-extracted `tensor_args` for NaN/Inf check
- `prepare_args_for_contiguous()`: fast-path skipping `_make_contig()` loop when all tensors already contiguous

### Tests
- 40+ new unit tests covering all fallback checkers, compile utilities, scalar NaN detection, and fast-path behavior

---

## Related Issues / Tickets

* Related to codebase maintainability, performance, and test coverage

---

## Type of Change

- [ ] `feature` — New capability or functionality
- [ ] `core` — Changes to RBLN backend, device layer, C++ extension, op registration, or `torch.compile` integration
- [x] `fix` — Bug fix
- [x] `perf` — Performance improvement
- [x] `refactor` — Code improvement without behavior change
- [ ] `docs` — Documentation only
- [ ] `other` — Other (describe below)

---

## Affected Modules

- [ ] Backend
- [ ] Device
- [x] Ops/Kernels
- [ ] `torch.compile`
- [ ] C++ extension (`torch_rbln/csrc`)
- [ ] Memory
- [x] Build/Tools
- [ ] Docs

---

## How to Test (if applicable)

1. Run `lintrunner -m dev -a` — verify no lint issues
2. Run `python test/run_tests.py --suite=core` — all existing + new unit tests should pass
3. Run `python test/run_tests.py --suite=ops` — verify `test_compare_cpu_le_rbln_float16` passes with scalar NaN input

---

## Checklist

* [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
* [ ] This PR is linked to a corresponding issue — see [Contributing to torch-rbln](docs/CONTRIBUTING.md)
* [x] Linting passes — see [Linting](docs/LINTING.md)
* [ ] All CI tests pass — see [CI/CD Workflows](docs/WORKFLOWS.md)
* [x] The test method is described, and the expected result is clearly stated (if applicable)
* [ ] Relevant documentation has been updated (if applicable)

---