### PR TITLE
test: cover weight handling on module recompilation

### DIFF
--- a/test/rbln/test_graph_eager_mode.py
+++ b/test/rbln/test_graph_eager_mode.py
@@ -414,8 +414,61 @@ class TestGraphEagerMode(TestCase):
         self.assertEqual(eager_out.cpu(), graph_out.cpu(), atol=ATOL, rtol=RTOL)
 
 
+@pytest.mark.test_set_ci
+class TestRecompileWeightHandling(TestCase):
+    """Test cases for weight handling when a module is rebuilt and recompiled under a fixed seed."""
+
+    rbln_device = torch.device("rbln:0")
+
+    class Net(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = nn.Linear(128, 128)
+
+        def forward(self, x):
+            return self.linear(x)
+
+    @dtypes(*SUPPORTED_DTYPES)
+    def test_reseed_recompile_in_loop(self, dtype):
+        """Test that reseeding and recompiling a rebuilt module each iteration produces consistent results."""
+        x = torch.ones([128, 128], device=self.rbln_device, dtype=dtype)
+
+        graph_outs = []
+        for _ in range(2):
+            torch.manual_seed(0)
+            model = self.Net().to(device=self.rbln_device, dtype=dtype)
+
+            eager_out = model(x)
+            compiled_model = torch.compile(model, backend="rbln", dynamic=False)
+            graph_out = compiled_model(x)
+
+            self.assertEqual(eager_out.cpu(), graph_out.cpu(), atol=ATOL, rtol=RTOL)
+            graph_outs.append(graph_out.cpu())
+
+        # Identical seeds → identical weights → identical compiled output.
+        self.assertEqual(graph_outs[0], graph_outs[1], atol=ATOL, rtol=RTOL)
+
+    @dtypes(*SUPPORTED_DTYPES)
+    def test_identical_weights_distinct_models(self, dtype):
+        """Test that two separately built modules with identical weights both compile and match."""
+        x = torch.ones([128, 128], device=self.rbln_device, dtype=dtype)
+
+        torch.manual_seed(0)
+        model_a = self.Net().to(device=self.rbln_device, dtype=dtype)
+        torch.manual_seed(0)
+        model_b = self.Net().to(device=self.rbln_device, dtype=dtype)
+
+        self.assertEqual(model_a.linear.weight.cpu(), model_b.linear.weight.cpu())
+
+        out_a = torch.compile(model_a, backend="rbln", dynamic=False)(x)
+        out_b = torch.compile(model_b, backend="rbln", dynamic=False)(x)
+
+        self.assertEqual(out_a.cpu(), out_b.cpu(), atol=ATOL, rtol=RTOL)
+
+
 instantiate_device_type_tests(TestGraphMode, globals(), only_for="privateuse1")
 instantiate_device_type_tests(TestGraphEagerMode, globals(), only_for="privateuse1")
+instantiate_device_type_tests(TestRecompileWeightHandling, globals(), only_for="privateuse1")
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary of Changes

Adds regression tests for weight handling when a module is rebuilt under a fixed seed and recompiled.

Resetting `torch.manual_seed(0)` before each rebuild makes every module instance carry bit-identical weights. Recompiling such a module must still produce correct, consistent results rather than letting those identical weights interfere with compilation.

Two tests cover this: one reseeds, rebuilds, and recompiles across iterations; the other isolates the identical-weight condition using two separately built modules.

---

## Type of Change

- [x] `other` — Other (describe below)

Test code change only.

---

## Affected Modules

- [x] `torch.compile`

---

## Checklist

* [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
* [x] Linting passes — see [Linting](docs/LINTING.md)
* [x] All CI tests pass — see [CI/CD Workflows](docs/WORKFLOWS.md)
* [x] Relevant documentation has been updated (if applicable)

---
