### PR TITLE
fix: workaround FINE-542 hash collision in rebel get_torch_hash

### DIFF
--- a/test/rbln/test_monkey_patch_hash.py
+++ b/test/rbln/test_monkey_patch_hash.py
@@ -1,0 +1,109 @@
+# Owner(s): ["module: PrivateUse1"]
+
+"""Tests for ``patch_get_torch_hash`` in ``torch_rbln._internal.monkey_patches``.
+
+Workaround for FINE-542: rebel-compiler's ``get_torch_hash`` does not include
+graph structure in its signature, so two parameter-less ``fx.GraphModule``s
+collide on the same ``mod_name``. Under ``use_weight_sharing=True`` the second
+compile fails with ``DEVICE_GRAPH_CONVERSION``. The patch forces
+``include_graph=True`` so distinct graphs get distinct hashes.
+"""
+
+import pytest
+import torch
+import torch.nn as nn
+import torch_rbln  # noqa: F401  -- registers backend, applies patches
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+from torch_rbln._internal import monkey_patches as mp
+
+
+def _capture_graph_module(fn, *example_inputs):
+    """Capture the fx.GraphModule that dynamo would hand the rbln backend."""
+    captured = {}
+
+    def _spy(gm, _inputs):
+        captured["gm"] = gm
+        return gm.forward
+
+    compiled = torch.compile(fn, backend=_spy, dynamic=False)
+    compiled(*example_inputs)
+    return captured["gm"]
+
+
+@pytest.mark.test_set_ci
+class TestPatchGetTorchHash(TestCase):
+    def test_patch_marker_set(self):
+        self.assertTrue(mp._get_torch_hash_patched)
+
+    def test_patch_idempotent(self):
+        mp.apply_all_patches()
+        mp.apply_all_patches()
+        self.assertTrue(mp._get_torch_hash_patched)
+
+    def test_module_bindings_updated(self):
+        """``compile_from_any`` imports ``get_torch_hash`` by name; that
+        binding must point to the patched function so the cached reference
+        in the importing module also goes through the include_graph path.
+        """
+        import rebel.compile_from_any as _cfa
+        import rebel.core.compilation._impl as _impl
+        self.assertIs(_cfa.get_torch_hash, _impl.get_torch_hash)
+        # Optional: ``rebel.core.compilation`` may or may not re-export the
+        # name depending on the wheel build; tolerate either.
+        import rebel.core.compilation as _rc
+        if getattr(_rc, "get_torch_hash", None) is not None:
+            self.assertIs(_rc.get_torch_hash, _impl.get_torch_hash)
+
+    def test_distinct_paramless_graphs_get_distinct_hashes(self):
+        """Two structurally different parameter-less graphs must hash differently.
+
+        Pre-patch (or upstream): both signatures are
+            ("no-param", "no-buffer", "", version, "class:GraphModule", "tp:1")
+        and produce identical hashes -> mod_name collision -> FINE-542 failure.
+        Post-patch: ``include_graph=True`` differentiates them.
+        """
+        from rebel.core.compilation._impl import get_torch_hash
+
+        gm_mul = _capture_graph_module(lambda x: x * 1024, torch.zeros(2, dtype=torch.int32))
+        gm_softmax = _capture_graph_module(
+            lambda x: torch.nn.functional.softmax(x, dim=-1),
+            torch.zeros(1, 16, dtype=torch.float16),
+        )
+
+        # Sanity: same class name, both no-param.
+        self.assertEqual(gm_mul.__class__.__name__, gm_softmax.__class__.__name__)
+        self.assertEqual(list(gm_mul.parameters()), [])
+        self.assertEqual(list(gm_softmax.parameters()), [])
+
+        h_mul = get_torch_hash(gm_mul, tensor_parallel_size=1)
+        h_softmax = get_torch_hash(gm_softmax, tensor_parallel_size=1)
+
+        # The whole point of the patch: these MUST differ.
+        self.assertNotEqual(
+            h_mul,
+            h_softmax,
+            f"hash collision: both gm hashed to {h_mul!r} (FINE-542 unfixed)",
+        )
+
+    def test_same_graph_same_hash(self):
+        """Idempotence: hashing the same graph twice yields the same value."""
+        from rebel.core.compilation._impl import get_torch_hash
+
+        gm = _capture_graph_module(lambda x: x + 1, torch.zeros(4, dtype=torch.float16))
+        h1 = get_torch_hash(gm, tensor_parallel_size=1)
+        h2 = get_torch_hash(gm, tensor_parallel_size=1)
+        self.assertEqual(h1, h2)
+
+    def test_tp_size_affects_hash(self):
+        """Different tp_size must still differentiate (preserved upstream behavior)."""
+        from rebel.core.compilation._impl import get_torch_hash
+
+        gm = _capture_graph_module(lambda x: x + 1, torch.zeros(4, dtype=torch.float16))
+        h1 = get_torch_hash(gm, tensor_parallel_size=1)
+        h4 = get_torch_hash(gm, tensor_parallel_size=4)
+        self.assertNotEqual(h1, h4)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch_rbln/_internal/monkey_patches.py
+++ b/torch_rbln/_internal/monkey_patches.py
@@ -13,6 +13,7 @@ from torch_rbln._internal.torch_compile_patch_helpers import CompiledFunctionWra
 # Module-level state to track if patches have been applied
 _torch_compile_patched: bool = False
 _rbln_backend_registered: bool = False
+_get_torch_hash_patched: bool = False
 
 
 def _is_backend_registered(backend_name: str) -> bool:
