### PR TITLE
fix(c10d): align ReduceScatter padded-remainder recv_count to driver requirement

### DIFF
--- a/torch_rbln/csrc/distributed/c10d/rbln/ProcessGroupRBLN.cpp
+++ b/torch_rbln/csrc/distributed/c10d/rbln/ProcessGroupRBLN.cpp
@@ -49,9 +49,13 @@ namespace {
 // RCCL Alignment Constants
 // ============================================================================
 
-// RCCL alignment constraints vary by operation type
-constexpr size_t RCCL_ALLGATHER_ALIGNMENT = 128ULL; // AllGather: 128 bytes
-constexpr size_t RCCL_ALLREDUCE_ALIGNMENT = 512ULL; // AllReduce: 512 bytes
+// Per-op driver alignment requirements (RCCL_DATA_ALIGNSIZE_FOR_CS).
+// v3.0.0 enforced 512 B for CS-based AllReduce/ReduceScatter and 128 B for
+// AllGather; v3.1+ relaxed CS alignment to 128 B. Keep these at the tighter
+// historical values so a single torch-rbln build runs against either driver
+// generation — 512-aligned trivially satisfies the newer 128 B requirement.
+constexpr size_t RCCL_ALLGATHER_ALIGNMENT = 128ULL;
+constexpr size_t RCCL_ALLREDUCE_ALIGNMENT = 512ULL;
 constexpr size_t RCCL_REDUCE_SCATTER_ALIGNMENT = RCCL_ALLREDUCE_ALIGNMENT;
 
 // AllReduce size limit: data_size / world_size <= 1MB (temporary driver limitation)
@@ -1363,42 +1367,61 @@ class ReduceScatterRBLNWork : public RBLNWork {
       // ========================================================================
       // Step 3-1: Process unaligned remainder portion if exists
       if (needs_padding) {
-        // Step 3-1-1: Calculate output pointer for remainder
-        out_ptr = static_cast<char*>(output.data_ptr()) + (out_numel_offset * elem_size);
         size_t remainder_recv_numel = recv_numel - input_numel_offset;
         RBLN_CHECK(
             remainder_send_numel == remainder_recv_numel * worldSize_,
             "remainder_send_numel != remainder_recv_numel * worldSize_");
 
-        // Step 3-1-2: Calculate aligned size for padded remainder tensor
-        size_t aligned_up_remainder_send_numel =
-            (remainder_send_numel + align_unit_numel - 1) / align_unit_numel * align_unit_numel;
-        // Step 3-1-3: Create temporary tensor for padded remainder
+        // Step 3-1-1: Align the per-rank recv stride. The driver enforces
+        // (recv_count * elem_size) % RCCL_DATA_ALIGNSIZE_FOR_CS == 0; aligning
+        // only the total send size is insufficient because each rank's segment
+        // boundary must land on the alignment too.
+        const size_t aligned_up_remainder_recv_numel =
+            (remainder_recv_numel + align_unit_numel - 1) / align_unit_numel * align_unit_numel;
+        const size_t aligned_up_remainder_send_numel = aligned_up_remainder_recv_numel * worldSize_;
+
+        // Step 3-1-2: Allocate aligned send/recv staging tensors. A separate
+        // recv buffer is required because the real output has room for only
+        // remainder_recv_numel elements past out_numel_offset — writing the
+        // aligned-up count directly would overrun the output storage.
         at::Tensor remainder_tensor =
             torch::empty({static_cast<int64_t>(aligned_up_remainder_send_numel)}, inputs_[i][0].options());
+        at::Tensor padded_output_tensor =
+            torch::empty({static_cast<int64_t>(aligned_up_remainder_recv_numel)}, output.options());
 
-        // Step 3-1-4: Copy remainder portions from all input tensors to padded tensor
+        // Step 3-1-3: Pack each rank's tail into the send tensor at the aligned
+        // stride. Padding bytes inside each segment are reduced but their
+        // results are dropped when copying back, so leaving them uninitialized
+        // is safe.
         size_t offset = 0;
         for (const auto& input_tensor : inputs_[i]) {
           auto input_tensor_flatten = input_tensor.flatten();
           auto input_send_tensor_slice = input_tensor_flatten.slice(0, input_numel_offset, recv_numel);
           auto remainder_tensor_slice = remainder_tensor.slice(0, offset, offset + remainder_recv_numel);
           remainder_tensor_slice.copy_(input_send_tensor_slice);
-          offset += remainder_recv_numel;
+          offset += aligned_up_remainder_recv_numel;
         }
 
-        // Step 3-1-5: Execute ReduceScatter on padded remainder
+        // Step 3-1-4: Execute ReduceScatter on the aligned padded remainder.
         ensureRcclReduceMemory(remainder_tensor);
+        ensureRcclReduceMemory(padded_output_tensor);
         RBLNRetCode ret = rccl_->ReduceScatter(
             std::vector<void*>{remainder_tensor.data_ptr()},
-            out_ptr,
-            static_cast<int>(remainder_recv_numel),
+            padded_output_tensor.data_ptr(),
+            static_cast<int>(aligned_up_remainder_recv_numel),
             rcclDataType_,
             rcclReduceOp_,
             0,
             nullptr);
         RBLN_CHECK(
             ret == RBLNRetCode_SUCCESS, "RCCL ReduceScatter (padded remainder) failed: {}", static_cast<int>(ret));
+
+        // Step 3-1-5: Copy back only the unpadded portion to the real output.
+        auto output_flat = output.flatten();
+        auto output_remainder_slice = output_flat.slice(0, out_numel_offset, recv_numel);
+        auto padded_output_slice = padded_output_tensor.slice(0, 0, remainder_recv_numel);
+        output_remainder_slice.copy_(padded_output_slice);
+
         RBLN_LOG_DEBUG("RCCL ReduceScatter (padded remainder) completed successfully");
       }
     }


### PR DESCRIPTION
## Summary of Changes

Fixes `RCCL ReduceScatter (padded remainder) failed: 1` on the `dev` CI for unaligned `reduce_scatter` sizes (e.g. `8 MiB + 88`). The remainder block in `ReduceScatterRBLNWork::run()` was padding the **total send buffer** but still passing the **unaligned per-rank `recv_count`** to the driver, which v3.2.0's strict `_rcclReduceScatter` rejects with `-EINVAL`.

### Problem

`driver 3.2.0~rc2 ` recently shifted REBEL ReduceScatter routing:

| Driver | REBEL ReduceScatter path | Alignment check |
|---|---|---|
| v3.0.0 | `_rcclReduceScatterOrig` (auto-pads `data_size` to 256) | none |
| v3.1.x | `-EOPNOTSUPP` for REBEL | n/a |
| **v3.2.0** | `_rcclReduceScatter` (strict) | **`recv_count × elem_size % 128 == 0`** (`comm_api.c:3478`) |

The remainder block computed `aligned_up_remainder_send_numel` for the staging tensor, but the host call still used `remainder_recv_numel` for `recv_count`. For `size = 8 MiB + 88`, world=2, fp16 → `recv_count × 2 = 1,048,752 B`, `% 128 = 48` → driver returns `-EINVAL`.

The AllReduce remainder path in the same file does *not* hit this because it passes the aligned `align_numel` as `count` and copies back only `remainder_numel`. Only ReduceScatter had the asymmetric bug.

### Solution

Align the **per-rank recv stride** (not just total send), stage through a separate aligned recv buffer, and copy back the unpadded portion to the real output — the same pattern AllReduce already uses.

```
Before                                  After
──────                                  ─────
align total send_numel                  align per-rank recv_numel
pack stride = remainder_recv_numel      pack stride = aligned_up_remainder_recv_numel
ReduceScatter(recv_count = unaligned)   ReduceScatter(recv_count = aligned) → temp buf
write directly to output tail           copy temp[:remainder_recv_numel] → output tail
```

Why a temporary recv buffer is required: writing the aligned-up count straight into the output would overrun storage (output has space for only `remainder_recv_numel` past `out_numel_offset`).

The `RCCL_*_ALIGNMENT` constants are intentionally **left at the original values** (`512` for AllReduce/ReduceScatter, `128` for AllGather). Lowering them to 128 would break v3.0.0 compatibility (it enforces 512 B for CS ops). Comment expanded to document this cross-version contract.

---

## Related Issues / Tickets

* Resolves #

---

## Type of Change

- [x] `fix` — Bug fix
- [x] `core` — Changes to RBLN backend, device layer, C++ extension, op registration, or `torch.compile` integration

---

## Affected Modules

- [x] C++ extension (`torch_rbln/csrc`)

---

## How to Test

```sh
cd torch-rbln
.venv/bin/python -m pytest -xvs \
  test/distributed/test_process_group.py::TestReduceScatterRBLNPRIVATEUSE1::test_reduce_scatter_sum_unaligned_size_8388696_c10d_async_env_0_rbln
```

Expected: `PASSED` (previously raised `RuntimeError: RCCL ReduceScatter (padded remainder) failed: 1`).

Full regression run of the unaligned + chunked variants:

```sh
.venv/bin/python -m pytest -x test/distributed/test_process_group.py::TestReduceScatterRBLNPRIVATEUSE1 \
  -k "unaligned or chunk_limit"
```

Expected: **18 passed** across all unaligned sizes (1, 2, 4, 8, 16, 32, 64 MiB + remainder) × {sync, async}.

---

## Screenshots / Logs

Before (CI):
```
RuntimeError: RCCL ReduceScatter (padded remainder) failed: 1
  at ProcessGroupRBLN.cpp:1401
```

After (local, driver 3.2.0~rc2, world=2):
```
test_reduce_scatter_sum_unaligned_size_8388696_c10d_async_env_0_rbln PASSED [8.94s]
================ 18 passed, 26 deselected in 154.06s ================
```

---

## Checklist

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to a corresponding issue
* [x] Linting passes
* [x] All CI tests pass
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (n/a)

---

## Notes for reviewers

* Hot paths (fast-path / chunked) are untouched — only the `needs_padding` block changed. Aligned sizes skip this block entirely.
* Unaligned sizes incur one extra device alloc (`padded_output_tensor`, ≤ few MB) and one extra D2D copy per ReduceScatter call. Negligible vs the bulk transfer; not in a loop.
* Constants kept at 512 B intentionally — see expanded comment at the top of the file.

