### PR TITLE
fix: harden strided-copy-based op kernels

### DIFF
--- a/aten/src/ATen/native/rbln/RBLNStridedV2V.cpp
+++ b/aten/src/ATen/native/rbln/RBLNStridedV2V.cpp
@@ -2,10 +2,13 @@
 
 #include <ATen/native/rbln/RBLNStrideUtils.h>
 #include <ATen/native/rbln/RBLNTensorUtils.h>
+#include <c10/rbln/RBLNFallbackConfig.h>
 #include <c10/rbln/RBLNLogging.h>
 #include <c10/util/Exception.h>
 
 #include <cstdint>
+#include <functional>
+#include <string_view>
 #include <vector>
 
 namespace at::native::rbln {
@@ -108,7 +111,28 @@ void strided_v2v_copy(const at::Tensor& dst, const at::Tensor& src, c10::rbln::V
 void strided_v2v_copy(const at::Tensor& dst, const at::Tensor& src) {
   c10::rbln::V2VBatch batch;
   strided_v2v_copy(dst, src, batch);
-  batch.submit();
+  submit_or_fallback(batch, "strided_v2v_copy", [&] { dst.copy_(src.cpu()); });
+}
+
+void submit_or_fallback(c10::rbln::V2VBatch& batch, const char* op_name, std::function<void()> cpu_fallback) {
+  try {
+    batch.submit();
+  } catch (const c10::Error& e) {
+    const std::string_view error_message = e.what();
+    // TODO: Replace substring match with a typed exception when the wrapper API allows.
+    if (error_message.find("rbln_memcpy_v2v_multi failed") == std::string_view::npos) {
+      throw; // validation error — propagate
+    }
+    if (c10::rbln::is_fallback_disabled("strided_copy_error")) {
+      throw;
+    }
+    RBLN_LOG_WARN(
+        "{}: batched strided copy failed — falling back to CPU op. "
+        "Underlying error: {}",
+        op_name,
+        error_message);
+    cpu_fallback();
+  }
 }
 
 } // namespace at::native::rbln

--- a/aten/src/ATen/native/rbln/RBLNStridedV2V.h
+++ b/aten/src/ATen/native/rbln/RBLNStridedV2V.h
@@ -3,6 +3,8 @@
 #include <ATen/core/Tensor.h>
 #include <c10/rbln/RBLNV2VBatch.h>
 
+#include <functional>
+
 namespace at::native::rbln {
 
 /**
@@ -45,5 +47,24 @@ void strided_v2v_copy(
  * inline. Use the batch-aware overload for multi-step kernels.
  */
 void strided_v2v_copy(const at::Tensor& dst, const at::Tensor& src);
+
+/**
+ * @brief Submits `batch`, invoking `cpu_fallback` on a backend call failure.
+ *
+ * Only `rbln_memcpy_v2v_multi` failures (identified by the
+ * "rbln_memcpy_v2v_multi failed" substring in `e.what()`) route to
+ * `cpu_fallback`; every other `c10::Error` (validation, other backend
+ * calls) propagates so caller-side bugs surface. Gated by
+ * `TORCH_RBLN_DISABLE_FALLBACK=strided_copy_error` (default enabled).
+ *
+ * @param batch         V2V batch to submit.
+ * @param op_name       Op identifier used in the fallback warning log.
+ * @param cpu_fallback  Callable performing the CPU-equivalent computation;
+ *                      invoked only on a backend call failure.
+ */
+void submit_or_fallback(
+    c10::rbln::V2VBatch& batch,
+    const char* op_name,
+    std::function<void()> cpu_fallback);
 
 } // namespace at::native::rbln

--- a/aten/src/ATen/native/rbln/RBLNTensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/rbln/RBLNTensorAdvancedIndexing.cpp
@@ -1,11 +1,15 @@
 #include <ATen/native/rbln/RBLNTensorAdvancedIndexing.h>
 
+#include <ATen/MemoryOverlap.h>
 #include <ATen/core/Tensor.h>
 #include <ATen/native/Resize.h>
 #include <ATen/native/rbln/RBLNIndexUtils.h>
 #include <ATen/native/rbln/RBLNStridedV2V.h>
 #include <ATen/native/rbln/RBLNTensorUtils.h>
 #include <ATen/ops/empty.h>
+#include <ATen/ops/index_copy.h>
+#include <ATen/ops/index_select.h>
+#include <c10/rbln/RBLNFallbackConfig.h>
 #include <c10/rbln/RBLNLogging.h>
 #include <c10/rbln/RBLNV2VBatch.h>
 
@@ -35,6 +39,11 @@ at::Tensor& index_select_out_rbln(const at::Tensor& self, int64_t dim, const at:
       "index_select: out dtype {} doesn't match self dtype {}",
       c10::str(out.scalar_type()),
       c10::str(self.scalar_type()));
+
+  // Mirror upstream PyTorch's `aten::index_select.out` overlap checks.
+  at::assert_no_internal_overlap(out);
+  at::assert_no_overlap(out, self);
+  at::assert_no_overlap(out, index);
 
   const int64_t rank = self.dim();
   const auto idx_host = read_index_to_host(index, "index_select");
@@ -103,7 +112,12 @@ at::Tensor& index_select_out_rbln(const at::Tensor& self, int64_t dim, const at:
     auto dst_view = out.narrow(axis, run.pos, run.length);
     strided_v2v_copy(dst_view, src_view, batch);
   }
-  batch.submit();
+  submit_or_fallback(batch, "index_select_out_rbln", [&] {
+    const auto cpu_self = self.cpu();
+    const auto cpu_index = index.cpu();
+    const auto cpu_out = at::index_select(cpu_self, dim, cpu_index);
+    out.copy_(cpu_out);
+  });
 
   return out;
 }
