### PR TITLE
test(ops): add regression for bias-less 3D linear host op seq mismatch

### DIFF
--- a/test/rbln/test_llama_ops.py
+++ b/test/rbln/test_llama_ops.py
@@ -177,6 +177,35 @@ class TestLlamaOps(TestCase):
         weight = torch.randn([out_features, in_features], dtype=dtype)
         self._run_op(torch.nn.functional.linear, input, weight)
 
+    # 3D input × bias-less linear where the compiler generates a post-GEMM host
+    # op sequence whose reshape and transpose ranks disagree. rebel-compiler
+    # PR #10429 (GEMM primitive interface change, released in dev281) made
+    # WrapHostOps emit a 3D reshape followed by a 4D transpose for the output,
+    # tripping `transpose_op.axis_order().size() == curr_shape.size()` at
+    # runtime/vmemory/transform/calculate.cc:250. Fixed by rebel-compiler
+    # PR #10476 (dev top).
+    #
+    # Shapes come from real compiled graphs captured during perf testing: the
+    # (1, 16, 1024) × (640, 1024) case is the one reported on Slack; the (192)
+    # and (768) siblings were in the same trace and were empirically verified
+    # to reproduce the identical runtime assert on rebel-compiler==dev281, but
+    # not on dev307+.
+    @dtypes(*SUPPORTED_DTYPES)
+    @parametrize(
+        "batch_size,seq_len,in_features,out_features",
+        [
+            (1, 16, 1024, 192),
+            (1, 16, 1024, 640),
+            (1, 16, 1024, 768),
+        ],
+    )
+    def test_llama_nn_functional_linear_host_op_seq_regression(
+        self, dtype, batch_size, seq_len, in_features, out_features
+    ):
+        input = torch.randn([batch_size, seq_len, in_features], dtype=dtype)
+        weight = torch.randn([out_features, in_features], dtype=dtype)
+        self._run_op(torch.nn.functional.linear, input, weight, None)
+
     @dtypes(*SUPPORTED_DTYPES)
     @parametrize("batch_size", batch_sizes)
     @parametrize("input_shape", [(8, 2048)])


### PR DESCRIPTION
## Summary of Changes

Adds a regression test for `torch.nn.functional.linear` on bias-less 3D inputs that triggered a rebel-compiler runtime assert on dev281.

The bug: post-GEMM output host op sequence paired a 3D reshape with a 4D transpose, failing `transpose_op.axis_order().size() == curr_shape.size()` at `runtime/vmemory/transform/calculate.cc`. Introduced by rebellions-sw/rebel_compiler#10429 (dev281) and fixed by rebellions-sw/rebel_compiler#10476 (dev307+).

Three shapes from a perf-test trace are included; each one was verified to reproduce the runtime assert on dev281 and pass on dev307+.

---

## Related Issues / Tickets

* Related to rebellions-sw/rebel_compiler#10476

---

## Type of Change

- [ ] \`feature\` — New capability or functionality
- [ ] \`core\` — Changes to RBLN backend, device layer, C++ extension, op registration, or \`torch.compile\` integration
- [ ] \`fix\` — Bug fix
- [ ] \`perf\` — Performance improvement
- [ ] \`refactor\` — Code improvement without behavior change
- [ ] \`docs\` — Documentation only
- [x] \`other\` — Test-only regression guard

---

## Affected Modules

- [ ] Backend
- [ ] Device
- [x] Ops/Kernels
- [ ] \`torch.compile\`
- [ ] C++ extension (\`torch_rbln/csrc\`)
- [ ] Memory
- [ ] Build/Tools
- [ ] Docs

---

## How to Test

1. Run \`python -m pytest test/rbln/test_llama_ops.py -k host_op_seq_regression -v\`
2. Expected: 3 tests pass on rebel-compiler dev307+.
3. On dev281 the same tests fail with \`transpose_op.axis_order().size() == curr_shape.size()\` from the RBLN runtime.

---

## Screenshots / Logs

N/A

---

## Checklist

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to a corresponding issue
* [x] Linting passes
* [x] All CI tests pass
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (N/A)

---

## Notes

Test-only change. No production code touched.