### PR TITLE
chore: c10::rbln borrow unify + pin rebel-compiler 045b3ed0

### DIFF
--- a/aten/src/ATen/native/rbln/RBLNCPUFallback.cpp
+++ b/aten/src/ATen/native/rbln/RBLNCPUFallback.cpp
@@ -408,7 +408,8 @@ void cpu_fallback_rbln(
       const uint64_t nbytes = rbln_out.nbytes();
       if (rbln_out.device().type() == c10::DeviceType::PrivateUse1 &&
           rbln_out.is_contiguous() && nbytes > 0) {
-        auto borrowed = c10::rbln::acquire_host_ptr_for_overwrite(rbln_out.data_ptr(), nbytes);
+        auto borrowed =
+            c10::rbln::borrow_host_ptr(rbln_out.data_ptr(), nbytes, /*for_overwrite=*/true);
         borrow_ids[i] = borrowed.borrow_id;
         auto opts = at::TensorOptions().dtype(rbln_out.dtype()).device(at::kCPU);
         cpu_tensors[i] = at::from_blob(
@@ -507,9 +508,10 @@ void cpu_fallback_rbln(
       }
       const uint64_t nbytes = rbln_out.nbytes();
       if (nbytes > 0) {
-        // Acquire-for-overwrite: we immediately memcpy over the whole region, so any
+        // Borrow for overwrite: we immediately memcpy over the whole region, so any
         // D2H from a stale PHYSICAL_VIEW_IS_LATEST state would be thrown away.
-        auto borrowed = c10::rbln::acquire_host_ptr_for_overwrite(rbln_out.data_ptr(), nbytes);
+        auto borrowed =
+            c10::rbln::borrow_host_ptr(rbln_out.data_ptr(), nbytes, /*for_overwrite=*/true);
         std::memcpy(reinterpret_cast<void*>(borrowed.host_ptr), cpu_tensors[i].data_ptr(), nbytes);
         c10::rbln::return_borrowed(borrowed.borrow_id, /*updated=*/true);
       }
@@ -709,7 +711,8 @@ void cpu_fallback_rbln(
               // any pre-existing data (in practice there is none, but if the
               // allocator ever caches a warm buffer the old device data is
               // irrelevant) will be overwritten by the memcpy below.
-              auto borrowed = c10::rbln::acquire_host_ptr_for_overwrite(rbln_out.data_ptr(), nbytes);
+              auto borrowed = c10::rbln::borrow_host_ptr(rbln_out.data_ptr(), nbytes,
+                                                         /*for_overwrite=*/true);
               std::memcpy(reinterpret_cast<void*>(borrowed.host_ptr), cpu_out.data_ptr(), nbytes);
               c10::rbln::return_borrowed(borrowed.borrow_id, /*updated=*/true);
             }

--- a/c10/rbln/RBLNFunctions.cpp
+++ b/c10/rbln/RBLNFunctions.cpp
@@ -319,8 +319,9 @@ void memcpy_v2v(void* rbln_dst_data, const void* rbln_src_data, size_t nbytes) {
   }
 }
 
-BorrowedHostPtr borrow_host_ptr(const void* rbln_data, size_t nbytes) {
-  RBLN_LOG_DEBUG("rbln_data={}, nbytes={}", fmt::ptr(rbln_data), nbytes);
+BorrowedHostPtr borrow_host_ptr(const void* rbln_data, size_t nbytes, bool for_overwrite) {
+  RBLN_LOG_DEBUG(
+      "rbln_data={}, nbytes={}, for_overwrite={}", fmt::ptr(rbln_data), nbytes, for_overwrite);
   RBLN_CHECK(rbln_data != nullptr, "rbln_data cannot be nullptr");
   RBLN_CHECK(nbytes > 0, "nbytes must be positive, but got {}", nbytes);
 
@@ -328,30 +329,18 @@ BorrowedHostPtr borrow_host_ptr(const void* rbln_data, size_t nbytes) {
   const auto size = static_cast<uint64_t>(nbytes);
   uintptr_t host_ptr = 0;
   uint64_t borrow_id = 0;
-  RBLN_LOG_DEBUG("Calling rbln_v_borrow_host_ptr: vaddr={:#x}, size={}", vaddr, size);
-  RBLN_CHECK(
-      !::rbln::rbln_v_borrow_host_ptr(vaddr, size, host_ptr, borrow_id),
-      "rbln_v_borrow_host_ptr failed (vaddr={:#x}, size={}); see rebel runtime logs for details",
-      vaddr,
-      size);
-  return BorrowedHostPtr{host_ptr, borrow_id};
-}
-
-BorrowedHostPtr acquire_host_ptr_for_overwrite(void* rbln_data, size_t nbytes) {
-  RBLN_LOG_DEBUG("rbln_data={}, nbytes={}", fmt::ptr(rbln_data), nbytes);
-  RBLN_CHECK(rbln_data != nullptr, "rbln_data cannot be nullptr");
-  RBLN_CHECK(nbytes > 0, "nbytes must be positive, but got {}", nbytes);
-
-  const auto vaddr = reinterpret_cast<uint64_t>(rbln_data);
-  const auto size = static_cast<uint64_t>(nbytes);
-  uintptr_t host_ptr = 0;
-  uint64_t borrow_id = 0;
-  RBLN_LOG_DEBUG("Calling rbln_v_acquire_host_ptr_for_overwrite: vaddr={:#x}, size={}", vaddr, size);
-  RBLN_CHECK(
-      !::rbln::rbln_v_acquire_host_ptr_for_overwrite(vaddr, size, host_ptr, borrow_id),
-      "rbln_v_acquire_host_ptr_for_overwrite failed (vaddr={:#x}, size={}); see rebel runtime logs for details",
-      vaddr,
-      size);
+  const char* api_name =
+      for_overwrite ? "rbln_v_acquire_host_ptr_for_overwrite" : "rbln_v_borrow_host_ptr";
+  RBLN_LOG_DEBUG("Calling {}: vaddr={:#x}, size={}", api_name, vaddr, size);
+  const auto err = for_overwrite
+                       ? ::rbln::rbln_v_acquire_host_ptr_for_overwrite(
+                             vaddr, size, host_ptr, borrow_id)
+                       : ::rbln::rbln_v_borrow_host_ptr(vaddr, size, host_ptr, borrow_id);
+  RBLN_CHECK(!err,
+             "{} failed (vaddr={:#x}, size={}); see rebel runtime logs for details",
+             api_name,
+             vaddr,
+             size);
   return BorrowedHostPtr{host_ptr, borrow_id};
 }
 

--- a/c10/rbln/RBLNFunctions.h
+++ b/c10/rbln/RBLNFunctions.h
@@ -175,7 +175,7 @@ C10_RBLN_API void memcpy_v2h(void* cpu_dst_data, const void* rbln_src_data, size
 C10_RBLN_API void memcpy_v2v(void* rbln_dst_data, const void* rbln_src_data, size_t nbytes);
 
 /**
- * @brief Result of a borrow_host_ptr / acquire_host_ptr_for_overwrite call.
+ * @brief Result of a borrow_host_ptr call.
  *
  * The borrow id MUST be passed back to `return_borrowed` exactly once to
  * release the underlying virtual-memory entry. A successful borrow always
@@ -190,50 +190,42 @@ struct BorrowedHostPtr {
 
 /**
  * @brief Borrow a host pointer into the rbln virtual memory backing
- * `rbln_data`. Triggers a device→host sync if the device view is currently
- * authoritative; allocates host backing if none exists. After this call the
- * host buffer is read-ready.
+ * `rbln_data`.
+ *
+ * Default mode (`for_overwrite=false`): triggers a device→host sync if the
+ * device view is currently authoritative; allocates host backing if none
+ * exists. After this call the host buffer is read-ready.
+ *
+ * Write-only mode (`for_overwrite=true`): device→host transfer is skipped
+ * even when the entry is physical-latest. Callers MUST overwrite **the
+ * entire borrowed region** before `return_borrowed(..., updated=true)`;
+ * otherwise the region surfaces stale bytes to subsequent device consumers.
+ * Use `for_overwrite=false` if a partial overwrite is intended.
  *
  * The borrow MUST be released via `return_borrowed(result.borrow_id, ...)`.
  *
- * @param rbln_data A pointer to rbln-device memory (typically tensor data_ptr).
- *        Must not be nullptr.
+ * @param rbln_data A pointer to rbln-device memory (typically tensor
+ *        data_ptr). Must not be nullptr.
  * @param nbytes Number of bytes to borrow. Must be positive — callers with a
  *        legitimate zero-byte case must short-circuit before invoking.
+ * @param for_overwrite If true, request write-only access (skip D2H). See
+ *        write-only mode description above.
  * @return Host pointer + non-zero borrow id; throws c10::Error via RBLN_CHECK
  *         on failure (invalid args, rebel-side error).
  */
-C10_RBLN_API BorrowedHostPtr borrow_host_ptr(const void* rbln_data, size_t nbytes);
-
-/**
- * @brief Acquire a host pointer for **overwrite-only** access into the rbln
- * virtual memory backing `rbln_data`. Same lifecycle as `borrow_host_ptr`,
- * but the device→host transfer is skipped even when the entry is
- * physical-latest.
- *
- * IMPORTANT: callers MUST overwrite **the entire borrowed region** before
- * `return_borrowed(..., updated=true)`; otherwise the region surfaces stale
- * bytes to subsequent device consumers. Use `borrow_host_ptr` instead if a
- * partial overwrite is intended.
- *
- * @param rbln_data A pointer to rbln-device memory. Must not be nullptr.
- * @param nbytes Number of bytes to acquire (must be positive).
- * @return Host pointer + non-zero borrow id; throws c10::Error via RBLN_CHECK
- *         on failure.
- */
-C10_RBLN_API BorrowedHostPtr acquire_host_ptr_for_overwrite(void* rbln_data, size_t nbytes);
+C10_RBLN_API BorrowedHostPtr borrow_host_ptr(const void* rbln_data, size_t nbytes,
+                                             bool for_overwrite = false);
 
 /**
  * @brief Release a previously borrowed host pointer.
  *
- * @param borrow_id The id returned from `borrow_host_ptr` /
- *        `acquire_host_ptr_for_overwrite`. The value `0` is the
- *        "no live borrow" sentinel and is treated as a no-op so cleanup
+ * @param borrow_id The id returned from `borrow_host_ptr`. The value `0` is
+ *        the "no live borrow" sentinel and is treated as a no-op so cleanup
  *        paths can release vectors of optional borrows uniformly.
  * @param updated If true, marks the host view as the latest source of truth;
  *        the next device consumer performs a lazy host→device copy. Must be
- *        true after a successful `acquire_host_ptr_for_overwrite` write
- *        sequence; otherwise the overwritten bytes are discarded.
+ *        true after a successful write-only borrow + overwrite sequence;
+ *        otherwise the overwritten bytes are discarded.
  */
 C10_RBLN_API void return_borrowed(uint64_t borrow_id, bool updated);
 

--- a/constraints-build-dev.txt
+++ b/constraints-build-dev.txt
@@ -1,2 +1,2 @@
 # Build/dev dependency constraints (single source of truth).
-rebel-compiler==0.10.4.dev41+g8746e1bf.prod
+rebel-compiler==0.10.4.dev53+g045b3ed0

--- a/test/cpp/core/RBLNFunctionsTest.cpp
+++ b/test/cpp/core/RBLNFunctionsTest.cpp
@@ -223,9 +223,9 @@ TEST_F(RBLNFunctionsTest, GetUninitializedMemoryInfo) {
 }
 
 // ---------------------------------------------------------------------------
-// borrow_host_ptr / acquire_host_ptr_for_overwrite / return_borrowed.
+// borrow_host_ptr (default / for_overwrite=true) / return_borrowed.
 // Covers the round-trip happy path, host-write-back semantics, the
-// overwrite-acquire variant (no D2H sync), and the input-validation contracts
+// for_overwrite=true variant (no D2H sync), and the input-validation contracts
 // (nullptr / zero size / sentinel borrow_id).
 // ---------------------------------------------------------------------------
 
@@ -282,16 +282,16 @@ TEST_F(RBLNFunctionsTest, BorrowHostPtrWriteBackVisibleAfterReturn) {
   c10::rbln::free(rbln_data);
 }
 
-TEST_F(RBLNFunctionsTest, AcquireHostPtrForOverwriteRoundTrip) {
-  // Acquire-for-overwrite skips the device→host sync; caller must overwrite
-  // the entire region. Verify (a) the call returns a valid host pointer and
-  // (b) writing through it and returning(updated=true) makes the host bytes
+TEST_F(RBLNFunctionsTest, BorrowHostPtrForOverwriteRoundTrip) {
+  // for_overwrite=true skips the device→host sync; caller must overwrite the
+  // entire region. Verify (a) the call returns a valid host pointer and (b)
+  // writing through it and returning(updated=true) makes the host bytes
   // visible on subsequent v2h.
   const size_t nbytes = 256;
   auto rbln_data = c10::rbln::malloc(/*device_index=*/0, nbytes);
   ASSERT_NE(rbln_data, nullptr);
 
-  const auto borrowed = c10::rbln::acquire_host_ptr_for_overwrite(rbln_data, nbytes);
+  const auto borrowed = c10::rbln::borrow_host_ptr(rbln_data, nbytes, /*for_overwrite=*/true);
   EXPECT_NE(borrowed.host_ptr, uintptr_t{0});
   EXPECT_NE(borrowed.borrow_id, uint64_t{0});
 
@@ -310,7 +310,8 @@ TEST_F(RBLNFunctionsTest, AcquireHostPtrForOverwriteRoundTrip) {
 
 TEST_F(RBLNFunctionsTest, BorrowRejectsNullData) {
   EXPECT_THROW(c10::rbln::borrow_host_ptr(/*rbln_data=*/nullptr, 64), c10::Error);
-  EXPECT_THROW(c10::rbln::acquire_host_ptr_for_overwrite(/*rbln_data=*/nullptr, 64), c10::Error);
+  EXPECT_THROW(c10::rbln::borrow_host_ptr(/*rbln_data=*/nullptr, 64, /*for_overwrite=*/true),
+               c10::Error);
 }
 
 TEST_F(RBLNFunctionsTest, BorrowRejectsZeroSize) {
@@ -319,7 +320,8 @@ TEST_F(RBLNFunctionsTest, BorrowRejectsZeroSize) {
   auto rbln_data = c10::rbln::malloc(/*device_index=*/0, 64);
   ASSERT_NE(rbln_data, nullptr);
   EXPECT_THROW(c10::rbln::borrow_host_ptr(rbln_data, /*nbytes=*/0), c10::Error);
-  EXPECT_THROW(c10::rbln::acquire_host_ptr_for_overwrite(rbln_data, /*nbytes=*/0), c10::Error);
+  EXPECT_THROW(c10::rbln::borrow_host_ptr(rbln_data, /*nbytes=*/0, /*for_overwrite=*/true),
+               c10::Error);
   c10::rbln::free(rbln_data);
 }
 

--- a/third_party/rebel_compiler/include/rebel/runtime/api/rbln_runtime_api.h
+++ b/third_party/rebel_compiler/include/rebel/runtime/api/rbln_runtime_api.h
@@ -230,8 +230,8 @@ RBLNRetCode rbln_get_memory_info(uint64_t vaddr, MemoryInfo& memory_info_out);
 // return convention (RBLNRetCode vs Status); free of vmemory_manager.h
 // dependencies so it is safe to call from torch-rbln without dragging in
 // absl / model headers.
-RBLNRetCode rbln_v_borrow_host_ptr(uint64_t vaddr, uint64_t size,
-                                   uintptr_t& host_ptr_out, uint64_t& borrow_id_out);
+RBLNRetCode rbln_v_borrow_host_ptr(uint64_t vaddr, uint64_t size, uintptr_t& host_ptr_out,
+                                   uint64_t& borrow_id_out);
 
 // Acquire a host pointer for **overwrite-only** access. Same lifecycle as
 // `rbln_v_borrow_host_ptr` (must be released via `rbln_v_return_borrowed`),


### PR DESCRIPTION
## Summary

Final PR in the LLaMA-1B eager-mode optimization stack. Lands the c10::rbln borrow API unification that mirrors the upstream rebel-compiler `BorrowVirtualAtHost` consolidation (PR 10617), and pins `rebel-compiler` to `0.10.4.dev53+g045b3ed0` (commit `045b3ed01c`).

This is PR 3 of 3 stacked PRs:
- **#46** Foundation — V4 shim + warm cache + borrow + native factory + cpu_fallback perf + cleanup refactors (rebel_runtime_decl, pybind raw-ptr helper, CPP_SHIM_OPS sub-sets, fast-path registry)
- **#47** View-on-device + fp16 quirks + align-fallback + BFS geometric-key cache + custom float tolerance
- **#48 (this PR)** c10::rbln borrow unify + constraint pin to rebel-compiler `045b3ed0`

## c10::rbln borrow API unification

Collapses `acquire_host_ptr_for_overwrite` into `borrow_host_ptr(..., for_overwrite)` to mirror the rebel-compiler PR 10617 unification of `VMemoryManager::BorrowVirtualAtHost` (single entry point, `no_sync_to_overwrite` flag). The underlying C-API still exposes both `rbln_v_borrow_host_ptr` and `rbln_v_acquire_host_ptr_for_overwrite` (the wrapper dispatches based on the flag), so all earlier borrow call sites continue to compile against the same `045b3ed0` wheel.

The vendored `rbln_runtime_api.h` header is sync'd to the public `045b3ed` source (cosmetic line-wrap only; no semantic change in the C-API).

## Constraint pin

```
- rebel-compiler==0.10.4.dev41+g8746e1bf.prod
+ rebel-compiler==0.10.4.dev53+g045b3ed0
```

The `045b3ed` commit on the rebel-compiler side contains the `BorrowVirtualAtHost` unification (PR 10617) the borrow refactor in #46 and the wrapper consolidation in this PR were sized against.

## Test status

- `test/rbln/` + `test/internal/` smoke (47 tests including the storage-offset suite from PR #47's tolerance commit): **47 pass, 1 skip, 0 fail**.

## Risk + revert plan

- The borrow unification (`refactor(borrow): unify c10::rbln borrow_host_ptr write-only path`) is a wrapper-level refactor; the underlying C-API is unchanged. Revert is local to `c10/rbln/RBLNFunctions.{h,cpp}` and the call sites in `RBLNCPUFallback.cpp`.
- The constraint pin moves to a `dev` wheel; if `0.10.4.dev53+g045b3ed0` ever has to roll back, the previous pin `0.10.4.dev41+g8746e1bf.prod` is the safe target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)