### PR TITLE
docs(install): switch to two-step torch install per PyTorch RFC #180215

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ PyTorch RBLN is currently in **beta** and under active development. APIs may cha
 
 ### Install pre-built wheels
 
-**`torch-rbln`** (public wheel; **`torch`** resolves to **2.10.0+cpu** via the PyTorch CPU index):
+**`torch-rbln`** (public wheel). Install **`torch`** from the PyTorch CPU index first, then **`torch-rbln`** from PyPI.
 
 ```bash
-pip3 install torch-rbln --extra-index-url https://download.pytorch.org/whl/cpu
+pip3 install torch==2.10.0+cpu --index-url https://download.pytorch.org/whl/cpu
+pip3 install torch-rbln
 ```
 
 For **`rebel-compiler`** and the rest of the setup, see **Prerequisites** above and [Installation](https://docs.rbln.ai/latest/software/rbln_pytorch/installation.html#install).


### PR DESCRIPTION
## Summary of Changes

Replace the single-step `--extra-index-url` quick-install with the secure two-step form recommended by the PyTorch packaging maintainer in [pytorch/pytorch#180215](https://github.com/pytorch/pytorch/issues/180215).

**Before** (insecure — `pip` searched both indexes for every package, enabling [dependency confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)):

```bash
pip3 install torch-rbln --extra-index-url https://download.pytorch.org/whl/cpu
```

**After** (PyTorch CPU index is scoped to `torch` only; `torch-rbln` resolves from PyPI):

```bash
pip3 install torch==2.10.0+cpu --index-url https://download.pytorch.org/whl/cpu
pip3 install torch-rbln
```

The `torch==2.10.0+cpu` pin matches the version declared in `pyproject.toml` so the second step does not trigger a torch re-resolution.

---

## Related Issues / Tickets

* Related to https://github.com/pytorch/pytorch/issues/180215

---

## Type of Change

- [x] `docs` — Documentation only

---

## Affected Modules

- [x] Docs

---

## How to Test (if applicable)

In a clean Python 3.10–3.13 venv:

```bash
pip3 install torch==2.10.0+cpu --index-url https://download.pytorch.org/whl/cpu
pip3 install torch-rbln
python -c "import torch, torch_rbln; print(torch.__version__, torch_rbln.__version__)"
```

Expected: `2.10.0+cpu` and the installed `torch-rbln` version print without error.

---

## Notes

The matching change to the SDK install matrix (`rbln_sdk_doc`) is tracked separately so the rendered Installation page on docs.rbln.ai stays consistent with this README.