### PR TITLE
fix(test): add to empty_cache before run unit-test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -370,5 +370,6 @@ markers = [
     "test_set_experimental: [test set] marks tests for experimental features (deselect with `-m \"not test_set_experimental\"`)",
     "test_set_perf: [test set] marks performance tests (select with `-m test_set_perf`)",
     "no_dynamo_reset: skips autouse TorchDynamo reset fixture",
+    "no_caching_allocator_reset: skips autouse RBLN caching-allocator reset fixture",
     "single_worker: marks tests that must run on a single worker (select with `-m single_worker`)",
 ]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,8 +3,8 @@ import os
 import pytest
 import torch
 
+import torch_rbln
 from test.utils import set_deterministic_seeds
-
 from torch_rbln._internal.log_utils import rbln_log_debug
 
 
@@ -30,6 +30,37 @@ def reset_dynamo(request):
 
     rbln_log_debug("Resetting TorchDynamo")
     torch._dynamo.reset()
+
+
+# =============================================================================
+# RBLN caching-allocator reset fixture (autouse)
+# =============================================================================
+@pytest.fixture(scope="function", autouse=True)
+def reset_caching_allocator(request):
+    """Release the RBLN caching allocator's cached blocks before each test.
+
+    Without this, freed small blocks from prior tests accumulate in the
+    caching allocator and fragment the pool, so later tests can fail to
+    allocate large contiguous blocks. Mirrors the TorchDynamo reset above;
+    opt out per-test with the ``no_caching_allocator_reset`` marker.
+    """
+    if request.node.get_closest_marker("no_caching_allocator_reset"):
+        rbln_log_debug("Skipping RBLN caching allocator reset")
+        return
+
+    try:
+        num_devices = torch_rbln.device.device_count()
+    except Exception as exc:
+        rbln_log_debug(f"device_count() failed; skipping caching allocator reset: {exc}")
+        return
+
+    for idx in range(num_devices):
+        device = torch.device("rbln", idx)
+        rbln_log_debug(f"Releasing RBLN caching allocator blocks on {device}")
+        try:
+            torch_rbln.memory.empty_cache(device)
+        except Exception as exc:
+            rbln_log_debug(f"empty_cache({device}) failed: {exc}")
 
 
 # =============================================================================


### PR DESCRIPTION
 ## Summary of Changes

  Adds an autouse pytest fixture (`reset_caching_allocator` in `test/conftest.py`) that calls
  `torch_rbln.memory.empty_cache(...)` for every visible RBLN device before each test, mirroring the existing
  `reset_dynamo` fixture. Without this, freed small blocks from prior tests accumulate in the caching allocator
  and fragment the pool, causing later tests (notably the model suite on `dev`) to fail when allocating large
  contiguous blocks.

  Provides a per-test opt-out via the `no_caching_allocator_reset` marker (registered in `pyproject.toml`) for
  any test that needs the allocator state preserved across the autouse boundary.

  ---

  ## Related Issues / Tickets

  * Resolves #<!-- issue number -->

  ---

  ## Type of Change

  - [x] `fix` — Bug fix

  ---

  ## Affected Modules

  - [x] Build/Tools

  ---

  ## How to Test

  1. Run any subset of the suite under DEBUG logging to see the reset fire once per test, for every visible
  device:
     ```bash
     TORCH_RBLN_LOG_LEVEL=DEBUG pytest test/rbln/test_rbln_apis.py -q
     ```
     Expected: `Releasing RBLN caching allocator blocks on rbln:{0..N-1}` is logged before each test.

  2. Re-run the previously-failing model suite on `dev`:
     ```bash
     python test/run_tests.py --suite=models
     ```
     Expected: previously-failing tests pass (no fragmentation-induced large-block OOM).

  3. Opt-out path: any test decorated with `@pytest.mark.no_caching_allocator_reset` skips the reset, with a
  `Skipping RBLN caching allocator reset` debug log.

  ---

  ## Checklist

  * [x] PR title follows Conventional Commits format
  * [ ] This PR is linked to a corresponding issue
  * [x] Linting passes
  * [ ] All CI tests pass
  * [x] The test method is described, and the expected result is clearly stated