### PR TITLE
docs(install): add .netrc setup guide for rebel_compiler access credential

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ For **`rebel-compiler`** and the rest of the setup, see **Prerequisites** above 
 ### Build from source
 
 1. Install **[uv](https://docs.astral.sh/uv/getting-started/installation/)** (see [Installation — Prerequisites](https://docs.rbln.ai/latest/software/rbln_pytorch/installation.html#prerequisites) in the SDK docs).
-2. Follow **[Build from source](https://docs.rbln.ai/latest/software/rbln_pytorch/installation.html#build-from-source-advanced)** (venv, **`rebel-compiler`**, editable build, manual steps).
+2. Configure access to the RBLN package index (see [Authenticate to the RBLN package index](#authenticate-to-the-rbln-package-index) below).
+3. Follow **[Build from source](https://docs.rbln.ai/latest/software/rbln_pytorch/installation.html#build-from-source-advanced)** (venv, **`rebel-compiler`**, editable build, manual steps).
 
 ```bash
 git clone https://github.com/RBLN-SW/torch-rbln.git
@@ -51,6 +52,30 @@ uv venv .venv && source .venv/bin/activate
 ```
 
 **`rebel-compiler`** must be available in the same environment before the **`torch-rbln`** build finishes (see Prerequisites).
+
+#### Authenticate to the RBLN package index
+
+**`rebel-compiler`** is installed from the RBLN package index (`pypi.rbln.ai`), which requires an **[RBLN Portal account](https://docs.rbln.ai/latest/supports/contact_us.html#rbln-portal)**. Without credentials, `./tools/dev-setup.sh pypi` fails with:
+
+```
+❌ Cannot reach any rbln pypi index (no permission or network error).
+```
+
+Add your RBLN Portal credentials to `~/.netrc` so `pip`/`uv` can authenticate:
+
+```
+machine pypi.rbln.ai
+login <your-rbln-portal-id>
+password <your-rbln-portal-password>
+```
+
+Then restrict its permissions (tools refuse a world-readable `.netrc`):
+
+```bash
+chmod 600 ~/.netrc
+```
+
+Re-run `./tools/dev-setup.sh pypi` once the file is in place.
 
 ## Documentation
 

--- a/tools/dev-setup.sh
+++ b/tools/dev-setup.sh
@@ -79,6 +79,16 @@ check_rebel_index_access() {
     echo "   Checked with uv (same auth as install):"
     echo "   - pypi.rbln.ai: no access"
     echo ""
+    echo "   This usually means credentials for pypi.rbln.ai are missing."
+    echo "   Add your RBLN Portal account to ~/.netrc:"
+    echo ""
+    echo "       machine pypi.rbln.ai"
+    echo "       login <your-rbln-portal-id>"
+    echo "       password <your-rbln-portal-password>"
+    echo ""
+    echo "   Then: chmod 600 ~/.netrc  and re-run this script."
+    echo "   See README.md → 'Authenticate to the RBLN package index'."
+    echo ""
     exit 1
 }
 


### PR DESCRIPTION
## Summary

Running `./tools/dev-setup.sh pypi` without credentials for the RBLN package index (`pypi.rbln.ai`) fails with:

```
❌ Cannot reach any rbln pypi index (no permission or network error).
```

This adds a guide for configuring `~/.netrc` with an **RBLN Portal account** so `pip`/`uv` can authenticate when installing `rebel-compiler`.

## Changes

- **`README.md`** — new "Authenticate to the RBLN package index" subsection under *Build from source*, covering the `~/.netrc` format (`machine`/`login`/`password`), `chmod 600`, and re-running the setup script.
- **`tools/dev-setup.sh`** — the "Cannot reach any rbln pypi index" error now prints the `.netrc` setup steps and points at the new README section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)