### PR TITLE
fix(c10d): warn instead of throw when RBLN_RDMA_IP auto-discovery fails

### DIFF
--- a/torch_rbln/csrc/distributed/c10d/rbln/RdmaIpAutoDiscovery.cpp
+++ b/torch_rbln/csrc/distributed/c10d/rbln/RdmaIpAutoDiscovery.cpp
@@ -389,13 +389,9 @@ void DoOnce() {
     }
   }
 
-  // Final state log: recent librbln-ccl no longer needs RBLN_RDMA_IP on
-  // single-node runs, so missing-IP is no longer fatal even when
-  // RCCL_PORT_GEN is set. We cannot distinguish single- vs multi-node here
-  // (the world topology is decided later by ProcessGroupRBLN init), so
-  // warn loudly when RCCL_PORT_GEN is set without an IP and let the
-  // runtime decide whether the call is single-node (proceeds) or
-  // multi-node (will fail at RCCL init with its own diagnostics).
+  // No IP found. Missing-IP is no longer fatal: we can't tell single- vs
+  // multi-node here, so warn (when RCCL_PORT_GEN is set) and defer the
+  // decision to the runtime. See the header for the full contract.
   const char* port_gen_env = std::getenv("RCCL_PORT_GEN");
   const bool use_autoport = (port_gen_env != nullptr && port_gen_env[0] != '\0');
   const char* final_ip = std::getenv(kEnvRdmaIp);
@@ -405,13 +401,10 @@ void DoOnce() {
   }
   if (use_autoport) {
     RBLN_LOG_WARN(
-        "{} RCCL_PORT_GEN is set but {} could not be determined. "
-        "Single-node runs continue without it (recent librbln-ccl no longer "
-        "requires an IP); multi-node runs will fail later at RCCL init. To "
-        "pin an address explicitly set {} in the environment, or ensure "
-        "/sys/class/infiniband exposes a RoCE v2 capable device with an "
-        "ACTIVE port and an IPv4-assigned netdev. See [rbln_rdma_probe] "
-        "diagnostics above for the auto-discovery failure stage.",
+        "{} RCCL_PORT_GEN set but {} unresolved. Single-node runs continue; "
+        "multi-node will fail at RCCL init. To pin it set {}, or ensure "
+        "/sys/class/infiniband has a RoCE v2 ACTIVE port with an IPv4 netdev. "
+        "See [rbln_rdma_probe] above.",
         kDiagPrefix,
         kEnvRdmaIp,
         kEnvRdmaIp);

--- a/torch_rbln/csrc/distributed/c10d/rbln/RdmaIpAutoDiscovery.cpp
+++ b/torch_rbln/csrc/distributed/c10d/rbln/RdmaIpAutoDiscovery.cpp
@@ -389,10 +389,13 @@ void DoOnce() {
     }
   }
 
-  // Gate: RCCL_PORT_GEN-enabled runs require RBLN_RDMA_IP. Without it, the
-  // RCCL autoport init path in ProcessGroupRBLN cannot bind a remote
-  // endpoint and InitRBLNWork would fail deep inside the runtime with a
-  // less-actionable message. Surface the misconfiguration here.
+  // Final state log: recent librbln-ccl no longer needs RBLN_RDMA_IP on
+  // single-node runs, so missing-IP is no longer fatal even when
+  // RCCL_PORT_GEN is set. We cannot distinguish single- vs multi-node here
+  // (the world topology is decided later by ProcessGroupRBLN init), so
+  // warn loudly when RCCL_PORT_GEN is set without an IP and let the
+  // runtime decide whether the call is single-node (proceeds) or
+  // multi-node (will fail at RCCL init with its own diagnostics).
   const char* port_gen_env = std::getenv("RCCL_PORT_GEN");
   const bool use_autoport = (port_gen_env != nullptr && port_gen_env[0] != '\0');
   const char* final_ip = std::getenv(kEnvRdmaIp);
@@ -400,12 +403,20 @@ void DoOnce() {
   if (have_ip) {
     return;
   }
-  RBLN_CHECK(
-      !use_autoport,
-      "RCCL_PORT_GEN is set but RBLN_RDMA_IP could not be determined. "
-      "Set RBLN_RDMA_IP explicitly, or ensure /sys/class/infiniband exposes a "
-      "RoCE v2 capable device with an ACTIVE port and an IPv4-assigned netdev. "
-      "See [rbln_rdma_probe] diagnostics above for the failure stage.");
+  if (use_autoport) {
+    RBLN_LOG_WARN(
+        "{} RCCL_PORT_GEN is set but {} could not be determined. "
+        "Single-node runs continue without it (recent librbln-ccl no longer "
+        "requires an IP); multi-node runs will fail later at RCCL init. To "
+        "pin an address explicitly set {} in the environment, or ensure "
+        "/sys/class/infiniband exposes a RoCE v2 capable device with an "
+        "ACTIVE port and an IPv4-assigned netdev. See [rbln_rdma_probe] "
+        "diagnostics above for the auto-discovery failure stage.",
+        kDiagPrefix,
+        kEnvRdmaIp,
+        kEnvRdmaIp);
+    return;
+  }
   RDMA_DIAG("RBLN_RDMA_IP unresolved, but RCCL_PORT_GEN is not set -- RDMA IP not required, continuing");
 }
 

