### PR TITLE
build: harden CMake configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,14 +12,13 @@ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
 endif()
 
 # Set C++ and C standard
-set(CMAKE_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
 
 # Generate compile_commands.json
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-
-set(CMAKE_LINK_WHAT_YOU_USE TRUE)
 
 # Set not to use link path for RPATH
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH OFF)
@@ -82,9 +81,27 @@ target_compile_definitions(${target} INTERFACE
 )
 target_compile_options(${target} INTERFACE
   ${TORCH_CXX_FLAGS}
-  -fdebug-prefix-map=${CMAKE_CURRENT_SOURCE_DIR}/=
-  -fdebug-prefix-map=${CMAKE_CURRENT_BINARY_DIR}/=
+  -ffile-prefix-map=${CMAKE_CURRENT_SOURCE_DIR}/=
+  -ffile-prefix-map=${CMAKE_CURRENT_BINARY_DIR}/=
+  -ffile-prefix-map=${CMAKE_INSTALL_PREFIX}/=
+  -ffile-prefix-map=${TORCH_INSTALL_PREFIX}/=torch/
 )
+# Hardening flags
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  target_compile_options(${target} INTERFACE
+    # _FORTIFY_SOURCE is a no-op without -O; gate on non-Debug to silence the warning.
+    $<$<NOT:$<CONFIG:Debug>>:-D_FORTIFY_SOURCE=2>
+    -fstack-protector-strong
+    -fstack-clash-protection
+  )
+  target_link_options(${target} INTERFACE
+    -Wl,-z,relro
+    -Wl,-z,now
+    -Wl,-z,noexecstack
+    # Scope to non-executables: tests need libtorch_rbln in NEEDED for static-init op registration.
+    $<$<NOT:$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>>:-Wl,--as-needed>
+  )
+endif()
 target_include_directories(${target} SYSTEM INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>

--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -35,9 +35,8 @@ target_link_libraries(${target} PUBLIC
 )
 set_target_properties(${target} PROPERTIES
   DEFINE_SYMBOL TORCH_RBLN_BUILD_MAIN_LIB
-)
-target_compile_options(${target} PRIVATE
-  -fvisibility=hidden
+  CXX_VISIBILITY_PRESET hidden
+  VISIBILITY_INLINES_HIDDEN ON
 )
 target_include_directories(${target} SYSTEM PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -107,10 +107,6 @@ class CMakeBuildHook(BuildHookInterface):
                 ]
             )
 
-        # Add custom CMake options from environment
-        if os.environ.get("TORCH_RBLN_DEPLOY") == "ON":
-            cmake_args.append("-DTORCH_RBLN_DEPLOY=ON")
-
         # Configure
         self._run_command(cmake_args, cwd=project_root)
 


### PR DESCRIPTION
## Summary of Changes

Hardens the CMake configuration so compiled artifacts no longer leak the build path, adopts the standard distribution hardening baseline, normalizes symbol visibility, enforces the C++17 / C11 standard floor, and removes two unused build settings.

Both gaps matter for an externally distributed wheel: the build path leaks through exception messages (`c10::Error` embeds `__FILE__`, so every `RuntimeError` exposes absolute paths), and the shipped shared libraries lack the hardening baseline.

Build-path normalization now covers the `__FILE__` macro, not just debug info, with an added mapping for PyTorch header paths so the leak does not shift into those headers. The C++17 / C11 standard floor is now actually enforced — the previous setting used an unrecognized variable name and was silently ignored. The two removed settings are `CMAKE_LINK_WHAT_YOU_USE`, redundant with the new `--as-needed`, and the `hatch_build.py` env-var forwarding, which had no consumer.

---

## Type of Change

- [x] `other` — Other (describe below)

Build configuration change only.

---

## Affected Modules

- [x] C++ extension (`torch_rbln/csrc`)
- [x] Build/Tools

---

## Checklist

* [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
* [x] Linting passes — see [Linting](docs/LINTING.md)
* [x] All CI tests pass — see [CI/CD Workflows](docs/WORKFLOWS.md)
* [x] Relevant documentation has been updated (if applicable)

---