@@ -162,6 +176,12 @@ at::Tensor& index_copy_out_rbln(
       "index_copy: source dtype {} doesn't match self dtype {}",
       c10::str(source.scalar_type()),
       c10::str(self.scalar_type()));
+
+  // Mirror upstream PyTorch's `aten::index_copy.out` overlap checks
+  // (self ↔ out aliasing excluded — in-place dispatch pattern).
+  at::assert_no_internal_overlap(out);
+  at::assert_no_overlap(out, index);
+  at::assert_no_overlap(out, source);
 
   const int64_t rank = self.dim();
   const auto idx_host = read_index_to_host(index, "index_copy");
@@ -294,7 +314,13 @@ at::Tensor& index_copy_out_rbln(
       auto dst_view = out.narrow(axis, run.value, run.length);
       strided_v2v_copy(dst_view, src_view, batch);
     }
-    batch.submit();
+    submit_or_fallback(batch, "index_copy_out_rbln", [&] {
+      const auto cpu_self = self.cpu();
+      const auto cpu_index = index.cpu();
+      const auto cpu_source = source.cpu();
+      const auto cpu_out = at::index_copy(cpu_self, dim, cpu_index, cpu_source);
+      out.copy_(cpu_out);
+    });
   }
 
   return out;

--- a/aten/src/ATen/native/rbln/RBLNTensorShape.cpp
+++ b/aten/src/ATen/native/rbln/RBLNTensorShape.cpp
@@ -4,8 +4,10 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/native/Resize.h>
 #include <ATen/native/rbln/RBLNStridedV2V.h>
+#include <ATen/ops/cat.h>
 #include <ATen/ops/empty.h>
 #include <c10/core/ScalarType.h>
+#include <c10/rbln/RBLNFallbackConfig.h>
 #include <c10/rbln/RBLNLogging.h>
 #include <c10/rbln/RBLNV2VBatch.h>
 #include <c10/util/Exception.h>
@@ -126,6 +128,12 @@ at::Tensor& cat_out_rbln(const at::ITensorListRef& tensors, int64_t dim, at::Ten
       c10::str(out.scalar_type()),
       c10::str(common_dtype));
 
+  // Mirror upstream PyTorch's `aten::cat.out` overlap checks.
+  at::assert_no_internal_overlap(out);
+  for (const auto& t : inputs) {
+    at::assert_no_overlap(out, t);
+  }
+
   // Resize via the upstream helper so a wrong-shape non-empty `out` triggers
   // the canonical UserWarning ("An output with one or more elements was
   // resized...").
@@ -150,13 +158,6 @@ at::Tensor& cat_out_rbln(const at::ITensorListRef& tensors, int64_t dim, at::Ten
     return out;
   }
 
-  // Reject any input that overlaps the output storage. In-place cat is not
-  // supported; we rely on upstream `at::assert_no_overlap` so the overlap
-  // detection matches PyTorch's semantics (full / partial / too-hard).
-  for (const at::Tensor& t : inputs) {
-    at::assert_no_overlap(out, t);
-  }
-
   // Per-input slab copy: `out.narrow(axis, axis_offset, n)` carves out the
   // destination view for one input; the engine handles whatever stride
   // pattern the input has. All sub-copies share a single V2VBatch so any
@@ -175,7 +176,15 @@ at::Tensor& cat_out_rbln(const at::ITensorListRef& tensors, int64_t dim, at::Ten
     strided_v2v_copy(dst_view, t, batch);
     axis_offset += extent;
   }