--- a/torch_rbln/csrc/distributed/c10d/rbln/RdmaIpAutoDiscovery.hpp
+++ b/torch_rbln/csrc/distributed/c10d/rbln/RdmaIpAutoDiscovery.hpp
@@ -30,7 +30,10 @@ namespace torch_rbln::detail {
 // capable device whose port is ACTIVE and whose netdev has an IPv4 matching
 // the GID table. Idempotent (c10::once_flag inside). Respects pre-set
 // RBLN_RDMA_IP (does not overwrite). Set RBLN_DISABLE_AUTO_RDMA_IP=1 to skip.
-// Throws (via RBLN_CHECK) when RCCL_PORT_GEN is set but no IP can be found.
+// Never throws: when no IP can be found, logs a warning (if RCCL_PORT_GEN
+// is set) or an info diagnostic (otherwise) and lets librbln-ccl decide
+// whether to fail at RCCL init -- recent librbln-ccl no longer requires
+// RBLN_RDMA_IP on single-node runs.
 void MaybeAutoDiscoverRbnRdmaIp();
 
 } // namespace torch_rbln::detail


### PR DESCRIPTION
## Summary of Changes

When ``MaybeAutoDiscoverRbnRdmaIp()`` cannot find an IP and
``RCCL_PORT_GEN`` is set, emit ``RBLN_LOG_WARN`` instead of throwing
``RBLN_CHECK``. Recent librbln-ccl no longer requires ``RBLN_RDMA_IP``
on single-node runs, so the previous hard failure broke dev/CI
machines that don't have RDMA hardware (e.g. K8s pods where
``/sys/class/infiniband`` is empty).

The world topology is decided later by ``ProcessGroupRBLN`` init, so
we cannot distinguish single- vs multi-node at the point of the
discovery probe. Defer the actual policy to the runtime:

- Single-node run: librbln-ccl proceeds without ``RBLN_RDMA_IP``.
- Multi-node run that genuinely needs the IP: fails later at RCCL
  init with the runtime's own diagnostics.

The non-autoport branch (``RCCL_PORT_GEN`` unset) keeps its existing
informational log; the warning only fires when the user asked for
autoport but no IP could be discovered.

Header doc updated to drop the "Throws (via ``RBLN_CHECK``)" guarantee.

---

## Related Issues / Tickets

* Related to #54 (introduced the now-relaxed gate)

---

## Type of Change

- [x] ``fix`` — Bug fix
- [x] ``core`` — Changes to RBLN backend, device layer, C++ extension, op registration, or ``torch.compile`` integration

---

## Affected Modules

- [x] Backend
- [x] C++ extension (``torch_rbln/csrc``)

---

## How to Test

1. Build: ``./tools/dev-setup.sh external --clean``
2. **No-RDMA host (e.g. ``kurie-13`` / K8s pod where ``/sys/class/infiniband`` is empty)** — single-node autoport sanity:
   ```bash
   RCCL_PORT_GEN=1 python -m test.distributed.test_process_group
   ```
   Expected (after this fix): completes successfully; ``[rbln_rdma_probe]``
   diagnostics show no candidate; one ``RBLN_LOG_WARN`` line appears
   noting "RCCL_PORT_GEN is set but RBLN_RDMA_IP could not be determined".
   Pre-fix behavior: ``RBLN_CHECK`` throw at ProcessGroupRBLN ctor.
3. **RDMA-capable host** — regression check, behavior unchanged:
   ```bash
   python -m test.distributed.test_tp_pp_autoport
   ```
   Expected: ``RBLN_RDMA_IP`` auto-discovered, no warning. Identical to
   pre-fix behavior on RDMA-capable hosts.
4. **Explicit override**: ``RBLN_RDMA_IP=<ipv4>`` set in env — probe
   short-circuits, no warning, no behavior change.

---

## Screenshots / Logs

New warning on no-RDMA host:
```
[W] [rbln_rdma_probe] RCCL_PORT_GEN is set but RBLN_RDMA_IP could not be
determined. Single-node runs continue without it (recent librbln-ccl no
longer requires an IP); multi-node runs will fail later at RCCL init.
To pin an address explicitly set RBLN_RDMA_IP in the environment, or
ensure /sys/class/infiniband exposes a RoCE v2 capable device with an
ACTIVE port and an IPv4-assigned netdev. See [rbln_rdma_probe]
diagnostics above for the auto-discovery failure stage.
```

---

## Checklist

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to a corresponding issue
* [x] Linting passes
* [ ] All CI tests pass
* [x] The test method is described, and the expected result is clearly stated
* [x] Relevant documentation has been updated (header comment)

---

## Notes

- This is still part of the temporary auto-discovery workaround that
  retires once librbln-ccl performs the discovery internally. Header
  removal procedure is unchanged.
- The ``RBLN_DISABLE_AUTO_RDMA_IP=1`` escape hatch is still honored.