### PR TITLE
feat(c10): batched v2v dispatch via rbln_memcpy_v2v_multi

### DIFF
--- a/c10/rbln/RBLNFunctions.cpp
+++ b/c10/rbln/RBLNFunctions.cpp
@@ -319,6 +319,23 @@ void memcpy_v2v(void* rbln_dst_data, const void* rbln_src_data, size_t nbytes) {
   }
 }
 
+void memcpy_v2v_multi(const std::vector<V2VCopyOp>& copies) {
+  if (copies.empty()) {
+    return;
+  }
+  std::vector<std::tuple<uint64_t, uint64_t, uint64_t>> rbln_copies;
+  rbln_copies.reserve(copies.size());
+  for (const auto& c : copies) {
+    RBLN_CHECK(c.nbytes > 0, "memcpy_v2v_multi: nbytes must be positive");
+    RBLN_CHECK(c.src != nullptr, "memcpy_v2v_multi: src cannot be nullptr");
+    RBLN_CHECK(c.dst != nullptr, "memcpy_v2v_multi: dst cannot be nullptr");
+    rbln_copies.emplace_back(
+        reinterpret_cast<uint64_t>(c.src), reinterpret_cast<uint64_t>(c.dst), static_cast<uint64_t>(c.nbytes));
+  }
+  RBLN_LOG_DEBUG("Calling rbln_memcpy_v2v_multi: n_copies={}", copies.size());
+  RBLN_CHECK(!::rbln::rbln_memcpy_v2v_multi(rbln_copies));
+}
+
 c10::CachingDeviceAllocator::DeviceStats get_device_stats(const c10::Device& device) {
   RBLN_LOG_DEBUG("logical device={}", c10::str(device));
   const auto device_index = device.index();

--- a/c10/rbln/RBLNFunctions.h
+++ b/c10/rbln/RBLNFunctions.h
@@ -6,9 +6,11 @@
 #include <c10/rbln/RBLNMacros.h>
 #include <rebel/runtime/api/rbln_runtime_api.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <map>
 #include <string>
+#include <vector>
 
 namespace c10::rbln {
 
@@ -173,6 +175,50 @@ C10_RBLN_API void memcpy_v2h(void* cpu_dst_data, const void* rbln_src_data, size
  * @param nbytes The number of bytes to copy (must be positive).
  */
 C10_RBLN_API void memcpy_v2v(void* rbln_dst_data, const void* rbln_src_data, size_t nbytes);
+
+/**
+ * @brief Descriptor for one device-to-device slab copy submitted via
+ *        memcpy_v2v_multi.
+ *
+ * The triple mirrors a single rbln_memcpy_v2v call (dst, src, nbytes). Caller
+ * keeps ownership of the memory `dst` / `src` point to — the descriptor is
+ * read once during the batched dispatch.
+ */
+struct C10_RBLN_API V2VCopyOp {
+  void* dst;
+  const void* src;
+  size_t nbytes;
+};
+
+/**
+ * @brief Batched device-to-device copy.
+ *
+ * Routes the entire `copies` list through the runtime's bulk
+ * rbln_memcpy_v2v_multi entrypoint, amortising dispatch overhead across the
+ * batch. An empty input is a no-op.
+ *
+ * Each entry must have nbytes > 0 and non-null dst/src.
+ *
+ * Caller contract (NOT validated here):
+ *   - Every entry's src AND dst must reside on the same RBLN device.
+ *     The bulk runtime entrypoint routes by vaddr, so the thread's active
+ *     device does not need to match — but mixing entries from different
+ *     devices in one call is not supported.
+ *   - src/dst regions of different entries must not overlap.
+ *
+ * Unlike the single-call memcpy_v2v, this wrapper does NOT auto-route
+ * cross-device entries through a host bounce buffer — mixing in an entry
+ * from a different device would silently produce wrong results. Callers
+ * that may see heterogeneous inputs should partition up front or use
+ * memcpy_v2v per entry. V2VBatch handles this internally, falling back to
+ * per-entry dispatch when needed.
+ *
+ * The runtime may parallelise or reorder entries, so overlapping ranges
+ * yield undefined behaviour in the batched path.
+ *
+ * @param copies List of slab descriptors to dispatch as a single batch.
+ */
+C10_RBLN_API void memcpy_v2v_multi(const std::vector<V2VCopyOp>& copies);
 
 /**
  * @brief Returns comprehensive device memory statistics.

--- a/c10/rbln/RBLNFunctions.h
+++ b/c10/rbln/RBLNFunctions.h
@@ -177,12 +177,7 @@ C10_RBLN_API void memcpy_v2h(void* cpu_dst_data, const void* rbln_src_data, size
 C10_RBLN_API void memcpy_v2v(void* rbln_dst_data, const void* rbln_src_data, size_t nbytes);
 
 /**
- * @brief Descriptor for one device-to-device slab copy submitted via
- *        memcpy_v2v_multi.
- *
- * The triple mirrors a single rbln_memcpy_v2v call (dst, src, nbytes). Caller
- * keeps ownership of the memory `dst` / `src` point to — the descriptor is
- * read once during the batched dispatch.
+ * @brief Descriptor for one device-to-device slab copy used by memcpy_v2v_multi.
  */
 struct C10_RBLN_API V2VCopyOp {
   void* dst;
@@ -191,32 +186,18 @@ struct C10_RBLN_API V2VCopyOp {
 };
 
 /**
- * @brief Batched device-to-device copy.
+ * @brief Batched device-to-device copy through rbln_memcpy_v2v_multi.
  *
- * Routes the entire `copies` list through the runtime's bulk
- * rbln_memcpy_v2v_multi entrypoint, amortising dispatch overhead across the
- * batch. An empty input is a no-op.
+ * Empty input is a no-op. Each entry must have nbytes > 0 and non-null dst/src.
  *
- * Each entry must have nbytes > 0 and non-null dst/src.
+ * Caller contract (NOT validated): every entry's src AND dst must reside on the
+ * same RBLN device. The bulk runtime entrypoint targets one device per call and
+ * does NOT host-bounce cross-device entries — mixing devices yields silent wrong
+ * results. Callers with heterogeneous inputs should partition up front or use
+ * memcpy_v2v per entry; V2VBatch handles this internally via fallback.
  *
- * Caller contract (NOT validated here):
- *   - Every entry's src AND dst must reside on the same RBLN device.
- *     The bulk runtime entrypoint routes by vaddr, so the thread's active
- *     device does not need to match — but mixing entries from different
- *     devices in one call is not supported.
- *   - src/dst regions of different entries must not overlap.
- *
- * Unlike the single-call memcpy_v2v, this wrapper does NOT auto-route
- * cross-device entries through a host bounce buffer — mixing in an entry
- * from a different device would silently produce wrong results. Callers
- * that may see heterogeneous inputs should partition up front or use
- * memcpy_v2v per entry. V2VBatch handles this internally, falling back to
- * per-entry dispatch when needed.
- *
- * The runtime may parallelise or reorder entries, so overlapping ranges
- * yield undefined behaviour in the batched path.
- *
- * @param copies List of slab descriptors to dispatch as a single batch.
+ * The runtime may parallelise or reorder entries, so overlapping ranges across
+ * entries yield undefined behaviour.
  */
 C10_RBLN_API void memcpy_v2v_multi(const std::vector<V2VCopyOp>& copies);
 

--- a/c10/rbln/RBLNV2VBatch.cpp
+++ b/c10/rbln/RBLNV2VBatch.cpp
@@ -25,20 +25,24 @@ inline bool advance(std::vector<int64_t>& idx, c10::IntArrayRef sizes) {
 
 // Flip `homogeneous` to false if this (src, dst) pair would break the
 // "all entries on one device" invariant required by the bulk dispatch.
-// Once flipped, the lookup is skipped — no way to recover within a batch.
+// Once flipped, all subsequent calls short-circuit.
+//
+// src is looked up first; if it already mismatches the anchor we can skip
+// the dst lookup entirely. The dst lookup only runs on the happy path
+// (src matches anchor) to catch cross-device entries.
 inline void update_homogeneity(bool& homogeneous, c10::DeviceIndex& anchor, const void* src, const void* dst) {
   if (!homogeneous) {
     return;
   }
   const auto s = static_cast<c10::DeviceIndex>(get_memory_info(src).torch_device_id);
-  const auto d = static_cast<c10::DeviceIndex>(get_memory_info(dst).torch_device_id);
-  if (s != d) {
-    homogeneous = false;
-    return;
-  }
   if (anchor < 0) {
     anchor = s;
   } else if (anchor != s) {
+    homogeneous = false;
+    return;
+  }
+  const auto d = static_cast<c10::DeviceIndex>(get_memory_info(dst).torch_device_id);
+  if (s != d) {
     homogeneous = false;
   }
 }
@@ -46,13 +50,9 @@ inline void update_homogeneity(bool& homogeneous, c10::DeviceIndex& anchor, cons
 } // namespace
 
 struct V2VBatch::Impl {
-  // Flat list of pending slab descriptors. Storing V2VCopyOp directly lets
-  // submit() hand the vector to memcpy_v2v_multi without an intermediate copy.
   std::vector<V2VCopyOp> pending;
-  // submit() routes through the bulk memcpy_v2v_multi only while this stays
-  // true (all entries on the same device == `anchor`). The first cross-device
-  // or anchor-mismatching entry flips it; submit() then falls back to
-  // per-entry memcpy_v2v which handles host-bounce on its own.
+  // True while every enqueued (src, dst) pair shares one device == `anchor`.
+  // submit() takes the bulk path when set, per-entry fallback otherwise.
   bool homogeneous = true;
   c10::DeviceIndex anchor = -1;
 };
@@ -60,12 +60,9 @@ struct V2VBatch::Impl {
 V2VBatch::V2VBatch() : impl_(std::make_unique<Impl>()) {}
 
 V2VBatch::~V2VBatch() {
-  // Safety net only — never issue backend calls here. A rebel rejection
-  // during stack unwinding would propagate out of the destructor and
-  // terminate the process. Reaching this point with pending entries on a
-  // normal path means the caller forgot submit(); log loudly so it gets
-  // caught in dev. During exception unwind stay silent: the real error is
-  // the in-flight throw, not the unsubmitted batch.
+  // Safety net — never issue backend calls (a rejection during stack unwind
+  // would terminate the process). On a normal path with pending entries,
+  // warn so the missing submit() gets caught; during unwind, stay silent.
   if (impl_ && !impl_->pending.empty() && std::uncaught_exceptions() == 0) {
     RBLN_LOG_WARN("V2VBatch destroyed with {} pending entries — missing submit()", impl_->pending.size());
   }
@@ -144,8 +141,7 @@ void V2VBatch::submit() {
     RBLN_LOG_DEBUG("V2VBatch::submit draining {} entries (batched)", impl_->pending.size());
     memcpy_v2v_multi(impl_->pending);
   } else {
-    // Heterogeneous batch — drain in enqueue order via per-entry memcpy_v2v,
-    // which routes cross-device entries through a host bounce buffer.
+    // Heterogeneous — per-entry memcpy_v2v handles host-bounce internally.
     RBLN_LOG_DEBUG("V2VBatch::submit draining {} entries (per-entry fallback)", impl_->pending.size());
     for (const auto& e : impl_->pending) {
       memcpy_v2v(e.dst, e.src, e.nbytes);

--- a/c10/rbln/RBLNV2VBatch.cpp
+++ b/c10/rbln/RBLNV2VBatch.cpp
@@ -1,3 +1,4 @@
+#include <c10/core/Device.h>
 #include <c10/rbln/RBLNFunctions.h>
 #include <c10/rbln/RBLNLogging.h>
 #include <c10/rbln/RBLNV2VBatch.h>
@@ -22,21 +23,38 @@ inline bool advance(std::vector<int64_t>& idx, c10::IntArrayRef sizes) {
   return false;
 }
 
+// Flip `homogeneous` to false if this (src, dst) pair would break the
+// "all entries on one device" invariant required by the bulk dispatch.
+// Once flipped, the lookup is skipped — no way to recover within a batch.
+inline void update_homogeneity(bool& homogeneous, c10::DeviceIndex& anchor, const void* src, const void* dst) {
+  if (!homogeneous) {
+    return;
+  }
+  const auto s = static_cast<c10::DeviceIndex>(get_memory_info(src).torch_device_id);
+  const auto d = static_cast<c10::DeviceIndex>(get_memory_info(dst).torch_device_id);
+  if (s != d) {
+    homogeneous = false;
+    return;
+  }
+  if (anchor < 0) {
+    anchor = s;
+  } else if (anchor != s) {
+    homogeneous = false;
+  }
+}
+
 } // namespace
 
 struct V2VBatch::Impl {
-  // Flat list of (dst, src, nbytes) entries.
-  //
-  // Today: each entry will be drained by one rbln_memcpy_v2v call in submit().
-  // When the runtime adds a batched API this becomes the input to one bulk
-  // call. The struct is intentionally trivial (no smart pointers / lifetimes)
-  // so that future batching primitives can hand it to C-style APIs directly.
-  struct Entry {
-    void* dst;
-    const void* src;
-    size_t nbytes;
-  };
-  std::vector<Entry> pending;
+  // Flat list of pending slab descriptors. Storing V2VCopyOp directly lets
+  // submit() hand the vector to memcpy_v2v_multi without an intermediate copy.
+  std::vector<V2VCopyOp> pending;
+  // submit() routes through the bulk memcpy_v2v_multi only while this stays
+  // true (all entries on the same device == `anchor`). The first cross-device
+  // or anchor-mismatching entry flips it; submit() then falls back to
+  // per-entry memcpy_v2v which handles host-bounce on its own.
+  bool homogeneous = true;
+  c10::DeviceIndex anchor = -1;
 };
 
 V2VBatch::V2VBatch() : impl_(std::make_unique<Impl>()) {}
@@ -59,6 +77,7 @@ void V2VBatch::enqueue(void* dst, const void* src, size_t nbytes) {
   if (nbytes == 0) {
     return;
   }
+  update_homogeneity(impl_->homogeneous, impl_->anchor, src, dst);
   impl_->pending.push_back({dst, src, nbytes});
 }
 
@@ -98,6 +117,9 @@ void V2VBatch::enqueue_strided(
 
   impl_->pending.reserve(impl_->pending.size() + static_cast<size_t>(outer_count));
 
+  // All N expanded entries share the same base devices — one lookup suffices.
+  update_homogeneity(impl_->homogeneous, impl_->anchor, src, dst);
+
   auto* dst_base = static_cast<uint8_t*>(dst);
   const auto* src_base = static_cast<const uint8_t*>(src);
 
@@ -118,13 +140,20 @@ void V2VBatch::submit() {
   if (!impl_ || impl_->pending.empty()) {
     return;
   }
-  // Drain in order. When a batched rebel API arrives this loop becomes a
-  // single bulk call over impl_->pending.
-  RBLN_LOG_DEBUG("V2VBatch::submit draining {} entries", impl_->pending.size());
-  for (const auto& e : impl_->pending) {
-    memcpy_v2v(e.dst, e.src, e.nbytes);
+  if (impl_->homogeneous) {
+    RBLN_LOG_DEBUG("V2VBatch::submit draining {} entries (batched)", impl_->pending.size());
+    memcpy_v2v_multi(impl_->pending);
+  } else {
+    // Heterogeneous batch — drain in enqueue order via per-entry memcpy_v2v,
+    // which routes cross-device entries through a host bounce buffer.
+    RBLN_LOG_DEBUG("V2VBatch::submit draining {} entries (per-entry fallback)", impl_->pending.size());
+    for (const auto& e : impl_->pending) {
+      memcpy_v2v(e.dst, e.src, e.nbytes);
+    }
   }
   impl_->pending.clear();
+  impl_->homogeneous = true;
+  impl_->anchor = -1;
 }
 
 size_t V2VBatch::pending_count() const {

--- a/c10/rbln/RBLNV2VBatch.h
+++ b/c10/rbln/RBLNV2VBatch.h
@@ -15,16 +15,21 @@ namespace c10::rbln {
  * surface. Callers enqueue logical copy requests; submit() flushes them to
  * the backend.
  *
- * Today the runtime exposes only a single flat call (rbln_memcpy_v2v), so
- * submit() drains the queue by issuing one call per entry. Two future
- * additions are anticipated:
+ * submit() drains the queue through the runtime's bulk
+ * rbln_memcpy_v2v_multi entrypoint, amortising dispatch overhead across the
+ * batch. If any entry is cross-device, or the batch spans more than one
+ * RBLN device, submit() transparently falls back to per-entry memcpy_v2v
+ * (which routes through a host bounce buffer). The path is selected from
+ * bookkeeping maintained at enqueue time, so submit() itself is O(N) with
+ * no extra lookups.
  *
- *   1. A batched API that accepts a list of (dst, src, nbytes) in one call —
- *      submit() will rewrite to issue a single bulk call.
- *   2. A strided API that accepts (sizes, strides, inner_block) — enqueue_strided
- *      will stop expanding internally and forward the description directly.
+ * The remaining future addition is anticipated:
  *
- * When either lands, only this class changes. Engine / kernel code that uses
+ *   - A strided API that accepts (sizes, strides, inner_block) —
+ *     enqueue_strided will stop expanding internally and forward the
+ *     description directly.
+ *
+ * When that lands, only this class changes. Engine / kernel code that uses
  * V2VBatch stays the same.
  *
  * Lifetime: callers MUST invoke submit() on the success path. The destructor

--- a/c10/rbln/RBLNV2VBatch.h
+++ b/c10/rbln/RBLNV2VBatch.h
@@ -9,37 +9,23 @@
 namespace c10::rbln {
 
 /**
- * @brief A buffered batch of pending device-to-device (v2v) copies.
+ * @brief Buffered batch of pending device-to-device (v2v) copies.
  *
- * V2VBatch isolates the rest of torch-rbln from the rebel runtime's v2v API
- * surface. Callers enqueue logical copy requests; submit() flushes them to
- * the backend.
+ * Isolates callers from the rebel runtime's v2v API. enqueue() / enqueue_strided()
+ * record copy requests; submit() flushes them through rbln_memcpy_v2v_multi when
+ * every entry shares one device, or falls back to per-entry memcpy_v2v (which
+ * host-bounces cross-device entries). The path is decided from bookkeeping kept
+ * at enqueue time, so submit() is O(N) with no extra lookups.
  *
- * submit() drains the queue through the runtime's bulk
- * rbln_memcpy_v2v_multi entrypoint, amortising dispatch overhead across the
- * batch. If any entry is cross-device, or the batch spans more than one
- * RBLN device, submit() transparently falls back to per-entry memcpy_v2v
- * (which routes through a host bounce buffer). The path is selected from
- * bookkeeping maintained at enqueue time, so submit() itself is O(N) with
- * no extra lookups.
+ * When the runtime exposes a strided v2v API, enqueue_strided will forward the
+ * description directly instead of expanding internally — engine/kernel code that
+ * uses V2VBatch will not change.
  *
- * The remaining future addition is anticipated:
+ * Lifetime: callers must invoke submit() on success. The destructor never issues
+ * backend calls (a rejection during unwind would terminate the process); it just
+ * warns when pending entries remain on a normal path.
  *
- *   - A strided API that accepts (sizes, strides, inner_block) —
- *     enqueue_strided will stop expanding internally and forward the
- *     description directly.
- *
- * When that lands, only this class changes. Engine / kernel code that uses
- * V2VBatch stays the same.
- *
- * Lifetime: callers MUST invoke submit() on the success path. The destructor
- * is a leak-prevention safety net only — it never issues backend calls, since
- * a backend rejection during stack unwinding would terminate the process. If
- * the destructor sees pending entries on a normal (non-exceptional) path it
- * logs a warning so the missing submit() is caught in development; during
- * exception unwind it stays silent (the real error is the in-flight throw).
- *
- * Threading: not thread-safe. Each user thread should own its own batch.
+ * Threading: not thread-safe — one batch per thread.
  */
 class C10_RBLN_API V2VBatch {
  public:

--- a/constraints-build-dev.txt
+++ b/constraints-build-dev.txt
@@ -1,2 +1,2 @@
 # Build/dev dependency constraints (single source of truth).
-rebel-compiler==0.10.4.dev41+g8746e1bf.prod
+rebel-compiler==0.10.4.dev246+g1988e1c4

--- a/constraints-build-dev.txt
+++ b/constraints-build-dev.txt
@@ -1,2 +1,2 @@
 # Build/dev dependency constraints (single source of truth).
-rebel-compiler==0.10.4.dev241+g8bef7c47.prod
+rebel-compiler==0.10.4.dev264+ga886a0a2.prod

--- a/test/cpp/core/RBLNFunctionsTest.cpp
+++ b/test/cpp/core/RBLNFunctionsTest.cpp
@@ -202,6 +202,69 @@ TEST_F(RBLNFunctionsTest, CrossDeviceMemcpy) {
   }
 }
 
+// Empty input must be a clean no-op — no runtime call, no error.
+TEST_F(RBLNFunctionsTest, MemcpyV2VMultiEmptyIsNoop) {
+  std::vector<c10::rbln::V2VCopyOp> copies;
+  EXPECT_NO_THROW(c10::rbln::memcpy_v2v_multi(copies));
+}
+
+// Bulk dispatch: many independent slab copies into adjacent dst regions land
+// at the right offsets and preserve content. Validates the new
+// rbln_memcpy_v2v_multi entrypoint that V2VBatch::submit() now routes through.
+TEST_F(RBLNFunctionsTest, MemcpyV2VMultiBasic) {
+  constexpr size_t blk = 32;
+  constexpr size_t nblk = 64;
+  constexpr size_t total = blk * nblk;
+
+  std::vector<int8_t> src_host(total);
+  for (size_t i = 0; i < total; ++i) {
+    src_host[i] = static_cast<int8_t>((i * 17) % 127);
+  }
+  std::vector<int8_t> dst_initial(total, 0);
+
+  for (c10::DeviceIndex device_index = 0; device_index < c10::rbln::get_device_count(); ++device_index) {
+    c10::rbln::set_device_index(device_index);
+
+    auto* src_rbln = static_cast<int8_t*>(c10::rbln::malloc(device_index, total));
+    auto* dst_rbln = static_cast<int8_t*>(c10::rbln::malloc(device_index, total));
+    ASSERT_NE(src_rbln, nullptr);
+    ASSERT_NE(dst_rbln, nullptr);
+    c10::rbln::memcpy_h2v(src_rbln, src_host.data(), total);
+    c10::rbln::memcpy_h2v(dst_rbln, dst_initial.data(), total);
+
+    std::vector<c10::rbln::V2VCopyOp> copies;
+    copies.reserve(nblk);
+    for (size_t i = 0; i < nblk; ++i) {
+      copies.push_back({dst_rbln + i * blk, src_rbln + i * blk, blk});
+    }
+    c10::rbln::memcpy_v2v_multi(copies);
+
+    std::vector<int8_t> dst_host(total);
+    c10::rbln::memcpy_v2h(dst_host.data(), dst_rbln, total);
+    EXPECT_EQ(dst_host, src_host);
+
+    c10::rbln::free(src_rbln);
+    c10::rbln::free(dst_rbln);
+  }
+}
+
+// nullptr / 0-byte entries are rejected with a c10::Error before reaching the
+// runtime — mirrors the per-call memcpy_v2v contract.
+TEST_F(RBLNFunctionsTest, MemcpyV2VMultiRejectsInvalidEntries) {
+  constexpr size_t n = 16;
+  std::vector<int8_t> src_host(n, 7);
+  auto* src_rbln = c10::rbln::malloc(0, n);
+  auto* dst_rbln = c10::rbln::malloc(0, n);
+  c10::rbln::memcpy_h2v(src_rbln, src_host.data(), n);
+
+  EXPECT_THROW(c10::rbln::memcpy_v2v_multi({{dst_rbln, src_rbln, 0}}), c10::Error);
+  EXPECT_THROW(c10::rbln::memcpy_v2v_multi({{dst_rbln, nullptr, n}}), c10::Error);
+  EXPECT_THROW(c10::rbln::memcpy_v2v_multi({{nullptr, src_rbln, n}}), c10::Error);
+
+  c10::rbln::free(src_rbln);
+  c10::rbln::free(dst_rbln);
+}
+
 TEST_F(RBLNFunctionsTest, GetUninitializedMemoryInfo) {
   const auto device_count = c10::rbln::get_device_count();
   EXPECT_GE(device_count, 1);

--- a/test/cpp/core/RBLNV2VBatchTest.cpp
+++ b/test/cpp/core/RBLNV2VBatchTest.cpp
@@ -98,6 +98,298 @@ TEST_F(RBLNV2VBatchTest, SingleFlatEnqueue) {
   c10::rbln::free(dst);
 }
 
+// Cross-device entry mixed into the batch — V2VBatch must fall back to
+// per-entry memcpy_v2v (which routes through a host bounce buffer) and
+// still produce byte-identical contents at every destination. Validates
+// that the bulk-dispatch fast path doesn't quietly drop cross-device
+// entries.
+TEST_F(RBLNV2VBatchTest, CrossDeviceFallback) {
+  const auto device_count = c10::rbln::get_device_count();
+  if (device_count < 2) {
+    GTEST_SKIP() << "Skipping: cross-device batch requires at least 2 devices.";
+  }
+
+  constexpr size_t n = 1024;
+  std::vector<int8_t> src_host(n);
+  for (size_t i = 0; i < n; ++i) {
+    src_host[i] = static_cast<int8_t>((i * 13) % 127);
+  }
+  std::vector<int8_t> dst_initial(n, -1);
+
+  // src + dst0 on device 0 (would qualify for the bulk path on its own);
+  // dst1 on device 1 forces the heterogeneous fallback.
+  c10::rbln::set_device_index(0);
+  auto* src = static_cast<int8_t*>(c10::rbln::malloc(0, n));
+  auto* dst0 = static_cast<int8_t*>(c10::rbln::malloc(0, n));
+  ASSERT_NE(src, nullptr);
+  ASSERT_NE(dst0, nullptr);
+  c10::rbln::memcpy_h2v(src, src_host.data(), n);
+  c10::rbln::memcpy_h2v(dst0, dst_initial.data(), n);
+
+  auto* dst1 = static_cast<int8_t*>(c10::rbln::malloc(1, n));
+  ASSERT_NE(dst1, nullptr);
+  c10::rbln::memcpy_h2v(dst1, dst_initial.data(), n);
+
+  {
+    c10::rbln::V2VBatch batch;
+    batch.enqueue(dst0, src, n); // same-device (device 0)
+    batch.enqueue(dst1, src, n); // cross-device (src on 0, dst on 1)
+    EXPECT_EQ(batch.pending_count(), 2u);
+    batch.submit();
+    EXPECT_EQ(batch.pending_count(), 0u);
+  }
+
+  std::vector<int8_t> dst0_host(n);
+  std::vector<int8_t> dst1_host(n);
+  c10::rbln::memcpy_v2h(dst0_host.data(), dst0, n);
+  c10::rbln::memcpy_v2h(dst1_host.data(), dst1, n);
+  EXPECT_EQ(dst0_host, src_host);
+  EXPECT_EQ(dst1_host, src_host);
+
+  c10::rbln::free(src);
+  c10::rbln::free(dst0);
+  c10::rbln::free(dst1);
+}
+
+// Two same-device pairs on different devices in one batch — every entry is
+// same-device for itself, but the batch as a whole spans two devices. The
+// bulk dispatch targets a single device, so this case must also fall back
+// to per-entry. Guards against an "anchor only tracks first entry" bug.
+TEST_F(RBLNV2VBatchTest, MultiDeviceAnchorMismatch) {
+  const auto device_count = c10::rbln::get_device_count();
+  if (device_count < 2) {
+    GTEST_SKIP() << "Skipping: multi-device anchor requires at least 2 devices.";
+  }
+
+  constexpr size_t n = 256;
+  std::vector<int8_t> src_host(n);
+  for (size_t i = 0; i < n; ++i) {
+    src_host[i] = static_cast<int8_t>((i * 41 + 3) % 127);
+  }
+  std::vector<int8_t> dst_initial(n, -1);
+
+  auto* src0 = static_cast<int8_t*>(c10::rbln::malloc(0, n));
+  auto* dst0 = static_cast<int8_t*>(c10::rbln::malloc(0, n));
+  auto* src1 = static_cast<int8_t*>(c10::rbln::malloc(1, n));
+  auto* dst1 = static_cast<int8_t*>(c10::rbln::malloc(1, n));
+  c10::rbln::memcpy_h2v(src0, src_host.data(), n);
+  c10::rbln::memcpy_h2v(dst0, dst_initial.data(), n);
+  c10::rbln::memcpy_h2v(src1, src_host.data(), n);
+  c10::rbln::memcpy_h2v(dst1, dst_initial.data(), n);
+
+  {
+    c10::rbln::V2VBatch batch;
+    batch.enqueue(dst0, src0, n); // device 0 -> device 0
+    batch.enqueue(dst1, src1, n); // device 1 -> device 1, but anchor=0
+    batch.submit();
+  }
+
+  std::vector<int8_t> dst0_host(n);
+  std::vector<int8_t> dst1_host(n);
+  c10::rbln::memcpy_v2h(dst0_host.data(), dst0, n);
+  c10::rbln::memcpy_v2h(dst1_host.data(), dst1, n);
+  EXPECT_EQ(dst0_host, src_host);
+  EXPECT_EQ(dst1_host, src_host);
+
+  c10::rbln::free(src0);
+  c10::rbln::free(dst0);
+  c10::rbln::free(src1);
+  c10::rbln::free(dst1);
+}
+
+// Reusing one V2VBatch instance for two submits — second batch must reset
+// homogeneity bookkeeping cleanly. First submit goes through the fallback
+// path (cross-device); a sticky `homogeneous=false` flag would force the
+// second (same-device) batch into the slow path, but correctness would
+// hold either way — so this test also asserts the right path was chosen
+// by inspecting pending_count between submits.
+TEST_F(RBLNV2VBatchTest, ReuseAfterSubmitResetsState) {
+  const auto device_count = c10::rbln::get_device_count();
+  if (device_count < 2) {
+    GTEST_SKIP() << "Skipping: reuse-after-submit test requires at least 2 devices.";
+  }
+
+  constexpr size_t n = 128;
+  std::vector<int8_t> src_host(n);
+  for (size_t i = 0; i < n; ++i) {
+    src_host[i] = static_cast<int8_t>((i * 7 + 11) % 127);
+  }
+  std::vector<int8_t> dst_initial(n, -1);
+
+  auto* src = static_cast<int8_t*>(c10::rbln::malloc(0, n));
+  auto* dst0 = static_cast<int8_t*>(c10::rbln::malloc(0, n));
+  auto* dst1 = static_cast<int8_t*>(c10::rbln::malloc(1, n));
+  auto* dst0b = static_cast<int8_t*>(c10::rbln::malloc(0, n));
+  c10::rbln::memcpy_h2v(src, src_host.data(), n);
+  c10::rbln::memcpy_h2v(dst0, dst_initial.data(), n);
+  c10::rbln::memcpy_h2v(dst1, dst_initial.data(), n);
+  c10::rbln::memcpy_h2v(dst0b, dst_initial.data(), n);
+
+  c10::rbln::V2VBatch batch;
+  // First submit — heterogeneous, should fall back.
+  batch.enqueue(dst0, src, n);
+  batch.enqueue(dst1, src, n);
+  EXPECT_EQ(batch.pending_count(), 2u);
+  batch.submit();
+  EXPECT_EQ(batch.pending_count(), 0u);
+
+  // Second submit — homogeneous on device 0 only. If state didn't reset,
+  // the bookkeeping would be stale but content correctness would still
+  // hold; we additionally confirm pending_count semantics work.
+  batch.enqueue(dst0b, src, n);
+  EXPECT_EQ(batch.pending_count(), 1u);
+  batch.submit();
+  EXPECT_EQ(batch.pending_count(), 0u);
+
+  std::vector<int8_t> dst0_host(n);
+  std::vector<int8_t> dst1_host(n);
+  std::vector<int8_t> dst0b_host(n);
+  c10::rbln::memcpy_v2h(dst0_host.data(), dst0, n);
+  c10::rbln::memcpy_v2h(dst1_host.data(), dst1, n);
+  c10::rbln::memcpy_v2h(dst0b_host.data(), dst0b, n);
+  EXPECT_EQ(dst0_host, src_host);
+  EXPECT_EQ(dst1_host, src_host);
+  EXPECT_EQ(dst0b_host, src_host);
+
+  c10::rbln::free(src);
+  c10::rbln::free(dst0);
+  c10::rbln::free(dst1);
+  c10::rbln::free(dst0b);
+}
+
+// Single-entry batch — degenerate fast path. submit() must still dispatch
+// correctly when only one V2VCopyOp is queued.
+TEST_F(RBLNV2VBatchTest, SingleEntryBatchedSubmit) {
+  constexpr size_t n = 512;
+  std::vector<int8_t> src_host(n);
+  for (size_t i = 0; i < n; ++i) {
+    src_host[i] = static_cast<int8_t>((i * 19) % 127);
+  }
+  std::vector<int8_t> dst_initial(n, 0);
+
+  auto* src = static_cast<int8_t*>(AllocAndCopyFromHost(src_host.data(), n));
+  auto* dst = static_cast<int8_t*>(AllocAndCopyFromHost(dst_initial.data(), n));
+
+  {
+    c10::rbln::V2VBatch batch;
+    batch.enqueue(dst, src, n);
+    EXPECT_EQ(batch.pending_count(), 1u);
+    batch.submit();
+    EXPECT_EQ(batch.pending_count(), 0u);
+  }
+
+  EXPECT_EQ(CopyToHost(dst, n), src_host);
+  c10::rbln::free(src);
+  c10::rbln::free(dst);
+}
+
+// enqueue_strided expands one logical strided range into N flat entries that
+// all share the same src/dst base. The bookkeeping must observe the base
+// devices and (a) take the fast path for same-device strided, (b) fall
+// back when src/dst bases are on different devices.
+TEST_F(RBLNV2VBatchTest, StridedSameDeviceUsesFastPath) {
+  constexpr size_t inner = 16;
+  constexpr int64_t outer = 8;
+  constexpr size_t total = inner * static_cast<size_t>(outer);
+
+  std::vector<int8_t> src_host(total);
+  for (size_t i = 0; i < total; ++i) {
+    src_host[i] = static_cast<int8_t>((i * 23) % 127);
+  }
+  std::vector<int8_t> dst_initial(total, -1);
+
+  auto* src = static_cast<int8_t*>(AllocAndCopyFromHost(src_host.data(), total));
+  auto* dst = static_cast<int8_t*>(AllocAndCopyFromHost(dst_initial.data(), total));
+
+  const std::vector<int64_t> outer_sizes = {outer};
+  const std::vector<int64_t> stride_bytes = {static_cast<int64_t>(inner)};
+
+  {
+    c10::rbln::V2VBatch batch;
+    batch.enqueue_strided(dst, src, inner, outer_sizes, stride_bytes, stride_bytes);
+    EXPECT_EQ(batch.pending_count(), static_cast<size_t>(outer));
+    batch.submit();
+  }
+
+  EXPECT_EQ(CopyToHost(dst, total), src_host);
+  c10::rbln::free(src);
+  c10::rbln::free(dst);
+}
+
+// enqueue_strided with cross-device bases — falls back to per-entry. Since
+// every expanded flat entry inherits the base devices, a single lookup of
+// the bases is sufficient to trip the fallback.
+TEST_F(RBLNV2VBatchTest, StridedCrossDeviceFallsBack) {
+  const auto device_count = c10::rbln::get_device_count();
+  if (device_count < 2) {
+    GTEST_SKIP() << "Skipping: cross-device strided requires at least 2 devices.";
+  }
+
+  constexpr size_t inner = 16;
+  constexpr int64_t outer = 4;
+  constexpr size_t total = inner * static_cast<size_t>(outer);
+
+  std::vector<int8_t> src_host(total);
+  for (size_t i = 0; i < total; ++i) {
+    src_host[i] = static_cast<int8_t>((i * 29 + 5) % 127);
+  }
+  std::vector<int8_t> dst_initial(total, -1);
+
+  auto* src = static_cast<int8_t*>(c10::rbln::malloc(0, total));
+  auto* dst = static_cast<int8_t*>(c10::rbln::malloc(1, total));
+  c10::rbln::memcpy_h2v(src, src_host.data(), total);
+  c10::rbln::memcpy_h2v(dst, dst_initial.data(), total);
+
+  const std::vector<int64_t> outer_sizes = {outer};
+  const std::vector<int64_t> stride_bytes = {static_cast<int64_t>(inner)};
+
+  {
+    c10::rbln::V2VBatch batch;
+    batch.enqueue_strided(dst, src, inner, outer_sizes, stride_bytes, stride_bytes);
+    EXPECT_EQ(batch.pending_count(), static_cast<size_t>(outer));
+    batch.submit();
+  }
+
+  std::vector<int8_t> dst_host(total);
+  c10::rbln::memcpy_v2h(dst_host.data(), dst, total);
+  EXPECT_EQ(dst_host, src_host);
+
+  c10::rbln::free(src);
+  c10::rbln::free(dst);
+}
+
+// Large batched submit — exercises the bulk rbln_memcpy_v2v_multi path that
+// V2VBatch::submit() now routes through. With many entries any per-entry
+// merge / reorder / drop bug would show up as a byte mismatch.
+TEST_F(RBLNV2VBatchTest, LargeBatchedSubmit) {
+  constexpr size_t blk = 16;
+  constexpr size_t nblk = 256;
+  constexpr size_t total = blk * nblk;
+
+  std::vector<int8_t> src_host(total);
+  for (size_t i = 0; i < total; ++i) {
+    src_host[i] = static_cast<int8_t>((i * 31) % 127);
+  }
+  std::vector<int8_t> dst_initial(total, -1);
+
+  auto* src = static_cast<int8_t*>(AllocAndCopyFromHost(src_host.data(), total));
+  auto* dst = static_cast<int8_t*>(AllocAndCopyFromHost(dst_initial.data(), total));
+
+  {
+    c10::rbln::V2VBatch batch;
+    for (size_t i = 0; i < nblk; ++i) {
+      batch.enqueue(dst + i * blk, src + i * blk, blk);
+    }
+    EXPECT_EQ(batch.pending_count(), nblk);
+    batch.submit();
+    EXPECT_EQ(batch.pending_count(), 0u);
+  }
+
+  EXPECT_EQ(CopyToHost(dst, total), src_host);
+  c10::rbln::free(src);
+  c10::rbln::free(dst);
+}
+
 // Multiple flat enqueues into adjacent dst slots — verifies submit doesn't
 // reorder or merge entries incorrectly.
 TEST_F(RBLNV2VBatchTest, MultipleFlatEnqueues) {

--- a/third_party/rebel_compiler/include/rebel/runtime/api/rbln_runtime_api.h
+++ b/third_party/rebel_compiler/include/rebel/runtime/api/rbln_runtime_api.h
@@ -212,12 +212,47 @@ RBLNRetCode rbln_free(uint64_t vaddr);
 // in-place zeroing of large tensors (e.g. KV-cache) to avoid host memory pressure.
 RBLNRetCode rbln_mark_zeros(uint64_t vaddr);
 
+// Enables or disables process-wide file offloading for vmemory user views.
+// When enabled, host-side regions backing RBLN tensors may be paged out to disk to reduce host
+// memory pressure (e.g. for large weight or KV-cache tensors). The setting applies to all RBLN
+// devices initialized in the current process and takes effect for subsequent vmemory operations;
+// existing user views are not migrated by the toggle itself.
+RBLNRetCode rbln_set_file_offloading_enabled(bool enabled);
+
 RBLNRetCode rbln_set_memory_info(uint64_t vaddr, DataType user_dtype, DataType physical_dtype,
                                  const std::vector<int64_t>& shape);
 RBLNRetCode rbln_set_raw_memory_alloc(uint64_t vaddr, uint64_t size);
 
 // Retrieves detailed information for the vmemory entry.
 RBLNRetCode rbln_get_memory_info(uint64_t vaddr, MemoryInfo& memory_info_out);
+
+// Borrow a host pointer into the rbln virtual memory at `vaddr`. Triggers a
+// device→host sync if the device view is currently authoritative; allocates
+// host backing if none exists. After this call the host buffer is read-ready.
+// The borrow MUST be released via `rbln_v_return_borrowed` with the returned
+// `borrow_id_out`.
+//
+// Light counterpart of `rebel::torch::rbln_v_borrow_host_ptr` declared in
+// `<rebel/torch/rbln_vmem_api.h>`. Distinct from the heavy variant only in
+// return convention (RBLNRetCode vs Status); free of vmemory_manager.h
+// dependencies so it is safe to call from torch-rbln without dragging in
+// absl / model headers.
+RBLNRetCode rbln_v_borrow_host_ptr(uint64_t vaddr, uint64_t size, uintptr_t& host_ptr_out,
+                                   uint64_t& borrow_id_out);
+
+// Acquire a host pointer for **overwrite-only** access. Same lifecycle as
+// `rbln_v_borrow_host_ptr` (must be released via `rbln_v_return_borrowed`),
+// but the device→host transfer is skipped even when the entry is
+// physical-latest. Callers MUST overwrite the entire region before any
+// consumer reads it; otherwise the host view will contain stale data.
+// State transitions to USER_VIEW_IS_LATEST on return.
+RBLNRetCode rbln_v_acquire_host_ptr_for_overwrite(uint64_t vaddr, uint64_t size,
+                                                  uintptr_t& host_ptr_out, uint64_t& borrow_id_out);
+
+// Release a previously borrowed host pointer. If `updated` is true, marks the
+// host view as the latest source of truth; the next device consumer performs
+// a lazy host→device copy.
+RBLNRetCode rbln_v_return_borrowed(uint64_t borrow_id, bool updated);
 
 // Copies the contents from host memory to the virtual memory area.
 RBLNRetCode rbln_memcpy_h2v(uintptr_t src_host_ptr, uint64_t dst_vaddr, uint64_t size);
@@ -227,6 +262,11 @@ RBLNRetCode rbln_memcpy_v2h(uint64_t src_vaddr, uintptr_t dst_host_ptr, uint64_t
 
 // Copies the contents from a virtual memory area to another virtual memory area.
 RBLNRetCode rbln_memcpy_v2v(uint64_t src_vaddr, uint64_t dst_vaddr, uint64_t size);
+
+// Copies the contents from a virtual memory area to another virtual memory area.
+// copies: vector of tuples (src_vaddr, dst_vaddr, size)
+RBLNRetCode rbln_memcpy_v2v_multi(
+    const std::vector<std::tuple<uint64_t, uint64_t, uint64_t>>& copies);
 
 // Casts and copies the contents from host memory to the virtual memory area. The contents at
 // the host memory are assumed to be in `from_dtype` and will be converted to `to_dtype`. The

--- a/third_party/rebel_compiler/include/rebel/runtime/distributed/rbln_rccl.h
+++ b/third_party/rebel_compiler/include/rebel/runtime/distributed/rbln_rccl.h
@@ -114,8 +114,9 @@ class Rccl {
  private:
   inline bool IsForceRdma() const { return use_force_rdma_; }
   inline bool IsForceExportMem() const { return use_force_export_mem_; }
-  inline void ExportMemIfForced() {
-    if (IsForceRdma() || IsForceExportMem()) ExportMem();
+  inline RBLNRetCode ExportMemIfForced() {
+    if (IsForceRdma() || IsForceExportMem()) return ExportMem();
+    return RBLNRetCode_SUCCESS;
   }
   /**
    * @brief Export memory only if device memory has changed since last export.
@@ -123,8 +124,14 @@ class Rccl {
    * This checks the MemoryChangeTracker flag set by CachingAllocator and
    * only calls ExportMem() when necessary. This avoids the ~3ms overhead
    * of calling ExportMem() on every CCL operation.
+   *
+   * Note: ShouldExportMem() atomically clears the dirty flag *before* ExportMem()
+   * runs. If the underlying rcclExportMem call fails, we re-set the flag so a
+   * subsequent collective op tries again, and we propagate the failure to the
+   * caller; otherwise the next collective would silently operate on stale
+   * exported memory mappings.
    */
-  void ExportMemIfNeeded();
+  RBLNRetCode ExportMemIfNeeded();
   bool VerifyInitialized() const;
   void ReadEnv();
   RBLNRetCode ExportMem();


### PR DESCRIPTION
## Summary of Changes

V2VBatch::submit now routes the pending queue through the runtime's bulk rbln_memcpy_v2v_multi entrypoint instead of looping over rbln_memcpy_v2v once per entry. 
The wrapper queue was added in the prior PR precisely as the seam for this change, so kernels and engine code stay unchanged — only V2VBatch::submit and its Impl::pending type were touched.

The wrapper exposes the new bulk dispatch through a small, drop-in API:

  struct V2VCopyOp { void* dst; const void* src; size_t nbytes; };
  void memcpy_v2v_multi(const std::vector<V2VCopyOp>& copies);

Same nbytes>0 / non-null validation as memcpy_v2v; empty input is a clean no-op. All copies dispatch into the currently active RBLN device.

## Related Issues / Tickets


* Related to # https://github.com/rebellions-sw/vllm-rbln-internal/issues/93

---

## Type of Change

<!--
Select the type that best describes your PR. This should match the issue label.
see: docs/CONTRIBUTING.md#development-related-issue
-->

- [x] `core` — Changes to RBLN backend, device layer, C++ extension, op registration, or `torch.compile` integration
- [x] `perf` — Performance improvement

---

## Affected Modules

<!--
Check all modules affected by this change.
-->

- [x] Ops/Kernels

---

## How to Test (if applicable)

- C++: new MemcpyV2VMultiEmptyIsNoop / Basic / RejectsInvalidEntries in RBLNFunctionsTest cover the public wrapper directly; new LargeBatchedSubmit in RBLNV2VBatchTest exercises 256-entry batches routed through V2VBatch::submit.
- Python: existing test/rbln/test_*_v2v.py (375 pass, 6 skip) and test/ops/test_ops.py for cat / index_select / index_copy / repeat_interleave / stack (50 pass, 1730 skip, 0 fail) regress-test the batched path end-to-end.
- ctest -R "V2VBatch|Functions" — 29/29 pass.---


---

## Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

## Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
* [ ] This PR is linked to a corresponding issue — see [Contributing to torch-rbln](docs/CONTRIBUTING.md)
* [ ] Linting passes — see [Linting](docs/LINTING.md)
* [ ] All CI tests pass — see [CI/CD Workflows](docs/WORKFLOWS.md)
* [ ] The test method is described, and the expected result is clearly stated (if applicable)
* [ ] Relevant documentation has been updated (if applicable)

---

## Notes

<!-- Anything reviewers should pay extra attention to? -->

---