@@ -133,16 +134,67 @@ def patch_torch_compile() -> None:
     _torch_compile_patched = True
 
 
+def patch_get_torch_hash() -> None:
+    """Force ``rebel.compilation.get_torch_hash`` to include graph structure.
+
+    Without ``include_graph=True`` the hash signature for parameter-less
+    fx.GraphModules is identical (``"no-param" + "no-buffer" + "" + version +
+    "class:GraphModule" + "tp:N"``). Distinct ops (e.g. eager ``mul int32``
+    triggered from torch-rbln's register_ops vs the vllm sampler's
+    ``softmax + top_k_top_p`` graph) collide on the same ``mod_name`` under
+    the shared CompileContext + ``use_weight_sharing=True``. The collision
+    surfaces as ``Graph Generation: [DEVICE_GRAPH_CONVERSION]`` at the
+    second compile (FINE-542 / WeightReusabilityCheck).
+
+    This patch wraps ``rebel.core.compilation._impl.get_torch_hash`` and
+    sets ``include_graph=True`` so the forward code becomes part of the
+    signature, giving distinct graphs distinct ``mod_name``s.
+
+    Patches all three module bindings (``_impl``, ``compile_from_any``,
+    ``core.compilation``) since some import the symbol by name (the import
+    locks an early reference that wouldn't see a single-module patch).
+    """
+    global _get_torch_hash_patched
+    if _get_torch_hash_patched:
+        return
+
+    try:
+        import rebel.compile_from_any as _cfa
+        import rebel.core.compilation as _rc
+        import rebel.core.compilation._impl as _impl
+    except ImportError:
+        return
+
+    original = _impl.get_torch_hash
+
+    def patched(mod, tensor_parallel_size=None):
+        from rebel.core.compilation._torch_hash import TorchModelHasher
+        meta = f"tp:{tensor_parallel_size}" if tensor_parallel_size is not None else None
+        digest = TorchModelHasher().get_model_hash(
+            mod, include_param=True, include_graph=True, meta=meta,
+        )
+        return digest[:6]
+
+    patched.__wrapped__ = original  # type: ignore[attr-defined]
+    for _mod in (_impl, _cfa, _rc):
+        if getattr(_mod, "get_torch_hash", None) is original:
+            _mod.get_torch_hash = patched
+
+    _get_torch_hash_patched = True
+
+
 def apply_all_patches() -> None:
     """
     Apply all monkey patches for RBLN functionality.
 
     This function applies patches in the correct order:
     1. torch.compile() patch
+    2. rebel get_torch_hash include-graph fix (FINE-542 workaround)
 
     Idempotent: Safe to call multiple times.
     """
     patch_torch_compile()
+    patch_get_torch_hash()
 
 
 def remove_all_patches() -> None:
@@ -155,7 +207,8 @@ def remove_all_patches() -> None:
     Note: This function only resets the patch flags. The actual patches remain
     applied. To fully restore, you would need to reload the module.
     """
-    global _torch_compile_patched
+    global _torch_compile_patched, _get_torch_hash_patched
 
     # Reset state flags (actual patches remain applied)
     _torch_compile_patched = False
+    _get_torch_hash_patched = False


### PR DESCRIPTION
## Summary

Workaround for **FINE-542** — sampler ``DEVICE_GRAPH_CONVERSION`` failure caused by ``mod_name`` collision between parameter-less fx.GraphModules.

## Root cause

``rebel/core/compilation/_impl.py:1008`` ``get_torch_hash`` calls:

\`\`\`python
TorchModelHasher().get_model_hash(mod, include_param=True, meta=meta)
\`\`\`

Notably ``include_graph`` defaults to ``False``. For parameter-less ``fx.GraphModule``s the resulting signature is identical:

\`\`\`
("no-param", "no-buffer", "", version, "class:GraphModule", "tp:N")
\`\`\`

Two structurally different parameter-less graphs (e.g. eager ``mul(int32[2], 1024)`` from torch-rbln's ``register_ops`` vs vllm's sampler ``softmax + top_k_top_p`` graph) collide on the same ``mod_name`` under the shared CompileContext (cached singleton, default ``use_weight_sharing=True``). The collision surfaces at the second compile as ``Graph Generation: [DEVICE_GRAPH_CONVERSION]`` (WeightReusabilityCheck rejects the IR mismatch).

**Verified**: both fx.GraphModules above hash to ``e743bc`` pre-patch — exactly matching the failing ``mod_name`` in the field report.

## Fix

Wrap ``get_torch_hash`` with ``include_graph=True`` so the forward code (``str(_LazyGraphModule)``) becomes part of the signature. Patches all three module bindings (``_impl``, ``compile_from_any``, ``core.compilation``) since some import the symbol by name.

## Tests

``test/rbln/test_monkey_patch_hash.py`` — patch marker, idempotence, module bindings, **regression test** capturing two parameter-less fx.GraphModules and asserting they hash to different ``mod_name``s (this was the bug), same-graph hash stability, and tp_size still affects the hash.

## Upstream

Long-term fix should land upstream at ``rebel/core/compilation/_impl.py:1008`` — adding ``include_graph=True`` to the ``TorchModelHasher.get_model_hash`` call. Filed as a comment on FINE-542. This monkey-patch unblocks torch-rbln callers in the meantime.

## Test plan
- [x] ``pytest test/rbln/test_monkey_patch_hash.py`` — 6 passed
- [x] vllm Llama-3.2-1B-Instruct end-to-end with int32 enabled (was failing pre-patch with ``DEVICE_GRAPH_CONVERSION``, now succeeds with byte-identical token output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)