### PR TITLE
perf(copy): route strided copy_ through on-device v2v engine

### DIFF
--- a/aten/src/ATen/native/rbln/RBLNCopy.cpp
+++ b/aten/src/ATen/native/rbln/RBLNCopy.cpp
@@ -1,6 +1,8 @@
 // TODO: The previous copy optimizations based on physical shape and physical dtype were removed during
 // v-memory integration. Revisit these optimizations in a future pass.
 #include <ATen/native/rbln/RBLNCopy.h>
+#include <ATen/native/rbln/RBLNStrideUtils.h>
+#include <ATen/native/rbln/RBLNStridedV2V.h>
 #include <ATen/native/rbln/RBLNTensorUtils.h>
 #include <ATen/ops/empty.h>
 #include <ATen/ops/empty_strided.h>
@@ -103,21 +105,38 @@ void tensor_copy_from_rbln_to_rbln(const at::Tensor& rbln_src, const at::Tensor&
   RBLN_LOG_DEBUG("src_data={}, dst_data={}", fmt::ptr(rbln_src.data_ptr()), fmt::ptr(rbln_dst.data_ptr()));
   RBLN_CHECK(rbln_src.device().is_privateuseone() && rbln_dst.device().is_privateuseone());
 
-  const auto direct_copy = is_direct_copy(rbln_src, rbln_dst);
-  if (direct_copy) {
+  if (is_direct_copy(rbln_src, rbln_dst)) {
     RBLN_LOG_DEBUG("Directly copying RBLN src to RBLN dst");
 
     auto* dst_data = rbln_dst.data_ptr();
     const auto* src_data = rbln_src.data_ptr();
     const auto nbytes = at::detail::computeStorageNbytes(rbln_src.sizes(), rbln_src.strides(), rbln_src.element_size());
     c10::rbln::memcpy_v2v(dst_data, src_data, nbytes);
-  } else {
-    RBLN_LOG_DEBUG("Creating CPU copy of RBLN src");
-    const auto cpu_src = at::native::rbln::get_cpu_copy_of_rbln_tensor(rbln_src);
-
-    RBLN_LOG_DEBUG("Copying CPU copy to RBLN dst");
-    tensor_copy_from_cpu_to_rbln(cpu_src, rbln_dst);
+    return;
   }
+
+  // Strided copy: route to the on-device v2v engine while the outer iteration
+  // count stays within the runtime per-dst v2v cap (kMaxV2VMultiCopies); above
+  // it the engine fans out to a host fallback anyway, so bounce via host here.
+  constexpr int64_t kMaxStridedV2VOuter = 1024;
+  if (rbln_src.sizes() == rbln_dst.sizes() && rbln_src.scalar_type() == rbln_dst.scalar_type() &&
+      rbln_src.device() == rbln_dst.device()) {
+    const auto inner_start = common_inner_start(rbln_src.sizes(), rbln_src.strides(), rbln_dst.strides());
+    int64_t outer_count = 1;
+    for (int64_t i = 0; i < inner_start; ++i) {
+      outer_count *= rbln_src.size(i);
+    }
+    if (outer_count <= kMaxStridedV2VOuter) {
+      strided_v2v_copy(rbln_dst, rbln_src);
+      return;
+    }
+  }
+
+  RBLN_LOG_DEBUG("Creating CPU copy of RBLN src");
+  const auto cpu_src = at::native::rbln::get_cpu_copy_of_rbln_tensor(rbln_src);
+
+  RBLN_LOG_DEBUG("Copying CPU copy to RBLN dst");
+  tensor_copy_from_cpu_to_rbln(cpu_src, rbln_dst);
 }
 
 void copy_impl_rbln(const at::Tensor& src, const at::Tensor& dst) {

--- a/aten/src/ATen/native/rbln/RBLNCopy.cpp
+++ b/aten/src/ATen/native/rbln/RBLNCopy.cpp
@@ -9,6 +9,7 @@
 #include <c10/rbln/RBLNFallbackConfig.h>
 #include <c10/rbln/RBLNFunctions.h>
 #include <c10/rbln/RBLNLogging.h>
+#include <rebel/runtime/api/rbln_runtime_api.h>
 
 namespace at::native::rbln {
 
@@ -116,9 +117,9 @@ void tensor_copy_from_rbln_to_rbln(const at::Tensor& rbln_src, const at::Tensor&
   }
 
   // Strided copy: route to the on-device v2v engine while the outer iteration
-  // count stays within the runtime per-dst v2v cap (kMaxV2VMultiCopies); above
-  // it the engine fans out to a host fallback anyway, so bounce via host here.
-  constexpr int64_t kMaxStridedV2VOuter = 1024;
+  // count stays within the runtime per-dst v2v cap (::rbln::kMaxV2VMultiCopies,
+  // the single source shared with the runtime); above it the engine fans out to
+  // a host fallback anyway, so bounce via host here.
   if (rbln_src.sizes() == rbln_dst.sizes() && rbln_src.scalar_type() == rbln_dst.scalar_type() &&
       rbln_src.device() == rbln_dst.device()) {
     const auto inner_start = common_inner_start(rbln_src.sizes(), rbln_src.strides(), rbln_dst.strides());
@@ -126,7 +127,7 @@ void tensor_copy_from_rbln_to_rbln(const at::Tensor& rbln_src, const at::Tensor&
     for (int64_t i = 0; i < inner_start; ++i) {
       outer_count *= rbln_src.size(i);
     }
-    if (outer_count <= kMaxStridedV2VOuter) {
+    if (outer_count <= static_cast<int64_t>(::rbln::kMaxV2VMultiCopies)) {
       strided_v2v_copy(rbln_dst, rbln_src);
       return;
     }

--- a/third_party/rebel_compiler/include/rebel/runtime/api/rbln_runtime_api.h
+++ b/third_party/rebel_compiler/include/rebel/runtime/api/rbln_runtime_api.h
@@ -266,6 +266,13 @@ RBLNRetCode rbln_memcpy_v2h(uint64_t src_vaddr, uintptr_t dst_host_ptr, uint64_t
 // Copies the contents from a virtual memory area to another virtual memory area.
 RBLNRetCode rbln_memcpy_v2v(uint64_t src_vaddr, uint64_t dst_vaddr, uint64_t size);
 
+// Maximum number of per-destination sub-copies that rbln_memcpy_v2v_multi
+// dispatches on-device. At or below this count the copies go through the device
+// command buffer; above it the runtime falls back to a host sync (slow but
+// correct). Callers that can compute their fan-out cheaply ahead of time may
+// gate on this to skip building descriptors that would only fall back.
+constexpr uint32_t kMaxV2VMultiCopies = 1024;
+
 // Copies the contents from a virtual memory area to another virtual memory area.
 // copies: vector of tuples (src_vaddr, dst_vaddr, size)
 RBLNRetCode rbln_memcpy_v2v_multi(


### PR DESCRIPTION
## Description

Part of fixing slow device-tensor KV d2d copy (rebellions-sw/vllm-rbln-internal#94). Strided `aten::copy_` on RBLN tensors fell back to a host bounce (device→host→device of the full view span), so KV sub-block copies paid that round-trip on every layer. This routes them to the on-device strided v2v engine when the geometry favors it.

1. **Routing:** non-contiguous, same-shape/dtype, same-device rbln→rbln `copy_` now goes through `strided_v2v_copy` (→ `rbln_memcpy_v2v_multi`) instead of the host bounce. Contiguous copies keep the existing direct `memcpy_v2v` path.
2. **Gate:** routed only when `outer_count <= 1024` (computed in O(rank) from strides, no expansion). Above the cap the runtime per-dst v2v limit (`kMaxV2VMultiCopies`) would fan out to a host fallback anyway, so we bounce via host directly and skip the wasted descriptor expansion.
3. **Paired PR:** rebel_compiler raises `kMaxV2VMultiCopies` to match the 1024 gate — rebellions-sw/rebel_compiler#11250. Both must land together.
