### PR TITLE
fix(ci): avoid duplicate --pattern in RAWCUDADEVICE linter

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -674,8 +674,7 @@ exclude_patterns = [
 command = [
     'python3',
     'tools/linter/adapters/grep_linter.py',
-    '--pattern=cudaSetDevice(',
-    '--pattern=cudaGetDevice(',
+    '--pattern=cuda(Set|Get)Device\(',
     '--linter-name=RAWCUDADEVICE',
     '--error-name=raw CUDA API usage',
     """--error-description=\


### PR DESCRIPTION
## Summary of Changes

RAWCUDADEVICE linter in `.lintrunner.toml` passed two `--pattern` args. The upstream `grep_linter.py` synced in #7 added a check that rejects duplicate `--pattern` at argparse level, so the linter now crashes on any PR that touches `aten/**`, `c10/**`, or `torch/csrc/**`. Fold the two patterns into one regex so the linter invokes cleanly while still matching both `cudaSetDevice(` and `cudaGetDevice(`.

## Related Issues / Tickets

* Related to #7

## Type of Change

- [x] ``fix`` — Bug fix

## Affected Modules

- [x] Build/Tools

## How to Test

1. On any file matching `c10/**` (e.g. `c10/CMakeLists.txt`):
   ``python3 tools/linter/adapters/grep_linter.py --pattern='cuda(Set|Get)Device\(' --linter-name=RAWCUDADEVICE --error-name='raw CUDA API usage' --error-description='test' -- c10/CMakeLists.txt``
   → exits 0, no argparse error.
2. Against a file containing both calls, the linter reports them as before.
3. CI ``Check code quality`` job passes on this PR.

## Checklist

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to a corresponding issue
* [x] Linting passes
* [x] All CI tests pass (pending CI run)

## Notes

This only fixes the immediate lint crash. Separately tracking a CI change in ``fsw-integration`` so that the same class of breakage (lint config/adapter drift that diff-only lint doesn't exercise) surfaces in the PR that introduces it.