### PR TITLE
perf(native): replace cpu_fallback with native impls for fill_/arange/_local_scalar_dense/clone

### DIFF
--- a/aten/src/ATen/native/RBLNRegisterOps.cpp
+++ b/aten/src/ATen/native/RBLNRegisterOps.cpp
@@ -168,7 +168,7 @@ TORCH_LIBRARY_IMPL(aten, PrivateUse1, m) {
   m.impl("min.dim_min", torch::CppFunction::makeFromBoxedFunction<&fallback_rbln>());
   m.impl("flip", torch::CppFunction::makeFromBoxedFunction<&fallback_rbln>());
   m.impl("cumsum.out", torch::CppFunction::makeFromBoxedFunction<&fallback_rbln>());
-  m.impl("arange.start_out", torch::CppFunction::makeFromBoxedFunction<&fallback_rbln>());
+  m.impl("arange.start_out", TORCH_FN(at::native::rbln::arange_start_out_rbln));
 
   // Operations used in pytest (temporary CPU fallbacks)
   // These are registered to manage unsupported operations encountered during pytest runs.
@@ -178,8 +178,9 @@ TORCH_LIBRARY_IMPL(aten, PrivateUse1, m) {
   // Operations not supported on the RBLN device (CPU fallback)
   // Scalar and tensor manipulation
   m.impl("trunc.out", torch::CppFunction::makeFromBoxedFunction<&fallback_rbln>());
-  m.impl("_local_scalar_dense", torch::CppFunction::makeFromBoxedFunction<&fallback_rbln>());
-  m.impl("fill_.Scalar", torch::CppFunction::makeFromBoxedFunction<&fallback_rbln>());
+  m.impl("_local_scalar_dense", TORCH_FN(at::native::rbln::_local_scalar_dense_rbln));
+  m.impl("fill_.Scalar", TORCH_FN(at::native::rbln::fill_scalar_rbln_));
+  m.impl("clone", TORCH_FN(at::native::rbln::clone_rbln));
   m.impl("fill_.Tensor", torch::CppFunction::makeFromBoxedFunction<&fallback_rbln>());
   m.impl("equal", torch::CppFunction::makeFromBoxedFunction<&fallback_rbln>());
   m.impl("_efficientzerotensor", TORCH_FN(at::native::rbln::_efficientzerotensor_rbln));

--- a/aten/src/ATen/native/rbln/RBLNCPUFallback.cpp
+++ b/aten/src/ATen/native/rbln/RBLNCPUFallback.cpp
@@ -31,19 +31,12 @@
 namespace at::native::rbln {
 
 namespace {
-// Per-op schema cache: mirrors the DispatchShim SchemaCache idea. Same op handle
-// reuses the same FunctionSchema pointer for the process lifetime, so caching
-// the per-arg static flags avoids walking schema_args/alias_info every dispatch.
-//
-// LLaMA-1B eager hits cpu_fallback_rbln 10066 times across <10 distinct ops, so
-// the cache populates at startup and stays read-only. Keep the populate step
-// behind a unique_lock; readers take a shared_lock and are otherwise lock-free.
-// OptionalTensor covers schema args typed `Tensor?` (e.g. linear's `bias`).
-// At runtime such an IValue is either a Tensor or None — old code recognized
-// this via the IValue's `isTensor()` cascade. After moving to schema-typed
-// arg_kind dispatch we must classify Tensor? explicitly, otherwise the arg
-// stays on the stack as an RBLN tensor when CPU dispatch runs (mixed-device
-// kernel inputs blow up at the next dispatch hop).
+// Per-op schema cache: same op handle reuses one FunctionSchema pointer for the
+// process lifetime, so caching per-arg kinds + alias-write flags avoids walking
+// schema_args every dispatch (LLaMA-1B eager hits this 10066x across <10 ops).
+// Populate under unique_lock; readers take a shared_lock. OptionalTensor (`Tensor?`,
+// e.g. linear's bias) must be classified explicitly — else the arg stays on the
+// stack as an RBLN tensor under CPU dispatch and blows up at the next hop.
 enum class CpuFbArgKind : uint8_t {
   Other = 0,
   Tensor,
@@ -301,14 +294,8 @@ void cpu_fallback_rbln(
   // fallback (used for non-rbln tensors, contiguity-guard skips, etc.).
   std::vector<std::vector<uint64_t>> tensorlist_borrow_ids;
 
-  // Step 1: Convert all non-CPU tensor inputs into CPU tensors and put them
-  // on the stack at the correct indices.
-  //
-  // Per-op schema info (arg-position kinds + alias-write flags) is cached: same
-  // operator handle reuses the same FunctionSchema pointer for the process
-  // lifetime, so a switch on the cached kind replaces the per-call IValue type
-  // cascade. ~10 distinct ops in LLaMA-1B eager → first call populates, every
-  // call after is a hashmap shared-lock.
+  // Step 1: convert all non-CPU tensor inputs into CPU tensors and stage them on
+  // the stack at the correct indices, switching on the cached per-arg schema kind.
   const auto& schema_info = get_or_populate_schema_info(op.schema());
   const auto n_args = arguments.size();
   for (size_t idx = 0; idx < n_args; ++idx) {
@@ -369,36 +356,25 @@ void cpu_fallback_rbln(
   std::vector<at::Tensor> cpu_tensors(tensor_args.size());
 
   for (size_t i = 0; i < tensor_args.size(); ++i) {
-    // Skip the borrow fast path for write-alias outputs (`out=` tensors).
-    // Borrowed tensors are wrapped via at::from_blob and have a fixed-size
-    // host-mapped storage, so the CPU op's resize path (which fires for
-    // wrong-shape `out=`, broadcasting binary ops, etc.) silently no-ops
-    // and the op then writes broadcasted values into the unresized buffer.
-    // Routing write-alias slots through the legacy `to_cpu` path gives
-    // them fresh CPU storage that PyTorch core can resize freely.
+    // Skip the borrow fast path for write-alias outputs (`out=`): from_blob's
+    // fixed-size storage can't be resized, so the CPU op's resize path (wrong-shape
+    // out=, broadcasting, etc.) would silently no-op. The legacy `to_cpu` path
+    // gives them fresh CPU storage that core can resize freely.
     if (schema_info.is_write_alias[tensor_args_indices[i]]) {
       continue;
     }
     cpu_tensors[i] = borrow_rbln_as_cpu(tensor_args[i], borrow_ids[i]);
   }
-  // Fill any slots that weren't borrowed (write-alias, undefined, non-rbln,
-  // or contiguity guard) by routing them through the legacy batched copy.
-  // Pure `out=` slots — kwarg-only, write-alias, named exactly "out" — get
-  // fresh empty CPU storage instead of going through the batched D2H copy:
-  // the CPU kernel will overwrite the buffer immediately, so D2H'ing the
-  // device contents we're about to discard is wasted bandwidth.
-  //
-  // We deliberately stay narrow here (vs. all write-alias args). In-place
-  // ops like `add_(self, other)` have a write-alias `self` that is also an
-  // *input* the CPU kernel reads from; replacing it with empty storage
-  // would feed garbage to the kernel. Kwarg-only `out=` is the schema shape
-  // that's guaranteed pure output (the CPU op writes; never reads). Other
-  // output kwarg names (e.g. `max.dim_max`'s `max`/`max_values`) need
-  // per-schema audit before extending.
-  //
-  // Profiling on LLaMA-1B eager: this single change freed ~22% of
-  // cpu_fallback_rbln host time — mean.out / rsqrt.out / pow.out's `out=`
-  // was hitting the slow path 1122 times each.
+  // Fill slots that weren't borrowed (write-alias / undefined / non-rbln /
+  // contiguity guard) via the legacy batched copy. Pure `out=` slots (kwarg-only,
+  // write-alias, named "out") instead get fresh empty CPU storage: the kernel
+  // overwrites immediately, so D2H'ing the about-to-be-discarded contents is
+  // wasted bandwidth. Stay narrow — in-place ops like `add_(self, other)` have a
+  // write-alias `self` the kernel also *reads*, so empty storage would feed it
+  // garbage; only kwarg-only `out=` is guaranteed pure-output. Other output kwarg
+  // names (e.g. max.dim_max) need a per-schema audit first.
+  // (LLaMA-1B eager: freed ~22% of cpu_fallback_rbln host time — mean/rsqrt/pow.out
+  // hit the slow path 1122x each.)
   std::vector<at::Tensor> non_borrowed;
   std::vector<size_t> non_borrowed_indices;
   for (size_t i = 0; i < tensor_args.size(); ++i) {
@@ -407,18 +383,12 @@ void cpu_fallback_rbln(
     }
     const bool is_pure_out = schema_info.is_pure_out[tensor_args_indices[i]];
     if (is_pure_out && tensor_args[i].defined()) {
-      // Direct output borrow: wrap the rbln out= tensor's host backing as a
-      // CPU view. The CPU kernel writes straight into the rbln vmem region,
-      // skipping the writeback memcpy entirely. release_borrowed(updated=true)
-      // is issued automatically by the existing borrow-write path in Step 3.
-      //
-      // Safety conditions: contiguous + offset 0 + non-zero bytes + RBLN
-      // device. PyTorch out= callers pass a tensor whose shape matches the
-      // result; if the CPU kernel ever tries to resize_(), `from_blob`'s
-      // fixed-size mapping silently no-ops and we'd corrupt the next slot, so
-      // we keep the size/contig guards strict and fall back to fresh empty
-      // otherwise. offset 0 matches borrow_rbln_as_cpu: an interior vaddr is
-      // not offset-resolved by the runtime borrow.
+      // Direct output borrow: wrap the rbln out= host backing as a CPU view so
+      // the kernel writes straight into vmem (no writeback memcpy); Step 3 issues
+      // release_borrowed(updated=true). Guards: contiguous + offset 0 + nonzero
+      // bytes + RBLN device — from_blob's fixed-size mapping can't resize_(), and
+      // offset 0 matches borrow_rbln_as_cpu (interior vaddrs aren't offset-resolved
+      // by the runtime borrow). Anything else falls back to fresh empty.
       auto& rbln_out = tensor_args[i];
       const uint64_t nbytes = rbln_out.nbytes();
       // try_acquire (not acquire): the overwrite borrow can be rejected for the
@@ -457,28 +427,20 @@ void cpu_fallback_rbln(
     (*stack)[arguments_begin + idx] = c10::IValue(cpu_tensors[i]);
   }
 
-  // Step 2: Call the underlying CPU implementation of the operator.
+  // Step 2: call the underlying CPU implementation.
   //
-  // Before redispatching, consult :class:`CPUFastPathRegistry` — handlers
-  // registered under aten/src/ATen/native/rbln/fast_paths/*.cpp self-register
-  // a specialized host micro-kernel for a single op (e.g. rsqrt.out,
-  // pow.Tensor_Scalar_out with exp==2, mean.out reducing last dim). The
-  // handler runs its own dtype/contig/shape guard; on match it writes the
-  // result directly into the borrowed out-tensor buffer and replaces
-  // ``stack`` with the single return. On no-match it returns ``false`` and
-  // we fall through to the generic boxed dispatcher.
-  // If anything in Step 2 (dispatch) or Step 3 (write-back) throws — e.g.
-  // PyTorch raises "result type X can't be cast to Y" for a dtype-mismatched
-  // out=, or _copy_from_and_resize trips when the caller passes a wrong-device
-  // out= that survived to step 3 — the borrows acquired above must still be
-  // released. Otherwise the rbln vmem manager keeps the input/out vaddrs in
-  // the borrowed state, and the next free on that vaddr fails. Since
-  // c10::rbln::free throws from a c10::DataPtr deleter (called from
-  // ~TensorImpl, a noexcept context), that failure escalates to std::terminate.
-  // RAII guard releases every still-live borrow as `updated=false` on
-  // destruction; the normal step-4 release loop clears borrow_ids[*] to 0
-  // before this guard goes out of scope on the happy path, so the guard is a
-  // no-op when nothing threw.
+  // First consult CPUFastPathRegistry — fast_paths/*.cpp self-register host
+  // micro-kernels for single ops (rsqrt.out, pow.Tensor_Scalar_out exp==2,
+  // mean.out last-dim). On match the handler runs its own guards, writes into
+  // the borrowed out buffer, and replaces the stack; on no-match it returns
+  // false and we fall through to the boxed dispatcher.
+  //
+  // If Step 2/3 throws (e.g. dtype-mismatched or wrong-device out=), the borrows
+  // above must still be released — else the next free on a still-borrowed vaddr
+  // fails, and since c10::rbln::free throws from a ~TensorImpl (noexcept) deleter
+  // that escalates to std::terminate. The RAII guard releases any still-live
+  // borrow (updated=false) on destruction; Step 4 zeroes borrow_ids on the happy
+  // path, so the guard is then a no-op.
   struct BorrowReleaseGuard {
     std::vector<uint64_t>& borrow_ids;
     std::vector<std::vector<uint64_t>>& tensorlist_borrow_ids;
@@ -516,20 +478,13 @@ void cpu_fallback_rbln(
     op.redispatchBoxed(c10::DispatchKeySet(cpu_dispatch_key), stack);
   }
 
-  // Step 3: Mutable alias write-back.
-  // - Legacy path: the CPU op wrote into the fresh CPU tensor at cpu_tensors[i];
-  //   we copy that result back into the original rbln tensor.
-  // - Borrow path, in-place case (borrow_ids[i] != 0): the CPU op wrote
-  //   directly into the borrowed host pointer, which already aliases the rbln
-  //   tensor's host-backed vmem; we only need to mark the borrow as updated so
-  //   the next device consumer lazily syncs.
-  // - Borrow path, resized-empty case: the composite's functional wrapper
-  //   allocates an empty out (numel=0) and lets the CPU kernel resize+fill it.
-  //   borrow_rbln_as_cpu couldn't borrow a zero-size vaddr, so borrow_id is 0
-  //   and cpu_tensors[i] holds fresh CPU storage. We resize the original rbln
-  //   tensor to match, borrow its now-sized vmem, memcpy the CPU content, and
-  //   return the borrow as updated — replacing the eager H2D that
-  //   at::_copy_from_and_resize would do.
+  // Step 3: mutable-alias write-back.
+  // - Legacy: copy the fresh CPU result at cpu_tensors[i] back into the rbln out.
+  // - Borrow, in-place (borrow_id != 0): the kernel already wrote into the host
+  //   ptr aliasing rbln vmem; just mark the borrow updated for lazy device sync.
+  // - Borrow, resized-empty: a functional wrapper passed an empty out (numel=0)
+  //   that couldn't be borrowed, so resize the rbln out, borrow its now-sized
+  //   vmem, memcpy the CPU content, and return updated — replacing the eager H2D.
   std::vector<bool> borrow_write(tensor_args.size(), false);
   for (const auto i : c10::irange(tensor_args_indices.size())) {
     if (!schema_info.is_write_alias[tensor_args_indices[i]]) {
@@ -648,24 +603,15 @@ void cpu_fallback_rbln(
     }
   }
 
-  // Step 4: Convert any CPU output tensors back to the original input device.
-  // For mutable alias'd outputs, we also need to take special care
-  // to move the ORIGINAL input tensor back onto the stack, in place of
-  // the temporary CPU output tensor that we created.
+  // Step 4: convert CPU output tensors back to the original input device. For
+  // mutable-alias outputs, move the ORIGINAL input tensor back onto the stack in
+  // place of the temporary CPU output.
   //
   // Note [CPU Fallback Does Not Handle View Operators]
-  // Also note that we are incapable of handling immutable aliases properly.
-  // Why?
-  // Schemas with an immutable alias'd tensor outputs correspond to view operators.
-  // For example, the `view_as` schema from native_functions.yaml:
-  // `view_as(Tensor(a) self, Tensor other) -> Tensor(a)`
-  // We can't handle these ops properly, because view ops are supposed to return
-  // a NEW tensor that shares the SAME storage as the original tensor.
-  // However, the new tensor that we created cannot share the same storage,
-  // since it lives on CPU and the original tensor lives on a different device.
-  // Because of that, we warn if someone attempts to call the
-  // CPU fallback on a view operator (this is to maintain BC for view ops for XLA
-  // that fall back to CPU).
+  // Immutable-alias outputs (view ops, e.g. `view_as(Tensor(a) self, ...) ->
+  // Tensor(a)`) can't be handled: a view must return a tensor sharing the input's
+  // storage, but our CPU temporary lives on a different device. We warn instead
+  // (BC for XLA-style view ops that fall back to CPU).
   const auto& schema_returns = op.schema().returns();
   const auto& num_returns = schema_returns.size();
   auto returns = torch::jit::last(stack, num_returns);

--- a/aten/src/ATen/native/rbln/RBLNCopy.cpp
+++ b/aten/src/ATen/native/rbln/RBLNCopy.cpp
@@ -8,6 +8,8 @@
 #include <c10/rbln/RBLNFunctions.h>
 #include <c10/rbln/RBLNLogging.h>
 
+#include <cstddef>
+
 namespace at::native::rbln {
 
 namespace {
@@ -194,6 +196,63 @@ at::Tensor _copy_from_and_resize_rbln(const at::Tensor& src, const at::Tensor& d
   copy_impl_rbln(src, dst);
 
   return dst;
+}
+
+at::Tensor clone_rbln(const at::Tensor& self, std::optional<c10::MemoryFormat> memory_format) {
+  RBLN_SCOPE_GUARD();
+  // aten::clone's default is MemoryFormat::Preserve, which is a *directive*
+  // (allocate the output with whatever layout best preserves the source's
+  // observable strides), not a concrete storage layout you can hand to
+  // ``at::empty``. Mirror PyTorch's reference resolution before allocating:
+  //   * Preserve + dense contiguous source → Contiguous
+  //   * Preserve + channels_last source → ChannelsLast (2D/3D)
+  //   * Preserve + arbitrary strided view → empty_strided(self.sizes(),
+  //     self.strides()) so the output observes identical strides
+  // For anything else the user explicitly named (Contiguous, ChannelsLast,
+  // ChannelsLast3d) we pass it through to ``at::empty`` as before.
+  const auto mf_req = memory_format.value_or(c10::MemoryFormat::Preserve);
+  const size_t nbytes = static_cast<size_t>(self.numel()) * self.element_size();
+
+  // Direct-d2d eligibility: contiguous storage layout, zero storage offset,
+  // and the user view spans the entire storage. When all three hold the
+  // source elements are contiguous in storage, so a single
+  // c10::rbln::memcpy_v2v moves them to a freshly allocated output without
+  // going through aten::copy_'s dispatch + TensorIterator path.
+  const bool direct_d2d_eligible = self.is_contiguous() && self.storage_offset() == 0 &&
+      static_cast<int64_t>(self.storage().nbytes()) == self.numel() * self.element_size();
+
+  at::Tensor out;
+  if (mf_req == c10::MemoryFormat::Preserve) {
+    if (self.is_non_overlapping_and_dense()) {
+      // Strided dense source: replay the strides on a fresh buffer so the
+      // clone observes identical layout.
+      out = at::empty_strided(self.sizes(), self.strides(), self.options());
+    } else if (self.is_contiguous(at::MemoryFormat::ChannelsLast)) {
+      out = at::empty(self.sizes(), self.options().memory_format(at::MemoryFormat::ChannelsLast));
+    } else if (self.is_contiguous(at::MemoryFormat::ChannelsLast3d)) {
+      out = at::empty(self.sizes(), self.options().memory_format(at::MemoryFormat::ChannelsLast3d));
+    } else {
+      out = at::empty(self.sizes(), self.options().memory_format(at::MemoryFormat::Contiguous));
+    }
+  } else {
+    out = at::empty(self.sizes(), self.options().memory_format(mf_req));
+  }
+
+  if (direct_d2d_eligible && nbytes > 0 && out.is_contiguous() && out.strides() == self.strides()) {
+    // Bypass aten::copy_ dispatch — write directly into the fresh output
+    // buffer. Both self and out live on the same RBLN device (Tensor::options
+    // preserves device), so this is always a same-device v2v. Require
+    // matching strides so the byte order is identical; if the requested
+    // memory format reshuffles strides (e.g. Preserve on a strided view
+    // gives empty_strided with non-contig strides), fall through to the
+    // copy_ path which honours strides.
+    c10::rbln::memcpy_v2v(out.data_ptr(), self.data_ptr(), nbytes);
+  } else {
+    // Non-contig / partial-storage view: keep the default composite path
+    // so aten::copy_'s TensorIterator handles the strided gather.
+    out.copy_(self);
+  }
+  return out;
 }
 
 } // namespace at::native::rbln

--- a/aten/src/ATen/native/rbln/RBLNCopy.h
+++ b/aten/src/ATen/native/rbln/RBLNCopy.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <ATen/native/Copy.h>
+#include <c10/core/MemoryFormat.h>
+
+#include <optional>
 
 namespace at::native::rbln {
 
@@ -24,5 +27,22 @@ at::Tensor _copy_from_rbln(const at::Tensor& src, const at::Tensor& dst, bool no
  * @return The destination tensor with copied data.
  */
 at::Tensor _copy_from_and_resize_rbln(const at::Tensor& src, const at::Tensor& dst);
+
+/**
+ * @brief Native impl of aten::clone for RBLN.
+ *
+ * Implements PyTorch's aten::clone semantics
+ * (clone(Tensor self, *, MemoryFormat? memory_format=None) -> Tensor)
+ * by allocating a fresh output tensor with the requested memory format and
+ * filling it from `self`. The fast path — `self` is contiguous with
+ * `storage_offset()==0` and spans the entire storage — bypasses the
+ * aten::copy_ dispatch and goes straight through `c10::rbln::memcpy_v2v`,
+ * eliminating the redispatch + TensorIterator host overhead. The general
+ * (non-contiguous / partial-storage view) case falls back to the standard
+ * empty + copy_ decomposition so that strided gather semantics stay correct.
+ */
+at::Tensor clone_rbln(
+    const at::Tensor& self,
+    std::optional<c10::MemoryFormat> memory_format);
 
 } // namespace at::native::rbln

--- a/aten/src/ATen/native/rbln/RBLNTensorFactories.cpp
+++ b/aten/src/ATen/native/rbln/RBLNTensorFactories.cpp
@@ -4,6 +4,11 @@
 #include <c10/rbln/RBLNFunctions.h>
 #include <c10/rbln/RBLNLogging.h>
 
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+
 namespace at::native::rbln {
 
 at::Tensor empty_rbln(
@@ -113,6 +118,275 @@ at::Tensor& zero_rbln_(at::Tensor& self) {
   }
   c10::rbln::mark_zeros(self.data_ptr());
   return self;
+}
+
+namespace {
+// Dispatch a scalar value into the appropriate typed std::fill_n over a host
+// buffer of given element count. We support the dtypes vllm-rbln actually hits
+// on Llama-class workloads (slot_mapping=int64, masks=bool, positions=int64,
+// fp16/bf16/fp32 activations). Adding more is a one-line case extension.
+bool fill_host_typed(void* host_ptr, int64_t numel, c10::ScalarType st, const at::Scalar& value) {
+  switch (st) {
+    case at::kLong:
+      std::fill_n(static_cast<int64_t*>(host_ptr), numel, value.to<int64_t>());
+      return true;
+    case at::kInt:
+      std::fill_n(static_cast<int32_t*>(host_ptr), numel, value.to<int32_t>());
+      return true;
+    case at::kShort:
+      std::fill_n(static_cast<int16_t*>(host_ptr), numel, value.to<int16_t>());
+      return true;
+    case at::kChar:
+      std::fill_n(static_cast<int8_t*>(host_ptr), numel, value.to<int8_t>());
+      return true;
+    case at::kByte: {
+      const auto v = value.to<uint8_t>();
+      std::memset(host_ptr, v, static_cast<size_t>(numel));
+      return true;
+    }
+    case at::kBool: {
+      const auto v = value.to<bool>();
+      std::memset(host_ptr, v ? 1 : 0, static_cast<size_t>(numel));
+      return true;
+    }
+    case at::kFloat:
+      std::fill_n(static_cast<float*>(host_ptr), numel, value.to<float>());
+      return true;
+    case at::kDouble:
+      std::fill_n(static_cast<double*>(host_ptr), numel, value.to<double>());
+      return true;
+    case at::kHalf:
+      std::fill_n(static_cast<at::Half*>(host_ptr), numel, value.to<at::Half>());
+      return true;
+    case at::kBFloat16:
+      std::fill_n(static_cast<at::BFloat16*>(host_ptr), numel, value.to<at::BFloat16>());
+      return true;
+    default:
+      return false; // unsupported dtype — caller falls back to cpu_fallback
+  }
+}
+} // namespace
+
+// Native impl of aten::fill_.Scalar for RBLN. Bypasses cpu_fallback_rbln's
+// redispatchBoxed(CPU) overhead: borrows a host pointer into the rbln vmemory
+// backing ``self``, writes the value with a typed std::fill_n (compiler
+// auto-vectorises), then commits via return_borrowed(updated=true). The
+// device→host transfer is implicit in borrow_host_ptr (we use the read variant
+// rather than acquire_host_ptr_for_overwrite because partial-view writes need
+// the rest of the storage to remain intact).
+//
+// Only contiguous tensors are handled. Non-contiguous fills (rare on the
+// Llama-1B vLLM hot path: 0 occurrences in measurement) trip the assert; the
+// proper extension is stride iteration in this function — we leave that as
+// a follow-up if/when the assert fires.
+// Cheap dtype check that mirrors ``fill_host_typed``'s case set. Used so we
+// can decide whether the borrow-and-fill fast path is viable *before*
+// acquiring the host-pointer (which has its own cost). When this returns
+// false (e.g. ComplexHalf, ComplexFloat) we route through the CPU fallback
+// path below so the OpInfo tests that exercise those dtypes don't trip a
+// hard assert in the native impl.
+namespace {
+bool fill_host_typed_supports(c10::ScalarType st) {
+  switch (st) {
+    case at::kLong:
+    case at::kInt:
+    case at::kShort:
+    case at::kChar:
+    case at::kByte:
+    case at::kBool:
+    case at::kFloat:
+    case at::kDouble:
+    case at::kHalf:
+    case at::kBFloat16:
+      return true;
+    default:
+      return false;
+  }
+}
+
+// CPU fallback for fill_.Scalar: copy device tensor to CPU, fill, copy back.
+// Used for shapes/dtypes the native borrow path can't handle (non-contig
+// self, complex / quantized dtypes, etc.). Keeps the native impl
+// transparent to callers: they observe the same in-place mutation.
+at::Tensor& fill_scalar_via_cpu(at::Tensor& self, const at::Scalar& value) {
+  auto self_cpu = self.cpu();
+  self_cpu.fill_(value);
+  self.copy_(self_cpu);
+  return self;
+}
+} // namespace
+
+at::Tensor& fill_scalar_rbln_(at::Tensor& self, const at::Scalar& value) {
+  RBLN_SCOPE_GUARD();
+  if (self.numel() == 0) {
+    return self;
+  }
+  // Fast path is restricted to contiguous tensors with a dtype the typed
+  // ``std::fill_n`` cascade in ``fill_host_typed`` covers. Anything else
+  // (non-contig views — strided OpInfo samples — and complex / quantized
+  // dtypes) routes through the CPU fallback so we don't hard-assert.
+  if (!self.is_contiguous() || !fill_host_typed_supports(self.scalar_type())) {
+    return fill_scalar_via_cpu(self, value);
+  }
+
+  const auto nbytes = static_cast<size_t>(self.numel()) * self.element_size();
+  const auto borrow = c10::rbln::borrow_host_ptr(self.data_ptr(), nbytes);
+  void* host_ptr = reinterpret_cast<void*>(borrow.host_ptr);
+
+  const bool handled = fill_host_typed(host_ptr, self.numel(), self.scalar_type(), value);
+  c10::rbln::return_borrowed(borrow.borrow_id, /*updated=*/handled);
+  // ``fill_host_typed_supports`` already vetted the dtype above, so the
+  // call above should always succeed. Keep a defensive fallback for the
+  // (hypothetical) case where the two predicates diverge.
+  if (!handled) {
+    return fill_scalar_via_cpu(self, value);
+  }
+  return self;
+}
+
+namespace {
+template <typename scalar_t>
+void arange_fill_host(scalar_t* host_ptr, int64_t n, scalar_t start, scalar_t step) {
+  for (int64_t i = 0; i < n; ++i) {
+    host_ptr[i] = static_cast<scalar_t>(start + static_cast<scalar_t>(i) * step);
+  }
+}
+} // namespace
+
+// Native impl of aten::arange.start_out for RBLN.
+//   schema: arange.start_out(Scalar start, Scalar end, Scalar step,
+//                            *, Tensor(a!) out) -> Tensor(a!)
+// Write-only on `out`, so we use acquire_host_ptr_for_overwrite (D2H sync
+// skipped) and commit via return_borrowed(updated=true). `out` is assumed
+// already sized correctly by the caller (vllm-rbln preallocates the tensor;
+// torch.arange's meta function sizes it before dispatch).
+at::Tensor& arange_start_out_rbln(
+    const at::Scalar& start,
+    const at::Scalar& end,
+    const at::Scalar& step,
+    at::Tensor& out) {
+  RBLN_SCOPE_GUARD();
+  // Compute expected length = ceil((end - start) / step). PyTorch's native
+  // CPU/CUDA path runs through TensorIterator + a structured meta function
+  // that resizes `out`. On PrivateUse1 we own the impl, so we have to
+  // mirror that behaviour explicitly. Use double for the range arithmetic
+  // and clamp to >=0.
+  const double s_d = start.to<double>();
+  const double e_d = end.to<double>();
+  const double st_d = step.to<double>();
+  TORCH_CHECK(st_d != 0.0, "arange.start_out: step must be non-zero");
+  int64_t n = 0;
+  if ((st_d > 0.0 && e_d > s_d) || (st_d < 0.0 && e_d < s_d)) {
+    n = static_cast<int64_t>(std::ceil((e_d - s_d) / st_d));
+  }
+  if (out.numel() != n) {
+    out.resize_({n});
+  }
+  if (n == 0) {
+    return out;
+  }
+  // Fast path needs both contiguous out AND a dtype the typed arange-fill
+  // cascade covers (int family + float/double). Half / BFloat16 / complex
+  // dtypes that OpInfo tests for arange route through the CPU fallback
+  // below so we don't hard-assert and crash the suite.
+  auto cpu_fallback_for_arange = [&]() -> at::Tensor& {
+    auto out_cpu = at::empty({n}, out.options().device(c10::Device(c10::DeviceType::CPU)));
+    at::arange_out(out_cpu, start, end, step);
+    out.copy_(out_cpu);
+    return out;
+  };
+  if (!out.is_contiguous()) {
+    return cpu_fallback_for_arange();
+  }
+  const auto st = out.scalar_type();
+  const bool dtype_supported = st == at::kLong || st == at::kInt || st == at::kShort || st == at::kChar ||
+      st == at::kByte || st == at::kFloat || st == at::kDouble;
+  if (!dtype_supported) {
+    return cpu_fallback_for_arange();
+  }
+
+  const auto nbytes = static_cast<size_t>(out.numel()) * out.element_size();
+  const auto borrow = c10::rbln::acquire_host_ptr_for_overwrite(out.data_ptr(), nbytes);
+  void* host_ptr = reinterpret_cast<void*>(borrow.host_ptr);
+
+  switch (st) {
+    case at::kLong:
+      arange_fill_host<int64_t>(static_cast<int64_t*>(host_ptr), n, start.to<int64_t>(), step.to<int64_t>());
+      break;
+    case at::kInt:
+      arange_fill_host<int32_t>(static_cast<int32_t*>(host_ptr), n, start.to<int32_t>(), step.to<int32_t>());
+      break;
+    case at::kShort:
+      arange_fill_host<int16_t>(static_cast<int16_t*>(host_ptr), n, start.to<int16_t>(), step.to<int16_t>());
+      break;
+    case at::kChar:
+      arange_fill_host<int8_t>(static_cast<int8_t*>(host_ptr), n, start.to<int8_t>(), step.to<int8_t>());
+      break;
+    case at::kByte:
+      arange_fill_host<uint8_t>(static_cast<uint8_t*>(host_ptr), n, start.to<uint8_t>(), step.to<uint8_t>());
+      break;
+    case at::kFloat:
+      arange_fill_host<float>(static_cast<float*>(host_ptr), n, start.to<float>(), step.to<float>());
+      break;
+    case at::kDouble:
+      arange_fill_host<double>(static_cast<double*>(host_ptr), n, start.to<double>(), step.to<double>());
+      break;
+    default:
+      // dtype_supported gate above rules this branch out.
+      c10::rbln::return_borrowed(borrow.borrow_id, /*updated=*/false);
+      return cpu_fallback_for_arange();
+  }
+  c10::rbln::return_borrowed(borrow.borrow_id, /*updated=*/true);
+  return out;
+}
+
+at::Scalar _local_scalar_dense_rbln(const at::Tensor& self) {
+  RBLN_SCOPE_GUARD();
+  TORCH_CHECK(self.numel() == 1, "_local_scalar_dense_rbln: expected 1-element tensor, got numel=", self.numel());
+
+  const size_t nbytes = static_cast<size_t>(self.element_size());
+  const auto borrow = c10::rbln::borrow_host_ptr(self.data_ptr(), nbytes);
+  void* p = reinterpret_cast<void*>(borrow.host_ptr);
+
+  at::Scalar r;
+  bool handled = true;
+  switch (self.scalar_type()) {
+    case at::kLong:
+      r = at::Scalar(*static_cast<int64_t*>(p));
+      break;
+    case at::kInt:
+      r = at::Scalar(*static_cast<int32_t*>(p));
+      break;
+    case at::kShort:
+      r = at::Scalar(*static_cast<int16_t*>(p));
+      break;
+    case at::kChar:
+      r = at::Scalar(*static_cast<int8_t*>(p));
+      break;
+    case at::kByte:
+      r = at::Scalar(*static_cast<uint8_t*>(p));
+      break;
+    case at::kBool:
+      r = at::Scalar(*static_cast<bool*>(p));
+      break;
+    case at::kFloat:
+      r = at::Scalar(*static_cast<float*>(p));
+      break;
+    case at::kDouble:
+      r = at::Scalar(*static_cast<double*>(p));
+      break;
+    case at::kHalf:
+      r = at::Scalar(*static_cast<at::Half*>(p));
+      break;
+    case at::kBFloat16:
+      r = at::Scalar(*static_cast<at::BFloat16*>(p));
+      break;
+    default:
+      handled = false;
+  }
+  c10::rbln::return_borrowed(borrow.borrow_id, /*updated=*/false);
+  TORCH_INTERNAL_ASSERT(handled, "_local_scalar_dense_rbln: unsupported dtype ", c10::toString(self.scalar_type()));
+  return r;
 }
 
 } // namespace at::native::rbln

--- a/aten/src/ATen/native/rbln/RBLNTensorFactories.h
+++ b/aten/src/ATen/native/rbln/RBLNTensorFactories.h
@@ -69,4 +69,23 @@ at::Tensor _efficientzerotensor_rbln(
  */
 at::Tensor& zero_rbln_(at::Tensor& self);
 
+// Native impl of aten::fill_.Scalar — borrow host pointer + typed std::fill_n
+// + return_borrowed(updated=true). Bypasses cpu_fallback_rbln's redispatchBoxed
+// + TensorIterator path. Contiguous self only (asserts otherwise).
+at::Tensor& fill_scalar_rbln_(at::Tensor& self, const at::Scalar& value);
+
+// Native impl of aten::arange.start_out — acquire_host_ptr_for_overwrite
+// (D2H skipped, write-only), host-fill out[i] = start + i*step, then
+// return_borrowed(updated=true). `out` is assumed already sized.
+at::Tensor& arange_start_out_rbln(
+    const at::Scalar& start,
+    const at::Scalar& end,
+    const at::Scalar& step,
+    at::Tensor& out);
+
+// Native impl of aten::_local_scalar_dense — 1-element tensor → Python scalar
+// (= `.item()`). D2H is unavoidable (we need the value on host) but we skip
+// cpu_fallback_rbln's schema cache + redispatch overhead. Read-only borrow.
+at::Scalar _local_scalar_dense_rbln(const at::Tensor& self);
+
 } // namespace at::native::rbln

--- a/test/rbln/test_native_arange.py
+++ b/test/rbln/test_native_arange.py
@@ -1,0 +1,92 @@
+# Owner(s): ["module: PrivateUse1"]
+
+"""
+Test suite for the RBLN-native `aten::arange.start_out` implementation.
+
+`arange_start_out_rbln` (RBLNTensorFactories.cpp) implements
+arange(start, end, step, *, out=tensor) directly on the RBLN device:
+* Computes the expected length as ceil((end - start) / step) and resizes
+  `out` to match (mirrors PyTorch's structured meta function which sizes
+  the output before dispatch on CPU/CUDA).
+* Uses acquire_host_ptr_for_overwrite to skip the device→host sync
+  (write-only) and fills out[i] = start + i*step on the host pointer.
+* Commits via return_borrowed(updated=true) so the next device-side read
+  picks up the new bytes lazily.
+
+These tests verify the result matches CPU `torch.arange` across all
+supported dtypes and across forward / reverse / fractional / single-step
+configurations.
+"""
+
+import pytest
+import torch
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import parametrize, run_tests, TestCase
+
+
+def _arange_via_out(start, end, step, dtype, device):
+    """Call torch.arange with an explicit out= tensor (triggers .start_out)."""
+    out = torch.empty(0, dtype=dtype, device=device)
+    return torch.arange(start, end, step, out=out)
+
+
+@pytest.mark.test_set_ci
+class TestArangeStartOutRBLN(TestCase):
+    """`aten::arange.start_out` on RBLN must match CPU."""
+
+    def _check(self, start, end, step, dtype):
+        ref = _arange_via_out(start, end, step, dtype, "cpu")
+        out = _arange_via_out(start, end, step, dtype, "rbln")
+        self.assertEqual(out.device.type, "rbln")
+        self.assertEqual(out.dtype, dtype)
+        self.assertEqual(tuple(out.shape), tuple(ref.shape))
+        self.assertEqual(out.to("cpu"), ref)
+
+    @parametrize(
+        "start,end,step,dtype",
+        [
+            # Integer dtypes — forward / signed / strided.
+            (0, 8, 1, torch.int64),
+            (0, 128, 1, torch.int64),
+            (5, 11, 2, torch.int64),
+            (0, 16, 1, torch.int32),
+            (-4, 4, 1, torch.int32),
+            (0, 32, 4, torch.int16),
+            (-3, 3, 1, torch.int8),
+            (0, 16, 2, torch.uint8),
+            # Float / double — forward, fractional step.
+            (0.0, 5.0, 0.5, torch.float32),
+            (-1.0, 1.0, 0.25, torch.float32),
+            (0.0, 4.0, 1.0, torch.float64),
+            # Reverse step (negative).
+            (10, 0, -2, torch.int64),
+            (5.0, 0.0, -0.5, torch.float32),
+        ],
+    )
+    def test_matches_cpu(self, start, end, step, dtype):
+        self._check(start, end, step, dtype)
+
+    def test_empty_range_noop(self):
+        # start == end → length 0
+        out = _arange_via_out(3, 3, 1, torch.int64, "rbln")
+        self.assertEqual(out.numel(), 0)
+
+    def test_zero_step_raises(self):
+        with self.assertRaises(RuntimeError):
+            _arange_via_out(0, 5, 0, torch.int64, "rbln")
+
+    # Note: undersized-out resize (caller passes ``torch.empty(2)`` and lets
+    # upstream PyTorch resize via ``arange.start_out``'s structured kernel)
+    # is not currently covered. The rbln allocator's storage is flagged
+    # non-resizable, so ``out.resize_(n)`` raises "Trying to resize storage
+    # that is not resizable" before control reaches our ``arange_start_out_rbln``.
+    # Add coverage once the allocator supports resize. The realistic path
+    # (``out=torch.empty(0)``) is exercised indirectly by ``test_compare_cpu_arange_rbln_float16``
+    # in ``test/ops/test_ops.py``.
+
+
+instantiate_device_type_tests(TestArangeStartOutRBLN, globals(), only_for="privateuse1")
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/rbln/test_native_clone.py
+++ b/test/rbln/test_native_clone.py
@@ -1,0 +1,125 @@
+# Owner(s): ["module: PrivateUse1"]
+
+"""
+Test suite for the RBLN-native `aten::clone` implementation.
+
+`clone_rbln` (RBLNCopy.cpp) handles two paths:
+* **Direct d2d (fast path):** `self` is contiguous, storage_offset() == 0,
+  and the view spans the entire storage. The fresh output is allocated
+  and filled with a single `c10::rbln::memcpy_v2v`, bypassing
+  aten::copy_'s dispatch + TensorIterator host overhead.
+* **Composite fallback (non-contig / partial-storage view):** falls
+  through to the standard empty + copy_ decomposition. copy_'s
+  TensorIterator handles arbitrary strided gather.
+
+These tests verify:
+* The fast path produces a tensor with the same values as the source.
+* The fallback path produces correct results for arbitrary strided views
+  (slice, transpose, broadcast).
+* Detached storage: cloning produces a new tensor whose mutations do not
+  affect the source.
+"""
+
+import pytest
+import torch
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import parametrize, run_tests, TestCase
+
+
+@pytest.mark.test_set_ci
+class TestCloneRBLNDirectD2D(TestCase):
+    """The contiguous, full-storage fast path."""
+
+    def _check(self, src_cpu: torch.Tensor) -> None:
+        src_rbln = src_cpu.to("rbln")
+        # Sanity-check the fast-path precondition.
+        self.assertTrue(src_rbln.is_contiguous())
+        self.assertEqual(src_rbln.storage_offset(), 0)
+
+        out = src_rbln.clone()
+        self.assertEqual(out.device.type, "rbln")
+        self.assertEqual(out.dtype, src_cpu.dtype)
+        self.assertEqual(tuple(out.shape), tuple(src_cpu.shape))
+        self.assertEqual(out.to("cpu"), src_cpu)
+        # Detached storage: cloning must produce an independent tensor.
+        self.assertNotEqual(out.data_ptr(), src_rbln.data_ptr())
+
+    @parametrize(
+        "dtype,shape",
+        [
+            (torch.int64, (10,)),
+            (torch.int32, (3, 4)),
+            (torch.float16, (2, 3, 4)),
+        ],
+    )
+    def test_arange_view(self, dtype, shape):
+        numel = 1
+        for s in shape:
+            numel *= s
+        self._check(torch.arange(numel, dtype=dtype).view(*shape))
+
+    def test_bool(self):
+        self._check(torch.tensor([True, False, True, True], dtype=torch.bool))
+
+    def test_empty_tensor(self):
+        # numel() == 0 — fast path is skipped (nbytes guard) but an empty
+        # output of the right shape/dtype is still returned.
+        src = torch.empty(0, dtype=torch.int64, device="rbln")
+        out = src.clone()
+        self.assertEqual(out.numel(), 0)
+        self.assertEqual(out.dtype, torch.int64)
+
+
+@pytest.mark.test_set_ci
+class TestCloneRBLNNonContigFallback(TestCase):
+    """The composite fallback path (non-contig / partial-storage views)."""
+
+    def _check_view(self, src_cpu, view_fn):
+        src_rbln = src_cpu.to("rbln")
+        view_cpu = view_fn(src_cpu)
+        view_rbln = view_fn(src_rbln)
+
+        out_rbln = view_rbln.clone()
+        out_cpu = view_cpu.clone()
+
+        self.assertEqual(out_rbln.device.type, "rbln")
+        self.assertEqual(out_rbln.dtype, src_cpu.dtype)
+        self.assertEqual(tuple(out_rbln.shape), tuple(out_cpu.shape))
+        self.assertEqual(out_rbln.to("cpu"), out_cpu)
+
+    def test_slice_view(self):
+        # 1D slice — view has storage_offset != 0.
+        src = torch.arange(16, dtype=torch.int64)
+        self._check_view(src, lambda x: x[4:12])
+
+    def test_strided_view_2d(self):
+        # Every second column — view is non-contiguous.
+        src = torch.arange(20, dtype=torch.int32).view(4, 5)
+        self._check_view(src, lambda x: x[:, ::2])
+
+    def test_transposed_view(self):
+        # transpose breaks contiguity even when the storage is fully spanned.
+        src = torch.arange(12, dtype=torch.float16).view(3, 4)
+        self._check_view(src, lambda x: x.transpose(0, 1))
+
+
+@pytest.mark.test_set_ci
+class TestCloneRBLNIsolation(TestCase):
+    """Clones must not alias the source's storage."""
+
+    def test_mutation_does_not_propagate(self):
+        src = torch.arange(8, dtype=torch.int64, device="rbln")
+        out = src.clone()
+        out.fill_(-1)
+        # `src` must keep its original values.
+        self.assertEqual(src.to("cpu"), torch.arange(8, dtype=torch.int64))
+        self.assertEqual(out.to("cpu"), torch.full((8,), -1, dtype=torch.int64))
+
+
+instantiate_device_type_tests(TestCloneRBLNDirectD2D, globals(), only_for="privateuse1")
+instantiate_device_type_tests(TestCloneRBLNNonContigFallback, globals(), only_for="privateuse1")
+instantiate_device_type_tests(TestCloneRBLNIsolation, globals(), only_for="privateuse1")
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/rbln/test_native_fill_scalar.py
+++ b/test/rbln/test_native_fill_scalar.py
@@ -1,0 +1,84 @@
+# Owner(s): ["module: PrivateUse1"]
+
+"""
+Test suite for the RBLN-native `aten::fill_.Scalar` implementation.
+
+`fill_scalar_rbln_` (RBLNTensorFactories.cpp) replaces the default
+`fallback_rbln` registration for `aten::fill_.Scalar`. It borrows a host
+pointer into the RBLN vmemory backing `self`, writes the scalar value with
+a typed std::fill_n / std::memset, and commits via
+return_borrowed(updated=true). Bypasses cpu_fallback_rbln's
+redispatchBoxed(CPU) + TensorIterator path.
+
+These tests verify:
+* All supported dtypes produce the same values as the CPU reference.
+* In-place semantics are preserved (same tensor identity, same storage).
+* Empty tensors are a no-op.
+"""
+
+import pytest
+import torch
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import parametrize, run_tests, TestCase
+
+
+@pytest.mark.test_set_ci
+class TestFillScalarRBLN(TestCase):
+    """`aten::fill_.Scalar` on RBLN must match CPU bit-for-bit."""
+
+    def _check(self, dtype, value, sizes=(8,)):
+        ref = torch.empty(*sizes, dtype=dtype).fill_(value)
+        x = torch.empty(*sizes, dtype=dtype, device="rbln")
+        ret = x.fill_(value)
+        # fill_ returns self for in-place semantics.
+        self.assertTrue(ret is x)
+        self.assertEqual(x.device.type, "rbln")
+        self.assertEqual(x.dtype, dtype)
+        self.assertEqual(x.to("cpu"), ref)
+
+    @parametrize(
+        "dtype,value",
+        [
+            (torch.int64, -1),
+            (torch.int64, 0),
+            (torch.int64, 12345),
+            (torch.int32, -1),
+            (torch.int32, 7),
+            (torch.int16, -2),
+            (torch.int16, 17),
+            (torch.int8, -3),
+            (torch.int8, 9),
+            (torch.uint8, 0),
+            (torch.uint8, 200),
+            (torch.bool, True),
+            (torch.bool, False),
+            (torch.float32, 3.14),
+            (torch.float32, -2.5),
+            (torch.float64, 1.0 / 3.0),
+            (torch.float16, 1.5),
+            (torch.float16, -0.25),
+            (torch.bfloat16, 0.125),
+        ],
+    )
+    def test_matches_cpu(self, dtype, value):
+        self._check(dtype, value)
+
+    def test_multi_dim_shape(self):
+        # Verify shape is preserved.
+        x = torch.empty(2, 3, 4, dtype=torch.int64, device="rbln")
+        x.fill_(42)
+        self.assertEqual(tuple(x.shape), (2, 3, 4))
+        self.assertEqual(x.to("cpu"), torch.full((2, 3, 4), 42, dtype=torch.int64))
+
+    def test_empty_tensor_noop(self):
+        # numel() == 0 must short-circuit without touching the vmemory.
+        x = torch.empty(0, dtype=torch.int64, device="rbln")
+        x.fill_(-1)
+        self.assertEqual(x.numel(), 0)
+
+
+instantiate_device_type_tests(TestFillScalarRBLN, globals(), only_for="privateuse1")
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/rbln/test_native_local_scalar_dense.py
+++ b/test/rbln/test_native_local_scalar_dense.py
@@ -1,0 +1,74 @@
+# Owner(s): ["module: PrivateUse1"]
+
+"""
+Test suite for the RBLN-native `aten::_local_scalar_dense` implementation.
+
+`_local_scalar_dense_rbln` (RBLNTensorFactories.cpp) replaces the default
+fallback_rbln registration. It is the op behind `tensor.item()` and is
+called whenever PyTorch needs a 1-element tensor's value as a Python
+scalar. The device→host transfer is unavoidable (semantics require it on
+the host) but bypassing cpu_fallback_rbln's schema cache + redispatch
+overhead saves tens of microseconds per call — important on prefill where
+vLLM's BasevLLMParameter dispatch hook may trigger thousands of these.
+
+These tests verify the returned scalar matches the CPU reference across
+all supported dtypes.
+"""
+
+import pytest
+import torch
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import parametrize, run_tests, TestCase
+
+
+@pytest.mark.test_set_ci
+class TestLocalScalarDenseRBLN(TestCase):
+    """`aten::_local_scalar_dense` via `tensor.item()` on RBLN must match CPU."""
+
+    def _check_item(self, value, dtype):
+        cpu_t = torch.tensor(value, dtype=dtype)
+        rbln_t = cpu_t.to("rbln")
+        self.assertEqual(rbln_t.item(), cpu_t.item())
+
+    @parametrize(
+        "value,dtype",
+        [
+            (-12345, torch.int64),
+            (0, torch.int64),
+            (2**31, torch.int64),
+            (-7, torch.int32),
+            (2**30, torch.int32),
+            (123, torch.int16),
+            (-456, torch.int16),
+            (-3, torch.int8),
+            (99, torch.int8),
+            (200, torch.uint8),
+            (0, torch.uint8),
+            (True, torch.bool),
+            (False, torch.bool),
+            (3.14159, torch.float32),
+            (-0.0, torch.float32),
+            (2.718281828, torch.float64),
+            (1.5, torch.float16),
+            (0.5, torch.bfloat16),
+        ],
+    )
+    def test_matches_cpu(self, value, dtype):
+        self._check_item(value, dtype)
+
+    def test_one_element_multi_dim(self):
+        # A 1-element tensor with non-trivial shape — item() still works.
+        t = torch.tensor([[[42]]], dtype=torch.int64, device="rbln")
+        self.assertEqual(t.item(), 42)
+
+    def test_multi_element_raises(self):
+        t = torch.tensor([1, 2, 3], dtype=torch.int64, device="rbln")
+        with self.assertRaises(RuntimeError):
+            t.item()
+
+
+instantiate_device_type_tests(TestLocalScalarDenseRBLN, globals(), only_for="privateuse1")
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
## Summary of Changes

Direct PrivateUse1 impls for four ATen ops that previously fell through to
`cpu_fallback_rbln`, eliminating the `redispatchBoxed(CPU)` + `TensorIterator`
overhead. Each op is hit on every vLLM decode step.

- `aten::fill_.Scalar` — host borrow + typed `std::fill_n` / `std::memset`; CPU fallback for non-contig / unsupported dtype.
- `aten::arange.start_out` — host range fill + `acquire_host_ptr_for_overwrite` + lazy h2v; CPU fallback for unsupported dtypes (Half/BFloat16/complex).
- `aten::_local_scalar_dense` — direct vmem read for `tensor.item()`.
- `aten::clone` — `memcpy_v2v` fast path for dense-storage source; `Preserve` memory format resolved per source layout (contig / strided / channels_last).

## Related Issues / Tickets

* Related to #

## Type of Change

- [x] `core` — RBLN backend op impls
- [x] `perf` — host-overhead reduction

## Affected Modules

- [x] Backend
- [x] Ops/Kernels
- [x] C++ extension (`torch_rbln/csrc`)

## How to Test

```bash
pytest test/rbln/test_native_fill_scalar.py \
       test/rbln/test_native_arange.py \
       test/rbln/test_native_local_scalar_dense.py \
       test/rbln/test_native_clone.py
python test/run_tests.py --suite=ops --test_mode=release
```

65 native-op cases (full dtype matrix + edge cases) + 1627 release-mode ops tests pass.

## Notes

Stacked on `chan/perf-foundation` (PR #46).