### PR TITLE
docs: add release process document

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ uv venv .venv && source .venv/bin/activate
 - [Test Guide](docs/TEST_GUIDE.md) — local test runs
 - [Linting](docs/LINTING.md) — code style and lint
 - [Third-party update](docs/THIRD_PARTY_UPDATE.md) — PyTorch pin, upstream files, `rebel-compiler` version bumps in `pyproject.toml`
+- [Release Process](docs/RELEASE_PROCESS.md) — branch model, versioning, tagging, and publication
 
 ## Contributing
 

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -1,0 +1,119 @@
+# Release Process
+
+This document describes how torch-rbln releases are prepared, validated, and published. For CI/CD workflow internals, see [Workflows](WORKFLOWS.md); for PR and merge policies, see [Contributing Guide](CONTRIBUTING.md).
+
+## Overview
+
+Every release follows the same pipeline: changes integrate on `dev`, a nightly sync updates `rc` with the latest `dev` state so a current `rc → main` pull request is always ready to merge, and a version tag on `main` triggers artifact build and publication. Because the release candidate stays current, promotions to `main` happen on a steady cadence rather than as large, infrequent merges.
+
+```
+         feature PRs        nightly sync       RC PR         version tag
+feature ─────────────► dev ──────────────► rc ───────► main ─────────────► publish
+                        ▲                                │
+                        └────────── backmerge ───────────┘
+```
+
+## Branch Model
+
+The release pipeline is built on five kinds of branches, each with a specific lifecycle:
+
+| Branch    | Lifecycle                                                    |
+|-----------|--------------------------------------------------------------|
+| `feature` | Branch from `dev` → PR to `dev`                              |
+| `dev`     | Long-lived. Everyday integration point for all feature work. |
+| `rc`      | Branch from `dev` → PR to `main`                             |
+| `hotfix`  | Branch from `main` → PR to `main`                            |
+| `main`    | Long-lived. Always release-ready. Tags are created here.     |
+
+The diagram below shows which workflow runs at each branch transition. The `(CI)`, `(Release)`, and `(CD)` labels refer to the workflows described in [Workflows](WORKFLOWS.md):
+
+```
+                  (CI)             (Release)           (CI)
+                PR to dev          PR to main        PR to dev
+                   │                   │                │
+feature        ○───●                   │                │
+              ╱     ╲                  │                │     (CI)
+             ╱       ╲                 │                │  push to dev
+dev     ────○─────────●────────○───────┼────────────────┼────●─────────────────
+                push to dev     ╲      │                │   ╱
+                    (CI)         ╲     │                │  ╱
+rc                                ○────●                │ ╱
+                (Release)               ╲               │╱
+                PR to main               ╲         ●────●  backmerge
+                    │                     ╲       ╱
+hotfix         ○────●                      ╲     ╱
+              ╱      ╲                      ╲   ╱
+             ╱        ╲                      ╲ ╱
+main    ────○──────────●──────────────────────●───────────────────────────●────
+                  push to main           push to main                     │
+                   (Release)              (Release)                      tag
+                                                                         (CD)
+```
+
+## Versioning
+
+torch-rbln releases align with the [RBLN SDK](https://docs.rbln.ai/) — each release version matches the corresponding SDK version.
+
+Versions are derived from git tags using [setuptools-scm](https://setuptools-scm.readthedocs.io/). Tags use the format `v<major>.<minor>.<patch>[rc<N>]`, where the optional `rc<N>` suffix marks a release candidate build.
+
+| Source                 | Example Tag      | Resulting Version      |
+|------------------------|------------------|------------------------|
+| On a release tag       | `v0.10.0`        | `0.10.0`               |
+| On a release candidate | `v0.10.0rc0`     | `0.10.0rc0`            |
+| 5 commits past a tag   | `v0.10.0rc0` + 5 | `0.10.1.dev5+g1a2b3c4` |
+
+Development builds between tags carry a `.devN+g<commit>` suffix so they sort below the next release.
+
+## Release Lifecycle
+
+### 1. Integration on `dev`
+
+All changes land on `dev` through pull requests. The CI workflow validates each PR with linting and `test_set_ci`-marked tests. See [Contributing Guide](CONTRIBUTING.md) for PR requirements and merge policy.
+
+### 2. Nightly sync to `rc`
+
+A nightly job syncs `rc` with the latest `dev` and keeps an open pull request from `rc` to `main`. Because the sync runs every night, the `rc → main` PR stays continuously up to date, giving the release manager a fresh release candidate to merge on a regular schedule. The Release workflow runs the full test suite on this PR whenever `rc` changes, surfacing regressions before they reach `main`.
+
+### 3. Promotion to `main`
+
+When the release candidate is ready, the release manager merges the `rc → main` pull request. The Release workflow runs again on `main`, building and linting across all supported Python versions.
+
+### 4. Tagging and publication
+
+The release manager creates a `v<version>` tag on `main` — either through the [GitHub Releases UI](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) or the command line:
+
+```bash
+git tag v<version>  # e.g. git tag v0.10.0
+git push origin v<version>
+```
+
+The tag triggers the CD workflow, which builds wheels for all supported Python versions and publishes them to the internal package index first, then to public PyPI.
+
+### 5. Release notes
+
+The release manager writes release notes for the new version on the [GitHub Releases](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) page. If step 4 used the GitHub Releases UI, the notes go in alongside the tag; otherwise, they are added afterward.
+
+### 6. Backmerge to `dev`
+
+Every merge into `main` — whether from `rc` or a hotfix — triggers an automated backmerge pull request from `main` back to `dev`, keeping `dev` in sync with `main`.
+
+## Debug Builds
+
+Debug wheels — built against a debug variant of PyTorch — are produced alongside release wheels during release validation and nightly runs. They surface issues that only manifest under debug-mode assertions, catching bugs that would otherwise ship unnoticed.
+
+Debug wheels are uploaded to the internal package index for testing, using a `.debug` or `+debug` version suffix (for example, `0.10.0+debug`) to distinguish them from release wheels. They are **not** published to public PyPI.
+
+## Hotfix
+
+When a critical issue in a released version cannot wait for the next release cycle:
+
+1. Branch from `main`.
+2. Open a pull request back to `main` — the Release workflow validates the change.
+3. Merge, then create a new patch-version tag on `main` (e.g. `v0.10.0` → `v0.10.1`) following the tagging and publication steps above.
+4. An automated backmerge PR propagates the fix back to `dev`.
+
+## Related Documentation
+
+- [Workflows](WORKFLOWS.md) — CI/CD workflow details, triggers, and concurrency
+- [Contributing Guide](CONTRIBUTING.md) — PR requirements and merge policy
+- [Third-Party Update](THIRD_PARTY_UPDATE.md) — Dependency versioning (PyTorch, rebel-compiler)

--- a/docs/THIRD_PARTY_UPDATE.md
+++ b/docs/THIRD_PARTY_UPDATE.md
@@ -83,3 +83,5 @@ override it by passing a tag: ```./sync-linter.sh v2.11.0```.
 - [PyTorch RBLN — Running and debugging](https://docs.rbln.ai/latest/software/rbln_pytorch/tutorial_running_n_debugging.html)
 
 To bump the **pinned build dependency** in torch-rbln, update the version specifier in **`pyproject.toml`** in both **`[build-system].requires`** and **`[dependency-groups].build`**, and keep them aligned with each other.
+
+> **Note:** The development build constraint is updated automatically by a nightly workflow. See [Workflows — Automated Dependency Updates](WORKFLOWS.md#automated-dependency-updates) for details.

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -46,7 +46,7 @@ This selects tests marked with `@pytest.mark.test_set_ci` — the core set of te
 
 **File:** [`.github/workflows/release.yaml`](../.github/workflows/release.yaml)
 
-The Release workflow runs when code is promoted from `dev` to `main` for release. It covers a broader test suite than CI, but neither is a strict superset of the other — experimental tests can run in CI but are excluded from Release:
+The Release workflow runs when code is promoted from `dev` to `main` for release. It builds and lints across all supported Python versions. It covers a broader test suite than CI, but neither is a strict superset of the other — experimental tests can run in CI but are excluded from Release:
 
 ```bash
 python test/run_tests.py --test_mode=release  # -m "not (test_set_experimental or test_set_perf)"
@@ -89,7 +89,7 @@ The workflow uses [`amannn/action-semantic-pull-request`](https://github.com/ama
 
 **Allowed types:** `feat`, `fix`, `refactor`, `perf`, `docs`, `test`, `build`, `ci`, `chore`
 
-If the title is invalid, the workflow posts a sticky comment on the PR explaining the required format using [`marocchino/sticky-pull-request-comment`](https://github.com/marocchino/sticky-pull-request-comment). The comment is automatically deleted once the title is corrected.
+If the title is invalid, the workflow uses [`marocchino/sticky-pull-request-comment`](https://github.com/marocchino/sticky-pull-request-comment) to post a sticky comment on the PR explaining the required format. The comment is automatically deleted once the title is corrected.
 
 ---
 
@@ -113,54 +113,15 @@ The event is dispatched to a separate repository (configured via `vars.TORCH_RBL
 
 ---
 
-## Workflow Lifecycle: From PR to Release
+## Automated Dependency Updates
 
-```
-                  (CI)              (Release)          (CI)
-                PR to dev          PR to main        PR to dev
-                   │                   │                │
-feature        ○───●                   │                │
-              ╱     ╲                  │                │     (CI)
-             ╱       ╲                 │                │  push to dev
-dev     ────○─────────●────────○───────┼────────────────┼────●─────────────────
-                push to dev     ╲      │                │   ╱
-                    (CI)         ╲     │                │  ╱
-rc                                ○────●                │ ╱
-                (Release)               ╲               │╱
-                PR to main               ╲         ●────●  backmerge
-                    │                     ╲       ╱
-hotfix         ○────●                      ╲     ╱
-              ╱      ╲                      ╲   ╱
-             ╱        ╲                      ╲ ╱
-main    ────○──────────●──────────────────────●───────────────────────────●────
-                  push to main           push to main                     │
-                   (Release)              (Release)                      tag
-                                                                         (CD)
-```
-
-### Branch roles
-
-| Branch    | Lifecycle                                                    |
-|-----------|--------------------------------------------------------------|
-| `feature` | Branch from `dev` → PR to `dev`                              |
-| `dev`     | Long-lived. Everyday integration point for all feature work. |
-| `rc`      | Branch from `dev`. Standing PR to `main`                     |
-| `hotfix`  | Branch from `main` → PR to `main`                            |
-| `main`    | Long-lived. Always release-ready. Tags are created here.     |
-
-### Flow summary
-
-1. **Feature development:** Developers branch from `dev`, open a PR back to `dev`. The CI workflow validates every PR with linting and `test_set_ci`-marked tests.
-2. **Integration:** Merging to `dev` triggers a CI push build, continuously verifying integration stability.
-3. **Release candidate:** A nightly job creates an `rc` branch from `dev` and maintains a standing PR to `main`. The Release workflow runs the full test suite on this PR daily.
-4. **Release:** When ready, the release manager merges the `rc` PR into `main`. Tagging `main` triggers the CD workflow for artifact build and deployment.
-5. **Backmerge:** After a `main` merge, a backmerge PR is automatically created from `main` to `dev`, ensuring hotfixes and release-only changes flow back.
-6. **Hotfix:** For urgent fixes, branch from `main`, PR back to `main`. The backmerge mechanism propagates the fix to `dev`.
+A nightly workflow tracks the latest `rebel-compiler` development build (not an official release) and automatically creates or updates a PR on `dev` when a newer build is available. Review and merge it once CI passes.
 
 ---
 
 ## Related Documentation
 
+- [Release Process](RELEASE_PROCESS.md) — Branch model, versioning, tagging, and publication
 - [Contributing Guide](CONTRIBUTING.md) — PR requirements and merge policy
 - [Test Guide](TEST_GUIDE.md) — Test infrastructure, markers, and `run_tests.py` usage
 - [Linting](LINTING.md) — Code style and pre-commit hooks


### PR DESCRIPTION
## Summary of Changes

Adds `docs/RELEASE_PROCESS.md` — a canonical guide to the torch-rbln release process — and aligns the surrounding documentation with it.

Contributors currently lack a single document explaining how releases flow from `dev` through `main` to published artifacts. The branching model and workflow triggers are scattered between `WORKFLOWS.md` and `CONTRIBUTING.md`, while the versioning policy, tagging conventions, publication path, and debug build strategy are undocumented. The new guide consolidates the scattered content and fills the documentation gaps.

The split between `WORKFLOWS.md` (workflow reference — what runs when) and `RELEASE_PROCESS.md` (release narrative — branching model, lifecycle, hotfix) follows the single source of truth principle: release-flow content lives in one place, preventing drift.

---

## Type of Change

- [x] `docs` — Documentation only

---

## Affected Modules

- [x] Docs

---

## Checklist

* [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
* [x] Linting passes — see [Linting](docs/LINTING.md)
* [x] All CI tests pass — see [CI/CD Workflows](docs/WORKFLOWS.md)
* [x] Relevant documentation has been updated (if applicable)

---

## Notes

The `rebel-compiler` nightly auto-update is documented in `WORKFLOWS.md` as a workflow concern, with a cross-reference from `THIRD_PARTY_UPDATE.md`. It is intentionally excluded from `RELEASE_PROCESS.md` because the automation is orthogonal to the release path — releases proceed identically whether or not the auto-update workflow fires.

---