-  batch.submit();
+  submit_or_fallback(batch, "cat_out_rbln", [&] {
+    std::vector<at::Tensor> cpu_tensors;
+    cpu_tensors.reserve(inputs.size());
+    for (const auto& t : inputs) {
+      cpu_tensors.push_back(t.cpu());
+    }
+    const auto cpu_out = at::cat(cpu_tensors, axis);
+    out.copy_(cpu_out);
+  });
 
   return out;
 }

--- a/c10/rbln/RBLNFallbackConfig.cpp
+++ b/c10/rbln/RBLNFallbackConfig.cpp
@@ -10,7 +10,8 @@ namespace c10::rbln {
 
 namespace {
 
-const std::set<std::string> kValidOptions = {"all", "compile_error", "non_blocking_copy", "unsupported_op"};
+const std::set<std::string> kValidOptions =
+    {"all", "compile_error", "non_blocking_copy", "strided_copy_error", "unsupported_op"};
 
 } // namespace
 

--- a/c10/rbln/RBLNFallbackConfig.h
+++ b/c10/rbln/RBLNFallbackConfig.h
@@ -12,7 +12,7 @@ namespace c10::rbln {
  * Parses the `TORCH_RBLN_DISABLE_FALLBACK` environment variable (comma-separated)
  * and returns true if the given category or 'all' is present.
  *
- * Valid categories: all, compile_error, non_blocking_copy, unsupported_op
+ * Valid categories: all, compile_error, non_blocking_copy, strided_copy_error, unsupported_op
  *
  * @param category The fallback category to check.
  * @return true if the category is disabled, false otherwise.

--- a/c10/rbln/RBLNFunctions.cpp
+++ b/c10/rbln/RBLNFunctions.cpp
@@ -336,7 +336,8 @@ void memcpy_v2v_multi(const std::vector<V2VCopyOp>& copies) {
         reinterpret_cast<uint64_t>(c.src), reinterpret_cast<uint64_t>(c.dst), static_cast<uint64_t>(c.nbytes));
   }
   RBLN_LOG_DEBUG("Calling rbln_memcpy_v2v_multi: n_copies={}", copies.size());
-  RBLN_CHECK(!::rbln::rbln_memcpy_v2v_multi(rbln_copies));
+  // Error message matched by `at::native::rbln::submit_or_fallback` to gate CPU fallback — keep stable.
+  RBLN_CHECK(!::rbln::rbln_memcpy_v2v_multi(rbln_copies), "rbln_memcpy_v2v_multi failed");
 }
 
 c10::CachingDeviceAllocator::DeviceStats get_device_stats(const c10::Device& device) {

--- a/c10/rbln/RBLNV2VBatch.cpp
+++ b/c10/rbln/RBLNV2VBatch.cpp
@@ -137,6 +137,17 @@ void V2VBatch::submit() {
   if (!impl_ || impl_->pending.empty()) {
     return;
   }
+  // RAII guard: reset batch state on any exit so the destructor's
+  // "missing submit()" warning fires only when submit() was genuinely skipped.
+  struct ResetGuard {
+    Impl* impl;
+    ~ResetGuard() noexcept {
+      impl->pending.clear();
+      impl->homogeneous = true;
+      impl->anchor = -1;
+    }
+  } guard{impl_.get()};
+
   if (impl_->homogeneous) {
     RBLN_LOG_DEBUG("V2VBatch::submit draining {} entries (batched)", impl_->pending.size());
     memcpy_v2v_multi(impl_->pending);
@@ -147,9 +158,6 @@ void V2VBatch::submit() {
       memcpy_v2v(e.dst, e.src, e.nbytes);
     }
   }
-  impl_->pending.clear();
-  impl_->homogeneous = true;
-  impl_->anchor = -1;
 }
 
 size_t V2VBatch::pending_count() const {

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -57,12 +57,13 @@ export TORCH_RBLN_DISABLE_FALLBACK=compile_error,unsupported_op
 
 The value is a **comma-separated list** of fallback categories to disable:
 
-| Category            | Fallback behavior (default)                            | When disabled                                         |
-|---------------------|--------------------------------------------------------|-------------------------------------------------------|
-| `compile_error`     | `torch.compile` failures fall back to CPU execution    | Raises the compilation error directly                 |
-| `non_blocking_copy` | Non-blocking copy silently falls back to blocking copy | Raises an error instead of degrading to blocking copy |
-| `unsupported_op`    | Unsupported RBLN ops silently fall back to CPU         | Raises an error listing the unsupported operator      |
-| `all`               | —                                                      | Disables **all** of the above fallbacks               |
+| Category             | Fallback behavior (default)                              | When disabled                                         |
+|----------------------|----------------------------------------------------------|-------------------------------------------------------|
+| `compile_error`      | `torch.compile` failures fall back to CPU execution      | Raises the compilation error directly                 |
+| `non_blocking_copy`  | Non-blocking copy silently falls back to blocking copy   | Raises an error instead of degrading to blocking copy |
+| `strided_copy_error` | Batched strided copy failures fall back to CPU execution | Raises the underlying error directly                  |
+| `unsupported_op`     | Unsupported RBLN ops silently fall back to CPU execution | Raises an error listing the unsupported operator      |
+| `all`                | —                                                        | Disables **all** of the above fallbacks               |
 
 **Examples:**
 

--- a/test/rbln/test_cat_index_select_v2v.py
+++ b/test/rbln/test_cat_index_select_v2v.py
@@ -258,6 +258,15 @@ class TestCatV2V(TestCase):
         with pytest.raises((RuntimeError, IndexError)):
             torch.cat([to_dev(a_cpu), to_dev(a_cpu)], dim=5)
 
+    @dtypes(*ENGINE_DTYPES)
+    def test_cat_out_internal_overlap_rejected(self, dtype):
+        """``out`` with internal overlap (broadcast view) must raise ``RuntimeError``."""
+        a = torch.arange(12, dtype=dtype, device=DEVICE).reshape(3, 4)
+        b = torch.arange(100, 112, dtype=dtype, device=DEVICE).reshape(3, 4)
+        out = torch.empty(1, 8, dtype=dtype, device=DEVICE).expand(3, 8)
+        with pytest.raises(RuntimeError):
+            torch.cat([a, b], dim=1, out=out)
+
     # ---- opinfo conformance regressions ----
 
     def test_cat_all_zero_axis_resizes_out_to_zero(self):
@@ -305,6 +314,30 @@ class TestCatV2V(TestCase):
         got = torch.cat([to_dev(a_cpu), to_dev(b_cpu)], dim=1)
         assert got.dtype == torch.float64
         _check(got, expected, atol=1e-3, rtol=1e-3)
+
+    @dtypes(*ENGINE_DTYPES)
+    def test_cat_out_non_contig_routes_through_staging(self, dtype):
+        """Non-contig ``out`` exercises the staging-buffer path."""
+        a_cpu = torch.arange(12, dtype=dtype).reshape(3, 4)
+        b_cpu = torch.arange(100, 112, dtype=dtype).reshape(3, 4)
+        expected = torch.cat([a_cpu, b_cpu], dim=0)
+        out = torch.empty(4, 6, dtype=dtype, device=DEVICE).t()
+        self.assertFalse(out.is_contiguous())
+        torch.cat([to_dev(a_cpu), to_dev(b_cpu)], dim=0, out=out)
+        _check(out, expected)
+
+    @pytest.mark.usefixtures("enable_eager_malloc")
+    def test_large_strided_cat(self):
+        """``aten::cat`` over a large batched strided copy."""
+        # Baseline allocations exercise the bulk strided copy path.
+        baseline_allocs = [torch.empty(102400, 2560, dtype=torch.float16, device=DEVICE) for _ in range(2)]
+        try:
+            a = torch.empty(4, 40, 1024, dtype=torch.float16, device=DEVICE).transpose(1, 2)
+            b = torch.empty(4, 40, 1024, dtype=torch.float16, device=DEVICE).transpose(1, 2)
+            out = torch.cat([a, b], dim=-1)
+            self.assertEqual(tuple(out.shape), (4, 1024, 80))
+        finally:
+            del baseline_allocs
 
 
 # ---------------------------------------------------------------------------
@@ -525,6 +558,17 @@ class TestIndexSelectV2V(TestCase):
         got = torch.index_select(to_dev(a_cpu), neg, idx)
         _check(got, expected)
 
+    @dtypes(*ENGINE_DTYPES)
+    def test_index_select_out_non_contig_routes_through_staging(self, dtype):
+        """Non-contig ``out`` exercises the staging-buffer path."""
+        src_cpu = torch.arange(20, dtype=dtype).reshape(4, 5)
+        idx = torch.tensor([3, 0, 2], dtype=torch.long)
+        expected = torch.index_select(src_cpu, 0, idx)
+        out = torch.empty(5, 3, dtype=dtype, device=DEVICE).t()
+        self.assertFalse(out.is_contiguous())
+        torch.index_select(to_dev(src_cpu), 0, idx, out=out)
+        _check(out, expected)
+
     # ---- error paths ----
 
     def test_index_select_2d_index_rejected(self):
@@ -533,6 +577,23 @@ class TestIndexSelectV2V(TestCase):
         idx_2d = torch.tensor([[0, 1], [2, 3]], dtype=torch.long)
         with pytest.raises(RuntimeError):
             torch.index_select(to_dev(a_cpu), 0, idx_2d)
+
+    @dtypes(*ENGINE_DTYPES)
+    def test_index_select_out_aliased_with_self_rejected(self, dtype):
+        """``out`` aliased with ``self`` must raise ``RuntimeError``."""
+        a = torch.arange(5, dtype=dtype, device=DEVICE)
+        idx = torch.tensor([1, 0], dtype=torch.long)
+        with pytest.raises(RuntimeError):
+            torch.index_select(a, 0, idx, out=a)
+
+    @dtypes(*ENGINE_DTYPES)
+    def test_index_select_out_internal_overlap_rejected(self, dtype):
+        """``out`` with internal overlap (broadcast view) must raise ``RuntimeError``."""
+        src = torch.arange(20, dtype=dtype, device=DEVICE).reshape(4, 5)
+        idx = torch.tensor([0, 2], dtype=torch.long)
+        out = torch.empty(1, 5, dtype=dtype, device=DEVICE).expand(2, 5)
+        with pytest.raises(RuntimeError):
+            torch.index_select(src, 0, idx, out=out)
 
     def test_index_select_oob_index_rejected(self):
         """Out-of-range index value must error, not silently corrupt output."""

--- a/test/rbln/test_index_copy_v2v.py
+++ b/test/rbln/test_index_copy_v2v.py
@@ -333,6 +333,26 @@ class TestIndexCopyV2V(TestCase):
         with pytest.raises(RuntimeError):
             torch.index_copy(self_dev, 0, idx_dev, bad_src)
 
+    @dtypes(*ENGINE_DTYPES)
+    def test_out_source_overlap_rejected(self, dtype):
+        """``out`` and ``source`` sharing storage (``source`` is a slice of ``out``) must raise ``RuntimeError``."""
+        self_ref = _to_dev(_arange((5,), dtype))
+        idx = torch.tensor([0, 2], dtype=torch.long)
+        out = _to_dev(_arange((5,), dtype))
+        source = out[1:3]
+        with pytest.raises(RuntimeError):
+            torch.index_copy(self_ref, 0, idx, source, out=out)
+
+    @dtypes(*ENGINE_DTYPES)
+    def test_out_internal_overlap_rejected(self, dtype):
+        """``out`` with internal overlap (broadcast view) must raise ``RuntimeError``."""
+        self_ref = _to_dev(_arange((2, 4), dtype))
+        source = _to_dev(_arange((1, 4), dtype))
+        idx = torch.tensor([0], dtype=torch.long)
+        out = torch.empty(1, 4, dtype=dtype, device=DEVICE).expand(2, 4)
+        with pytest.raises(RuntimeError):
+            torch.index_copy(self_ref, 0, idx, source, out=out)
+
     # ---- large / stress ----
 
     def test_large_consecutive_run(self):


### PR DESCRIPTION
## Summary of Changes

Hardens the three strided-copy-based op kernels (`cat`, `index_select`, `index_copy`) with an op-level CPU fallback and upstream-parity overlap checks. The fallback is enabled by default, gated on a new `strided_copy_error` category in `TORCH_RBLN_DISABLE_FALLBACK`.

The kernels have two robustness issues. First, the backend can fail on a large batched strided copy, breaking downstream model execution; the fallback keeps models running until the upstream backend is fixed. Second, the kernels lack the overlap checks that PyTorch's out variants enforce, so aliased inputs can produce silently incorrect results.

The fallback is narrowly scoped: only the batched-copy failure routes to CPU recomputation, while validation and other backend errors propagate so caller-side bugs still surface. The overlap checks exclude `index_copy`'s `self ↔ out` case, its legitimate in-place pattern.

---

## Type of Change

- [x] `core` — Changes to RBLN backend, device layer, C++ extension, op registration, or `torch.compile` integration
- [x] `fix` — Bug fix

---

## Affected Modules

- [x] Ops/Kernels
- [x] C++ extension (`torch_rbln/csrc`)
- [x] Docs

---

## Checklist

* [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
* [x] Linting passes — see [Linting](docs/LINTING.md)
* [x] All CI tests pass — see [CI/CD Workflows](docs/WORKFLOWS.md)
* [x] Relevant documentation has been updated (if applicable)

---
