### PR TITLE
fix(build): align external-rebel dev-setup with scikit-build-core layout

### DIFF
--- a/tools/build-with-external-rebel.sh
+++ b/tools/build-with-external-rebel.sh
@@ -268,11 +268,16 @@ check_rebel_python_version() {
     local expected_pattern="_C.cpython-${current_py_version}-*.so"
     local rebel_c_so
 
-    # Check in python/rebel first (primary location)
-    rebel_c_so=$(find "$REBEL_HOME/python/rebel" -maxdepth 1 -name "$expected_pattern" 2>/dev/null | head -1)
+    # scikit-build-core places the built extension under python/build/skbuild
+    # (current rebel-compiler layout). Source-tree python/rebel/ only holds .py
+    # files and _C/*.pyi stubs, so look in the build output first.
+    rebel_c_so=$(find "$REBEL_HOME/python/build/skbuild" -maxdepth 1 -name "$expected_pattern" 2>/dev/null | head -1)
 
+    # Legacy layouts (pre scikit-build-core migration) kept _C.so next to __init__.py.
     if [ -z "$rebel_c_so" ]; then
-        # Also check in rebel/python/rebel (alternative location)
+        rebel_c_so=$(find "$REBEL_HOME/python/rebel" -maxdepth 1 -name "$expected_pattern" 2>/dev/null | head -1)
+    fi
+    if [ -z "$rebel_c_so" ]; then
         rebel_c_so=$(find "$REBEL_HOME/rebel/python/rebel" -maxdepth 1 -name "$expected_pattern" 2>/dev/null | head -1)
     fi
 
@@ -288,7 +293,7 @@ check_rebel_python_version() {
 
     # Find all available versions
     local available_versions
-    available_versions=$(find "$REBEL_HOME/python/rebel" "$REBEL_HOME/rebel/python/rebel" -maxdepth 1 -name "_C.cpython-*.so" 2>/dev/null | \
+    available_versions=$(find "$REBEL_HOME/python/build/skbuild" "$REBEL_HOME/python/rebel" "$REBEL_HOME/rebel/python/rebel" -maxdepth 1 -name "_C.cpython-*.so" 2>/dev/null | \
         xargs -I{} basename {} | grep -oP 'cpython-\K\d+' | sort -u)
 
     if [ -n "$available_versions" ]; then
@@ -350,8 +355,11 @@ install_dependencies() {
     # Align with rebel-compiler Quick Install: cmake<4.0, lit
     pip install "cmake>=3.18,<4.0" ninja jinja2 hatchling setuptools-scm editables mypy lit
 
-    # Set environment for rebel-compiler (rebel Python deps installed after uv sync in build_torch_rbln)
-    export PYTHONPATH="$REBEL_HOME/python:$PYTHONPATH"
+    # Native lib paths only. Python import is wired up later by the editable
+    # rebel-compiler install (scikit-build-core), which drops its own redirect
+    # .pth into site-packages — prepending $REBEL_HOME/python to PYTHONPATH here
+    # would let the source-tree rebel/ shadow the editable install and break
+    # `import rebel._C` under the new layout.
     export LD_LIBRARY_PATH="$REBEL_HOME/build:$LD_LIBRARY_PATH"
 
     # Source dynamic_linking.env for additional libraries
@@ -362,11 +370,13 @@ install_dependencies() {
     # Create activate_rebel script
     create_activate_rebel_script
 
-    # Create .pth file for rebel-compiler in site-packages
+    # Remove the stale pre-scikit-build-core rebel_compiler.pth if an older run
+    # of this script left one behind; it would also shadow the editable install.
     local site_packages
     site_packages=$(python -c "import site; print(site.getsitepackages()[0])" 2>/dev/null || echo "")
-    if [ -n "$site_packages" ] && [ -d "$site_packages" ]; then
-        echo "$REBEL_HOME/python" > "$site_packages/rebel_compiler.pth"
+    if [ -n "$site_packages" ] && [ -f "$site_packages/rebel_compiler.pth" ]; then
+        log_info "  Removing stale rebel_compiler.pth from site-packages"
+        rm -f "$site_packages/rebel_compiler.pth"
     fi
 
     log_info "Dependencies installed"
@@ -386,9 +396,10 @@ create_activate_rebel_script() {
     cat > "$activate_script" << EOF
 # Rebel-compiler environment setup (sourced only when .use_external_rebel exists in venv)
 # To use PyPI package in this venv instead: remove .venv/.use_external_rebel and re-activate
+# rebel-compiler is installed editable via scikit-build-core; Python imports are
+# routed by _rebel_compiler_editable.pth in site-packages, so no PYTHONPATH here.
 export REBEL_HOME="$REBEL_HOME"
 export RBLN_USE_EXTERNAL_REBEL_COMPILER=1
-export PYTHONPATH="$REBEL_HOME/python:\$PYTHONPATH"
 export LD_LIBRARY_PATH="$REBEL_HOME/build:${conan_lib_path}:\$LD_LIBRARY_PATH"
 EOF
     chmod +x "$activate_script"
@@ -507,20 +518,39 @@ validate_torch_wheel() {
     log_info "Validated torch wheel: $wheel_path"
 }
 
-# Install rebel-compiler Python deps from gen_requirements.py + core.txt (after uv sync so they are not overwritten)
+# Install rebel-compiler into the venv. Runs after uv sync so `uv sync
+# --no-install-project` doesn't wipe it. Supports both the current
+# scikit-build-core layout (pyproject.toml; runtime deps resolved automatically
+# via the editable install) and the legacy gen_requirements.py + core.txt flow.
 install_rebel_python_deps() {
-    if [ ! -f "$REBEL_HOME/python/gen_requirements.py" ]; then
-        log_warn "REBEL_HOME/python/gen_requirements.py not found; skipping rebel Python deps"
-        return 0
+    # Legacy layout: generate core.txt and install it, if the file still exists.
+    if [ -f "$REBEL_HOME/python/gen_requirements.py" ]; then
+        log_info "Installing rebel-compiler Python dependencies (gen_requirements.py + core.txt)..."
+        (cd "$REBEL_HOME" && python ./python/gen_requirements.py) || return $?
+        if [ -d "$REBEL_HOME/python/requirements" ]; then
+            uv pip install -r "$REBEL_HOME/python/requirements/core.txt" || return $?
+        else
+            log_warn "REBEL_HOME/python/requirements not found after gen_requirements.py; skipping core.txt install"
+        fi
     fi
-    log_info "Installing rebel-compiler Python dependencies (gen_requirements.py + core.txt)..."
-    (cd "$REBEL_HOME" && python ./python/gen_requirements.py) || return $?
-    if [ ! -d "$REBEL_HOME/python/requirements" ]; then
-        log_warn "REBEL_HOME/python/requirements not found; skipping rebel Python deps"
-        return 0
+
+    # Editable install of rebel-compiler via scikit-build-core. Writes
+    # _rebel_compiler_editable.pth + the redirect hook to site-packages so that
+    # `import rebel` resolves to $REBEL_HOME/python/rebel/ while `import rebel._C`
+    # finds the extension under $REBEL_HOME/python/build/skbuild/. With
+    # [tool.scikit-build.editable] rebuild=false, the existing build output is
+    # reused rather than recompiled. pyproject.toml's [project].dependencies
+    # covers rebel-compiler's runtime deps, so no separate core.txt is needed
+    # under the new layout.
+    if [ ! -f "$REBEL_HOME/python/pyproject.toml" ]; then
+        log_error "REBEL_HOME/python/pyproject.toml not found — cannot install rebel-compiler."
+        log_error "Expected path: $REBEL_HOME/python/pyproject.toml"
+        return 1
     fi
-    uv pip install -r "$REBEL_HOME/python/requirements/core.txt" || return $?
-    log_info "Rebel Python dependencies installed"
+    log_info "Installing rebel-compiler (editable) from $REBEL_HOME/python..."
+    uv pip install -e "$REBEL_HOME/python" || return $?
+
+    log_info "rebel-compiler installed"
 }
 
 build_torch_rbln() {
@@ -532,7 +562,8 @@ build_torch_rbln() {
     fi
     export REBEL_HOME="$REBEL_HOME"
     export RBLN_USE_EXTERNAL_REBEL_COMPILER=1
-    export PYTHONPATH="$REBEL_HOME/python:$PYTHONPATH"
+    # No PYTHONPATH shim: rebel-compiler is editable-installed below (scikit-build-core),
+    # and FindRebel.cmake reads REBEL_HOME directly for headers/libs.
 
     # Install torch based on gcc version
     if [ "$gcc_version" = "12" ] && [ -n "$effective_torch_wheel_path" ]; then
@@ -677,8 +708,10 @@ print_summary() {
     echo ""
     echo "  2. The activate_rebel script is auto-sourced, setting:"
     echo "     - REBEL_HOME"
-    echo "     - PYTHONPATH (includes rebel-compiler)"
+    echo "     - RBLN_USE_EXTERNAL_REBEL_COMPILER=1"
     echo "     - LD_LIBRARY_PATH (includes native libraries)"
+    echo "     (rebel-compiler is editable-installed via scikit-build-core;"
+    echo "      Python imports are routed by _rebel_compiler_editable.pth)"
     echo ""
     echo "  3. Example usage:"
     echo "     python -c 'import torch; import rebel; import torch_rbln; print(\"OK\")'"

--- a/tools/build-with-external-rebel.sh
+++ b/tools/build-with-external-rebel.sh
@@ -352,7 +352,10 @@ setup_virtualenv() {
 install_dependencies() {
     log_info "Installing build dependencies..."
     pip install --upgrade pip
-    # Align with rebel-compiler Quick Install: cmake<4.0, lit
+    # Align with rebel-compiler Quick Install: cmake<4.0, lit.
+    # rebel-compiler's own build-system.requires (scikit-build-core, pybind11,
+    # cython, setuptools_scm) are installed later in install_rebel_python_deps,
+    # *after* `uv sync --no-install-project` — otherwise uv sync would wipe them.
     pip install "cmake>=3.18,<4.0" ninja jinja2 hatchling setuptools-scm editables mypy lit
 
     # Native lib paths only. Python import is wired up later by the editable
@@ -518,37 +521,52 @@ validate_torch_wheel() {
     log_info "Validated torch wheel: $wheel_path"
 }
 
-# Install rebel-compiler into the venv. Runs after uv sync so `uv sync
-# --no-install-project` doesn't wipe it. Supports both the current
-# scikit-build-core layout (pyproject.toml; runtime deps resolved automatically
-# via the editable install) and the legacy gen_requirements.py + core.txt flow.
+# Install rebel-compiler into the venv (scikit-build-core editable). Runs
+# after `uv sync --no-install-project` so the install isn't wiped by sync.
+#
+# Writes _rebel_compiler_editable.pth + the redirect hook to site-packages so
+# that `import rebel` resolves to $REBEL_HOME/python/rebel/ while
+# `import rebel._C` finds the extension under $REBEL_HOME/python/build/skbuild/.
+# With [tool.scikit-build.editable] rebuild=false, the pre-built extension is
+# reused rather than recompiled. Runtime deps come from the package's
+# pyproject.toml.
+#
+# --no-build-isolation keeps the editable install deterministic: it reuses the
+# scikit-build-core / pybind11 / cython / cmake / ninja pinned in
+# install_dependencies instead of fetching a separate PEP 517 build env from
+# PyPI each invocation.
 install_rebel_python_deps() {
-    # Legacy layout: generate core.txt and install it, if the file still exists.
-    if [ -f "$REBEL_HOME/python/gen_requirements.py" ]; then
-        log_info "Installing rebel-compiler Python dependencies (gen_requirements.py + core.txt)..."
-        (cd "$REBEL_HOME" && python ./python/gen_requirements.py) || return $?
-        if [ -d "$REBEL_HOME/python/requirements" ]; then
-            uv pip install -r "$REBEL_HOME/python/requirements/core.txt" || return $?
-        else
-            log_warn "REBEL_HOME/python/requirements not found after gen_requirements.py; skipping core.txt install"
-        fi
-    fi
-
-    # Editable install of rebel-compiler via scikit-build-core. Writes
-    # _rebel_compiler_editable.pth + the redirect hook to site-packages so that
-    # `import rebel` resolves to $REBEL_HOME/python/rebel/ while `import rebel._C`
-    # finds the extension under $REBEL_HOME/python/build/skbuild/. With
-    # [tool.scikit-build.editable] rebuild=false, the existing build output is
-    # reused rather than recompiled. pyproject.toml's [project].dependencies
-    # covers rebel-compiler's runtime deps, so no separate core.txt is needed
-    # under the new layout.
     if [ ! -f "$REBEL_HOME/python/pyproject.toml" ]; then
         log_error "REBEL_HOME/python/pyproject.toml not found — cannot install rebel-compiler."
         log_error "Expected path: $REBEL_HOME/python/pyproject.toml"
         return 1
     fi
-    log_info "Installing rebel-compiler (editable) from $REBEL_HOME/python..."
-    uv pip install -e "$REBEL_HOME/python" || return $?
+
+    # Fail loudly if the REBEL_HOME checkout isn't scikit-build-core (pre-migration
+    # trees built rebel-compiler via a different backend; this script no longer
+    # supports them).
+    if ! grep -q 'build-backend\s*=\s*"scikit_build_core.build"' "$REBEL_HOME/python/pyproject.toml"; then
+        log_error "REBEL_HOME/python/pyproject.toml does not use scikit_build_core.build."
+        log_error "This script targets the post-migration rebel-compiler layout; please upgrade"
+        log_error "REBEL_HOME to a scikit-build-core build of rebel-compiler."
+        return 1
+    fi
+
+    # Install rebel-compiler's own build-system.requires into the active venv so
+    # `uv pip install --no-build-isolation -e` can reuse them without creating a
+    # PEP 517 isolated build env (and its associated PyPI fetches). These pins
+    # track rebel-compiler/python/pyproject.toml's [build-system].requires.
+    log_info "Installing rebel-compiler build dependencies (scikit-build-core, pybind11, cython)..."
+    uv pip install \
+        "scikit-build-core>=0.10" \
+        "setuptools_scm>=8" \
+        "pybind11>=2.10,<=2.10.4" \
+        cython \
+        "cmake>=3.26,<4.0" \
+        ninja || return $?
+
+    log_info "Installing rebel-compiler (editable, --no-build-isolation) from $REBEL_HOME/python..."
+    uv pip install --no-build-isolation -e "$REBEL_HOME/python" || return $?
 
     log_info "rebel-compiler installed"
 }
@@ -562,8 +580,9 @@ build_torch_rbln() {
     fi
     export REBEL_HOME="$REBEL_HOME"
     export RBLN_USE_EXTERNAL_REBEL_COMPILER=1
-    # No PYTHONPATH shim: rebel-compiler is editable-installed below (scikit-build-core),
-    # and FindRebel.cmake reads REBEL_HOME directly for headers/libs.
+    # No PYTHONPATH shim: install_rebel_python_deps (called later in this function)
+    # does a scikit-build-core editable install of rebel-compiler, and
+    # FindRebel.cmake reads REBEL_HOME directly for headers/libs.
 
     # Install torch based on gcc version
     if [ "$gcc_version" = "12" ] && [ -n "$effective_torch_wheel_path" ]; then
@@ -667,7 +686,9 @@ print(f'  torch_rbln: {torch_rbln.__version__}')
         log_error "Possible causes:"
         log_error "  - Segmentation fault (library version mismatch)"
         log_error "  - LD_LIBRARY_PATH not set correctly"
-        log_error "  - PYTHONPATH not set correctly"
+        log_error "  - rebel-compiler editable install missing or shadowed"
+        log_error "    (check \$VIRTUAL_ENV/lib/python*/site-packages/_rebel_compiler_editable.pth;"
+        log_error "     re-run: uv pip install --no-build-isolation -e \$REBEL_HOME/python)"
         log_error "  - Python version mismatch with rebel-compiler"
         log_error "  - GCC version mismatch between torch and torch-rbln"
         log_error ""


### PR DESCRIPTION
## Summary of Changes

#18 migrated rebel-compiler's Python package to **scikit-build-core**, but `tools/build-with-external-rebel.sh` (invoked by `./tools/dev-setup.sh external --clean`) still assumed the pre-migration layout. On a Python 3.12 venv with a scikit-build-core-built `REBEL_HOME`, the script fails at the version check with:

```
[ERROR] rebel-compiler was not built for Python 312!
```

even though the extension is built and importable. Same root cause — old layout assumption — was duplicated in five more places in the script (PYTHONPATH shim in `install_dependencies` + in `activate_rebel` + in `build_torch_rbln`, the hand-written `rebel_compiler.pth`, and the `gen_requirements.py`-only install path), so fixing only the version check would not have produced a working `import rebel._C`.

### Root cause

Under scikit-build-core:

- The compiled extension `_C.cpython-*.so` lives in **`$REBEL_HOME/python/build/skbuild/`**, not in `python/rebel/`.
- The source tree `python/rebel/` holds only `.py` files and `_C/*.pyi` stubs.
- Imports are wired up by `_rebel_compiler_editable.pth` + `_rebel_compiler_editable.py` (scikit-build-core redirect hook) written to the consumer venv by `pip install -e`.
- Runtime deps come from `pyproject.toml` `[project].dependencies`; `python/gen_requirements.py` and `python/requirements/core.txt` no longer exist.
- Build deps come from `[build-system].requires`: `scikit-build-core>=0.10`, `pybind11>=2.10,<=2.10.4`, `cython`, `setuptools_scm>=8`, `cmake>=3.26`, `ninja`.

The previous script was built for the opposite of all three.

### Fix

`tools/build-with-external-rebel.sh`:

| Function | Change |
|----------|--------|
| `check_rebel_python_version` | Probe `$REBEL_HOME/python/build/skbuild/` first. Keep `python/rebel/` and `rebel/python/rebel/` as diagnostic fallbacks. Same expansion in the "available versions" listing. |
| `install_dependencies` | Drop `export PYTHONPATH="$REBEL_HOME/python:…"` and the hand-written `rebel_compiler.pth`. Prepending the source tree to `PYTHONPATH` shadows the editable install and breaks `import rebel._C`. Clean up any stale `rebel_compiler.pth` from prior runs. |
| `create_activate_rebel_script` | Drop the same `PYTHONPATH` export from generated `activate_rebel` so the shadow doesn't come back on every venv activation. |
| `install_rebel_python_deps` | **Target scikit-build-core only.** Detect the backend via `grep 'scikit_build_core.build'` on `REBEL_HOME/python/pyproject.toml` and fail loudly with an upgrade hint if a pre-migration tree is supplied. Pre-install rebel-compiler's `[build-system].requires` into the active venv (so they survive `uv sync --no-install-project`), then run `uv pip install --no-build-isolation -e "$REBEL_HOME/python"` — deterministic, no PEP 517 isolated-env PyPI fetches per invocation. |
| `build_torch_rbln` | Drop the duplicate `PYTHONPATH` shim; `cmake/FindRebel.cmake` already reads `REBEL_HOME` directly for headers/libs. |
| `verify_installation` | Replace the stale "PYTHONPATH not set correctly" debug hint with one that matches the new flow (missing `_rebel_compiler_editable.pth` / re-run the editable install). |
| `print_summary` | Update the trailing "How to use" block to match the new env (no `PYTHONPATH`). |

---

## Related Issues / Tickets

* Related to #18 (scikit-build-core packaging migration in `rebel_compiler`) — this PR is the torch-rbln-side follow-up for the external-rebel dev-setup.

---

## Type of Change

- [x] `fix` — Bug fix

---

## Affected Modules

- [x] Build/Tools (`tools/build-with-external-rebel.sh`)

---

## How to Test

1. **Prep a Python 3.12 venv with a scikit-build-core-built rebel-compiler** (as produced by current `rebel_install.sh`):
   ```
   export REBEL_HOME=/path/to/external_rebel_compiler
   ls "$REBEL_HOME/python/build/skbuild/_C.cpython-312-*.so"   # present
   ls "$REBEL_HOME/python/rebel/_C.cpython-*.so" 2>/dev/null   # absent (new layout)
   grep build-backend "$REBEL_HOME/python/pyproject.toml"      # scikit_build_core.build
   ```

2. **Before this PR** — the setup fails at the version check:
   ```
   ./tools/dev-setup.sh external --clean
   # [ERROR] rebel-compiler was not built for Python 312!
   ```

3. **After this PR** — the setup completes and the import test passes:
   ```
   ./tools/dev-setup.sh external --clean
   # [INFO] Found matching rebel._C: _C.cpython-312-x86_64-linux-gnu.so
   # [INFO] Installing rebel-compiler build dependencies (scikit-build-core, pybind11, cython)...
   # [INFO] Installing rebel-compiler (editable, --no-build-isolation) from $REBEL_HOME/python...
   #   torch: 2.10.0+cpu
   #   rebel: 0.10.3.dev321+g8763cc92
   #   torch_rbln: 0.1.10.dev12+g…
   # [INFO] Import test PASSED!
   ```

4. **Legacy-layout regression**: if someone points `REBEL_HOME` at a pre-migration rebel-compiler checkout, the script now fails fast with a clear upgrade message rather than silently attempting a fresh Cython compile.

---

## Checklist

* [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
* [ ] This PR is linked to a corresponding issue — linked to #18 instead
* [x] Linting passes (shell script only; no project lint impact)
* [ ] All CI tests pass — CI does not currently exercise `dev-setup.sh external`; verified manually
* [x] The test method is described, and the expected result is clearly stated
* [x] Relevant documentation has been updated — `print_summary` and error-hint text brought in line with the new flow

---

## Notes

- Only `tools/build-with-external-rebel.sh` is modified. `pyproject.toml` / `uv.lock` edits produced while running the script for verification are intentionally not included — they are an intended side effect of external-mode setup on the consumer's working copy, not source changes for this PR.
- No Python/C++ code paths change. The PyPI (`pypi`) and custom-wheel (`apply-custom-rebel.sh`) flows in `dev-setup.sh` are untouched.
- This PR is explicitly scikit-build-core-only. Supporting both layouts was attempted in the first commit but dropped on review — the install step ran unconditionally against legacy trees and would have triggered a fresh CMake/Cython build, invalidating the "legacy supported" claim. The fix-forward is to detect and reject pre-migration trees early.