### PR TITLE
fix(core): drop empty entries when splitting LD_LIBRARY_PATH in librbln loader

### DIFF
--- a/torch_rbln/_internal/tvm_libinfo.py
+++ b/torch_rbln/_internal/tvm_libinfo.py
@@ -31,7 +31,10 @@ def split_env_var(env_var, split):
         If env_var exists, split env_var. Otherwise, empty list.
     """
     if os.environ.get(env_var, None):
-        return [p.strip() for p in os.environ[env_var].split(split)]
+        # Drop empty entries: a trailing/leading/double separator in
+        # LD_LIBRARY_PATH etc. yields "", which os.path.realpath("") resolves
+        # to cwd — injecting the current directory as a search path.
+        return [p.strip() for p in os.environ[env_var].split(split) if p.strip()]
     return []
 
 


### PR DESCRIPTION
## Summary of Changes

`split_env_var` in `torch_rbln/_internal/tvm_libinfo.py` kept empty strings produced by separators like a trailing colon in `LD_LIBRARY_PATH` (`".../lib64:"` splits to `[".../lib64", ""]`). Later, `os.path.realpath("")` resolves to the current working directory and passes `os.path.isdir`, so the cwd silently becomes a `librbln.so` search directory. When the cwd happens to contain a shadow symlink to `librbln.so` (e.g. a `build/` directory that links into `.venv`), the walk picks the symlink first. Since `dlopen` evaluates `$ORIGIN` from the path it was given — not the symlink target — the library's `$ORIGIN/../rebel_compiler.libs` RPATH points at the wrong directory and the bundled `libgomp` fails to load.

Fix drops empty entries at split time.

---

## Related Issues / Tickets

* Resolves #
* Related to #

---

## Type of Change

- [x] `fix` — Bug fix
- [x] `core` — Device backend loader

---

## Affected Modules

- [x] Device
- [x] Build/Tools

---

## How to Test (if applicable)

1. Reproduce the split behavior directly:
   \`\`\`
   LD_LIBRARY_PATH="/nonexistent:" python -c \
     "from torch_rbln._internal.tvm_libinfo import split_env_var; \
      print(split_env_var('LD_LIBRARY_PATH', ':'))"
   \`\`\`
   Before: \`['/nonexistent', '']\` — after: \`['/nonexistent']\`.
2. Existing \`test/rbln/test_find_and_load_tvm_library.py\` (3 cases) still passes.

---

## Checklist

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to a corresponding issue
* [x] Linting passes
* [ ] All CI tests pass
* [ ] The test method is described, and the expected result is clearly stated (if applicable)
* [ ] Relevant documentation has been updated (if applicable)