### PR TITLE
fix(build): support scikit-build-core packaging in rebel_compiler

### DIFF
--- a/tools/apply-custom-rebel.sh
+++ b/tools/apply-custom-rebel.sh
@@ -91,8 +91,8 @@ main() {
   # Update the submodules
   git submodule update --init ./ || return $?
 
-  # Create a virtual environment using uv
-  uv venv .venv && . .venv/bin/activate || return $?
+  # Create a virtual environment using uv (--clear replaces any stale .venv from a prior run)
+  uv venv --clear .venv && . .venv/bin/activate || return $?
 
   # Tooling needed before rebel_install.sh
   uv pip install conan~=2.1.0 cmake~=3.18 build lit auditwheel wheel ninja setuptools || return $?
@@ -117,14 +117,15 @@ main() {
     "-DCMAKE_BUILD_TYPE=$build_type" \
     "-DREBEL_DEPLOY=$rebel_deploy" || return $?
 
-  if [ ! -f ./python/gen_requirements.py ]; then
-    echo "Error: expected python/gen_requirements.py under REBEL_HOME" >&2
-    return 1
+  # Install the Python dependencies.
+  # Newer rebel-compiler (scikit-build-core) declares deps in pyproject.toml and no
+  # longer ships python/gen_requirements.py. Fall back to the legacy path if present.
+  if [ -f ./python/gen_requirements.py ]; then
+    python ./python/gen_requirements.py
   fi
-
-  # Install the Python dependencies
-  python ./python/gen_requirements.py
-  uv pip install -r ./python/requirements/core.txt || return $?
+  if [ -f ./python/requirements/core.txt ]; then
+    uv pip install -r ./python/requirements/core.txt || return $?
+  fi
 
   if [ "$build_only" -eq 1 ]; then
     deactivate


### PR DESCRIPTION
## Summary

- `apply-custom-rebel.sh` assumed rebel_compiler ships `python/gen_requirements.py` and `python/requirements/core.txt`. After rebel_compiler's switch to scikit-build-core, those paths no longer exist, so the script aborted with an error on modern rebel_compiler checkouts.
- Re-running the script when `$REBEL_HOME/.venv` already existed failed because `uv venv` refuses to overwrite an existing venv. Added `--clear` so reruns replace stale environments cleanly.

## Changes

- Make the legacy `gen_requirements.py` + `requirements/core.txt` steps conditional on their presence (pre-scikit-build-core layouts still work).
- Pass `--clear` to `uv venv` so `.venv` gets recreated on rerun.

## Test plan

- [ ] `REBEL_HOME=/path/to/rebel_compiler TORCH_RBLN_BUILD_TYPE=Debug REBEL_DEPLOY=OFF bash tools/apply-custom-rebel.sh --build-only` succeeds on a scikit-build-core rebel_compiler tree.
- [ ] Rerunning the same command on a tree that already has `.venv` still succeeds.
- [ ] Pre-scikit-build-core rebel_compiler tree (if still in use) continues to build.

## Note

Cherry-picked from the previous repository (commit `e42f8a1` on `rebellions-sw/torch-rbln`) during the repo migration to `RBLN-SW/torch-rbln`.