### PR TITLE
refactor: centralize supported dtype policy

### DIFF
--- a/c10/rbln/CMakeLists.txt
+++ b/c10/rbln/CMakeLists.txt
@@ -19,6 +19,7 @@ set(headers
   RBLNHooksInterface.h
   RBLNLogging.h
   RBLNMacros.h
+  RBLNSupportedDtypes.h
   RBLNV2VBatch.h
 )
 add_library(${target}

--- a/c10/rbln/RBLNSupportedDtypes.h
+++ b/c10/rbln/RBLNSupportedDtypes.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <c10/core/ScalarType.h>
+
+#include <array>
+
+namespace c10::rbln {
+
+// Single source of truth for the RBLN supported dtype catalog.
+// Separate per-path arrays so extensions to `dispatch` (e.g., int dtypes)
+// don't leak into `sdpa` or `amp`, which must stay float-only.
+inline constexpr std::array<c10::ScalarType, 1> kDispatchDtypes = {c10::kHalf};
+inline constexpr std::array<c10::ScalarType, 1> kSdpaDtypes = {c10::kHalf};
+inline constexpr std::array<c10::ScalarType, 1> kAmpDtypes = {c10::kHalf};
+
+constexpr bool is_dispatch_dtype(c10::ScalarType s) noexcept {
+  for (const auto d : kDispatchDtypes) {
+    if (s == d) {
+      return true;
+    }
+  }
+  return false;
+}
+
+} // namespace c10::rbln

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -114,7 +114,7 @@ The value is a **comma-separated list** of fallback case names to disable:
 | `dispatch_mode`  | Falls back to CPU when a non-infra `TorchDispatchMode` is active | Skips the check — risks infinite recursion                    |
 | `trace`          | Falls back to CPU when a Python trace is active (e.g. pdb, coverage) | Skips the check — compile may run under tracer              |
 | `reentrant`      | Falls back to CPU when already inside RBLN compile op (e.g. print/repr, nested op); logs a warning | Skips the check — risks infinite recursion                 |
-| `dtype`          | Falls back when any input tensor is not `torch.float16`          | Sends non-float16 tensors to RBLN — may produce wrong results |
+| `dtype`          | Falls back on unsupported or mismatched tensor dtypes            | Sends such tensors to RBLN — may produce wrong results        |
 | `scalar`         | Falls back when all input tensors are 0-dim scalars              | Sends scalar ops to RBLN — may fail in rebel-compiler         |
 | `storage_offset` | Falls back when a contiguous tensor has `storage_offset != 0`    | Sends offset tensors to RBLN — may read wrong data            |
 | `nan_inf`        | Falls back when inputs contain NaN or Inf (non-deploy mode only) | Skips the NaN/Inf scan — invalid values reach the device      |

--- a/docs/TEST_GUIDE.md
+++ b/docs/TEST_GUIDE.md
@@ -313,7 +313,7 @@ instantiate_device_type_tests(TestRegisteredNativeOps, globals(), only_for="priv
 |----------------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
 | `@requires_logical_devices(N)`         | `pytest.mark.skipif` — skips if `torch.rbln.device_count() < N`.                                                                |
 | `@requires_physical_devices(N)`        | `pytest.mark.skipif` — skips if `torch.rbln.physical_device_count() < N`.                                                       |
-| `SUPPORTED_DTYPES`                     | `[torch.float16]` — the baseline dtype list for RBLN backend tests.                                                             |
+| `SUPPORTED_DTYPES`                     | Baseline dtype list for RBLN backend tests, derived from `torch_rbln._internal.ops_utils.SupportedDtypes.dispatch`.             |
 | `set_deterministic_seeds(seed)`        | Sets torch, numpy, and random seeds. Must be called in each spawned process for reproducibility.                                |
 | `run_in_isolated_process(func, *args)` | Runs `func` in a fresh `spawn`-method process. Useful when tests need clean process state. `func` and `args` must be picklable. |
 

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -5,6 +5,7 @@ set(sources
   core/RBLNDeviceGuardTest.cpp
   core/RBLNFunctionsTest.cpp
   core/RBLNLoggingTest.cpp
+  core/RBLNSupportedDtypesTest.cpp
   core/RBLNTensorUtilsTest.cpp
   core/RBLNV2VBatchTest.cpp
 )

--- a/test/cpp/core/RBLNSupportedDtypesTest.cpp
+++ b/test/cpp/core/RBLNSupportedDtypesTest.cpp
@@ -1,0 +1,85 @@
+#include <c10/rbln/RBLNFunctions.h>
+#include <c10/rbln/RBLNSupportedDtypes.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+
+class RBLNSupportedDtypesTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    c10::register_privateuse1_backend("rbln");
+    ASSERT_TRUE(c10::is_privateuse1_backend_registered());
+    ASSERT_EQ(c10::get_privateuse1_backend(true), "rbln");
+    ASSERT_GE(c10::rbln::get_device_count(), 1);
+  }
+
+  void SetUp() override {
+    c10::rbln::set_device_index(initial_device_index_);
+    ASSERT_EQ(c10::rbln::get_device_index(), initial_device_index_);
+  }
+
+  const c10::DeviceIndex initial_device_index_ = 0;
+};
+
+template <typename Arr, typename T>
+bool contains(const Arr& arr, const T& value) {
+  return std::find(arr.begin(), arr.end(), value) != arr.end();
+}
+
+TEST_F(RBLNSupportedDtypesTest, DispatchCatalogContents) {
+  constexpr c10::ScalarType kExpected[] = {c10::kHalf};
+  for (const auto scalar_type : kExpected) {
+    EXPECT_TRUE(contains(c10::rbln::kDispatchDtypes, scalar_type));
+  }
+}
+
+TEST_F(RBLNSupportedDtypesTest, SdpaCatalogContents) {
+  constexpr c10::ScalarType kExpected[] = {c10::kHalf};
+  for (const auto scalar_type : kExpected) {
+    EXPECT_TRUE(contains(c10::rbln::kSdpaDtypes, scalar_type));
+  }
+}
+
+TEST_F(RBLNSupportedDtypesTest, AmpCatalogContents) {
+  constexpr c10::ScalarType kExpected[] = {c10::kHalf};
+  for (const auto scalar_type : kExpected) {
+    EXPECT_TRUE(contains(c10::rbln::kAmpDtypes, scalar_type));
+  }
+}
+
+TEST_F(RBLNSupportedDtypesTest, SdpaCatalogIsFloatOnly) {
+  for (const auto scalar_type : c10::rbln::kSdpaDtypes) {
+    EXPECT_TRUE(c10::isFloatingType(scalar_type));
+  }
+}
+
+TEST_F(RBLNSupportedDtypesTest, AmpCatalogIsFloatOnly) {
+  for (const auto scalar_type : c10::rbln::kAmpDtypes) {
+    EXPECT_TRUE(c10::isFloatingType(scalar_type));
+  }
+}
+
+TEST_F(RBLNSupportedDtypesTest, IsDispatchDtypeAcceptsAdmitted) {
+  for (const auto scalar_type : c10::rbln::kDispatchDtypes) {
+    EXPECT_TRUE(c10::rbln::is_dispatch_dtype(scalar_type));
+  }
+}
+
+TEST_F(RBLNSupportedDtypesTest, IsDispatchDtypeRejectsUnsupported) {
+  constexpr c10::ScalarType kUnsupported[] = {
+      c10::kFloat,
+      c10::kBFloat16,
+      c10::kInt,
+      c10::kLong,
+      c10::kBool,
+  };
+  for (const auto scalar_type : kUnsupported) {
+    EXPECT_FALSE(c10::rbln::is_dispatch_dtype(scalar_type));
+  }
+}
+
+static_assert(!c10::rbln::kDispatchDtypes.empty(), "dispatch dtype catalog must not be empty");
+static_assert(!c10::rbln::kSdpaDtypes.empty(), "SDPA dtype catalog must not be empty");
+static_assert(!c10::rbln::kAmpDtypes.empty(), "AMP dtype catalog must not be empty");
+static_assert(c10::rbln::is_dispatch_dtype(c10::kHalf), "is_dispatch_dtype must be constexpr");
+static_assert(!c10::rbln::is_dispatch_dtype(c10::kFloat), "is_dispatch_dtype must be constexpr");

--- a/test/rbln/test_internal_op_utils.py
+++ b/test/rbln/test_internal_op_utils.py
@@ -28,6 +28,7 @@ from torch_rbln._internal.ops_utils import (
     is_cpu_fallback_cases,
     is_inplace_op,
     prepare_args_for_contiguous,
+    SupportedDtypes,
 )
 
 
@@ -276,6 +277,38 @@ class TestInternalOpUtils(TestCase):
         self.assertEqual(contig.flatten(), base.flatten())
 
     # =========================================================================
+    # SupportedDtypes.dispatch tests
+    # =========================================================================
+
+    def test_supported_dtypes_dispatch(self):
+        """Tuple of ``float16``; unsupported dtypes are absent."""
+        self.assertIsInstance(SupportedDtypes.dispatch, tuple)
+        self.assertIn(torch.float16, SupportedDtypes.dispatch)
+        self.assertNotIn(torch.float32, SupportedDtypes.dispatch)
+        self.assertNotIn(torch.bool, SupportedDtypes.dispatch)
+
+    def test_supported_dtypes_sdpa(self):
+        """Tuple of ``float16``; the SDPA path must stay float-only."""
+        self.assertIsInstance(SupportedDtypes.sdpa, tuple)
+        self.assertIn(torch.float16, SupportedDtypes.sdpa)
+        self.assertNotIn(torch.float32, SupportedDtypes.sdpa)
+        self.assertNotIn(torch.int32, SupportedDtypes.sdpa)
+
+    def test_supported_dtypes_amp(self):
+        """Tuple of ``float16``; the AMP autocast path must stay float-only."""
+        self.assertIsInstance(SupportedDtypes.amp, tuple)
+        self.assertIn(torch.float16, SupportedDtypes.amp)
+        self.assertNotIn(torch.float32, SupportedDtypes.amp)
+        self.assertNotIn(torch.int32, SupportedDtypes.amp)
+
+    def test_get_amp_supported_dtype_matches_catalog(self):
+        """``get_amp_supported_dtype()`` delegates to ``SupportedDtypes.amp``."""
+        self.assertEqual(
+            tuple(torch.rbln.get_amp_supported_dtype()),
+            SupportedDtypes.amp,
+        )
+
+    # =========================================================================
     # is_cpu_fallback_cases tests
     # =========================================================================
 
@@ -291,6 +324,22 @@ class TestInternalOpUtils(TestCase):
         # Should not fallback for float16 scalar (unless other conditions apply)
         # Note: scalar tensors still trigger fallback, so this may still be True
         # This test now only checks dtype fallback behavior
+
+    def test_is_cpu_fallback_cases_dtype_float16(self):
+        """``float16`` non-scalar tensor passes the dtype gate."""
+        fp16_tensor = torch.tensor([1.0, 2.0], dtype=torch.float16, device="rbln")
+        self.assertFalse(is_cpu_fallback_cases((fp16_tensor,)))
+
+    def test_is_cpu_fallback_cases_dtype_unsupported(self):
+        """Unsupported dtype (e.g. ``float32``) falls back to CPU."""
+        unsupported_fp32_tensor = torch.tensor([1.0, 2.0], dtype=torch.float32, device="rbln")
+        self.assertTrue(is_cpu_fallback_cases((unsupported_fp32_tensor,)))
+
+    def test_is_cpu_fallback_cases_dtype_mixed_unsupported(self):
+        """When any arg uses an unsupported dtype, fall back to CPU."""
+        supported_fp16_tensor = torch.tensor([1.0, 2.0], dtype=torch.float16, device="rbln")
+        unsupported_fp32_tensor = torch.tensor([3.0, 4.0], dtype=torch.float32, device="rbln")
+        self.assertTrue(is_cpu_fallback_cases((supported_fp16_tensor, unsupported_fp32_tensor)))
 
     def test_is_cpu_fallback_cases_trace(self):
         """When sys.gettrace() is set (e.g. pdb, coverage), is_cpu_fallback_cases returns True (0a)."""

--- a/test/utils.py
+++ b/test/utils.py
@@ -7,8 +7,10 @@ import numpy as np
 import pytest
 import torch
 
+from torch_rbln._internal.ops_utils import SupportedDtypes
 
-SUPPORTED_DTYPES = [torch.float16]
+
+SUPPORTED_DTYPES = list(SupportedDtypes.dispatch)
 
 _DEFAULT_DISTRIBUTED_MASTER_PORT = "29604"
 

--- a/torch_rbln/_internal/kernels/sdpa.py
+++ b/torch_rbln/_internal/kernels/sdpa.py
@@ -11,7 +11,7 @@ import torch
 
 from torch_rbln._internal.compile_cache import compile_rbln_cached
 from torch_rbln._internal.log_utils import rbln_log_cpu_fallback
-from torch_rbln._internal.ops_utils import is_cpu_fallback_cases, to_cpu
+from torch_rbln._internal.ops_utils import is_cpu_fallback_cases, SupportedDtypes, to_cpu
 
 
 # --- Attention Weights Cache for Overrideable SDPA ---
@@ -51,13 +51,12 @@ def _any_tensor_subclass(*tensors: torch.Tensor) -> bool:
 
 
 # --- RBLN SDPA Constraints ---
-# HW supports: 3D/4D tensors, float16, 64-byte aligned shapes
+# HW supports: 3D/4D tensors, dtypes in ``SupportedDtypes.sdpa``, 64-byte aligned shapes
 # PyTorch overrideable path requires 4D; non-4D uses SDPBackend::math
 
-RBLN_SDPA_SUPPORTED_DTYPES = {torch.float16}
 RBLN_SDPA_MIN_DIM = 3
 RBLN_SDPA_MAX_DIM = 4
-_RBLN_SDPA_SHAPE_ALIGNMENT = 32  # 64 bytes / 2 bytes (float16)
+_RBLN_SDPA_SHAPE_ALIGNMENT = 32  # 64 bytes / 2 bytes (the supported low-precision floats are all 2 bytes)
 
 
 def needs_sdpa_shape_fallback(
@@ -149,9 +148,11 @@ def can_use_rbln_sdpa(
     except (AttributeError, TypeError):
         pass
 
-    # Only float16 supported on RBLN
-    if query.dtype not in RBLN_SDPA_SUPPORTED_DTYPES:
+    if query.dtype not in SupportedDtypes.sdpa:
         return False, f"dtype {query.dtype} not supported"
+
+    if key.dtype != query.dtype or value.dtype != query.dtype:
+        return False, f"Q/K/V dtype mismatch (query {query.dtype}, key {key.dtype}, value {value.dtype})"
 
     if dropout_p > 0.0 and (query.requires_grad or key.requires_grad or value.requires_grad):
         return False, "dropout with gradients"
@@ -241,6 +242,11 @@ def _merge_masks(
 # --- CPU Fallback (using PyTorch's native SDPA) ---
 
 
+def _sdpa_fallback_compute_dtype(input_dtype: torch.dtype) -> torch.dtype:
+    """Upcast SDPA-supported dtypes to ``float32`` so the CPU fallback matches math-backend SDPA precision."""
+    return torch.float32 if input_dtype in SupportedDtypes.sdpa else input_dtype
+
+
 def _sdpa_cpu_fallback(
     query: torch.Tensor,
     key: torch.Tensor,
@@ -266,9 +272,7 @@ def _sdpa_cpu_fallback(
 
     original_dtype = query.dtype
     original_device = query.device
-
-    # Upcast float16 → float32 to prevent overflow in Q @ K^T
-    compute_dtype = torch.float32 if original_dtype == torch.float16 else original_dtype
+    compute_dtype = _sdpa_fallback_compute_dtype(original_dtype)
 
     query_cpu = to_cpu(query).to(compute_dtype)
     key_cpu = to_cpu(key).to(compute_dtype)
@@ -401,9 +405,9 @@ def _sdpa_attn_weights_fallback(
     L, S = query.size(-2), key.size(-2)
     original_dtype = query.dtype
     original_device = query.device
+    compute_dtype = _sdpa_fallback_compute_dtype(original_dtype)
 
-    # Upcast float16 → float32 to prevent overflow in Q @ K^T
-    compute_dtype = torch.float32 if original_dtype == torch.float16 else original_dtype
+    attn_mask = _convert_bool_mask_to_float(attn_mask, compute_dtype, original_device)
 
     q_cpu = to_cpu(query).to(compute_dtype)
     k_cpu = to_cpu(key).to(compute_dtype)
@@ -465,9 +469,7 @@ def _sdpa_output_fallback(
     """CPU fallback for SDPA output. Upcasts float16 to float32 for numerical consistency."""
     original_dtype = attn_weights.dtype
     original_device = attn_weights.device
-
-    # Upcast float16 → float32 for numerical consistency
-    compute_dtype = torch.float32 if original_dtype == torch.float16 else original_dtype
+    compute_dtype = _sdpa_fallback_compute_dtype(original_dtype)
 
     weights_cpu = to_cpu(attn_weights).to(compute_dtype)
     v_cpu = to_cpu(value).to(compute_dtype)
@@ -623,9 +625,7 @@ def _sdpa_backward_fallback(
     S = key.size(-2)
     original_device = grad_output.device
     original_dtype = grad_output.dtype
-
-    # Upcast float16 → float32 to prevent overflow
-    compute_dtype = torch.float32 if original_dtype == torch.float16 else original_dtype
+    compute_dtype = _sdpa_fallback_compute_dtype(original_dtype)
 
     grad_output_cpu = to_cpu(grad_output).to(compute_dtype)
     query_cpu = to_cpu(query).to(compute_dtype)

--- a/torch_rbln/_internal/ops_utils.py
+++ b/torch_rbln/_internal/ops_utils.py
@@ -9,7 +9,16 @@ from typing import Optional, Union
 import torch
 from torch.utils._pytree import tree_flatten, tree_unflatten
 
+import torch_rbln._C as _C
 from torch_rbln._internal.log_utils import rbln_log_cpu_fallback, rbln_log_warn
+
+
+class SupportedDtypes:
+    """Per-path supported dtype tuples for RBLN device dispatch."""
+
+    dispatch: tuple[torch.dtype, ...] = _C._dispatch_dtypes()
+    sdpa: tuple[torch.dtype, ...] = _C._sdpa_dtypes()
+    amp: tuple[torch.dtype, ...] = _C._amp_dtypes()
 
 
 def _estimate_mm_shape(shape1, shape2):
@@ -1707,7 +1716,7 @@ def compile_and_run_view_aware(op_callable, op_name, args, kwargs_filtered, out_
             **kwargs_filtered,
         )
 
-    # fp16 div with rounding_mode trunc/floor: the device kernel returns wrong
+    # Supported-dtype div with rounding_mode trunc/floor: the device kernel returns wrong
     # values for entire output rows (not ULP drift), so route it to cpu_fallback.
     # Plain div (no rounding_mode) and fp32 div are unaffected. (verified
     # 2026-05-07: trunc on (357,789), row 338 came back all 0.0/-0.0)
@@ -1715,7 +1724,7 @@ def compile_and_run_view_aware(op_callable, op_name, args, kwargs_filtered, out_
         rmode = kwargs_filtered.get("rounding_mode")
         if rmode in ("trunc", "floor"):
             for a in args:
-                if isinstance(a, torch.Tensor) and a.dtype == torch.float16:
+                if isinstance(a, torch.Tensor) and a.dtype in SupportedDtypes.dispatch:
                     return cpu_fallback_path(
                         op_callable,
                         args,
@@ -1819,8 +1828,9 @@ def is_cpu_fallback_cases(args):
        then runs the original torch.add eagerly; that eager call dispatches again and hits our add_rbln
        -> same path repeats -> infinite recursion. So when TorchDispatchMode is on, we fall back to CPU
        and never enter the compile path.
-    2. **Data Type Mismatch:** If any of the input tensors are not of the `torch.float16` data type,
-       which the `rbln` device is designed to handle.
+    2. **Unsupported or Mismatched Data Types**: If any input tensor's dtype is not in ``SupportedDtypes.dispatch``,
+       or if the inputs mix different supported dtypes. The RBLN compute path requires all tensors to share the
+       same supported dtype.
     3. **Scalar Tensors**: If all input tensors are scalar tensors, rebel-compiler falls back to host ops.
     4. **Storage Offset**: If any tensor has `storage_offset != 0`, fall back to CPU.
     5. **NaN/Inf Values**: When not in deploy mode, if any input tensor contains NaN or Inf values,
@@ -1862,10 +1872,14 @@ def is_cpu_fallback_cases(args):
     if not tensor_args:
         return False
 
-    # 2: RBLN device can only handle float16 dtype
+    # 2: fall back to the CPU if any input tensor has an unsupported dtype, or if input tensors have mismatched dtypes
     if "dtype" not in disabled_cases:
-        if any(a.dtype != torch.float16 for a in tensor_args):
+        first_dtype = tensor_args[0].dtype
+        if first_dtype not in SupportedDtypes.dispatch:
             return True
+        for i in range(1, len(tensor_args)):
+            if tensor_args[i].dtype != first_dtype:
+                return True
 
     # 3: fall back to the CPU if all input tensors are scalar tensors
     if "scalar" not in disabled_cases:
@@ -1985,7 +1999,7 @@ def can_use_out_tensor_directly(args: tuple, kwargs: dict) -> bool:
     2. Tensor is neither empty nor scalar
     3. Tensor is contiguous
     4. Tensor has zero storage offset
-    5. dtype is float16
+    5. dtype is in ``SupportedDtypes.dispatch``
 
     Args:
         args (tuple): Positional arguments for in-place operation check.
@@ -1998,18 +2012,12 @@ def can_use_out_tensor_directly(args: tuple, kwargs: dict) -> bool:
     if out_tensor is None or out_tensor.data_ptr() == 0:
         return False
 
-    # Check conditions:
-    # 1. Not inplace operation
-    # 2. Neither empty nor scalar
-    # 3. Contiguous
-    # 4. Zero storage offset
-    # 5. dtype is float16
     return (
         not is_inplace_op(args, kwargs)
         and ((out_tensor.numel() > 0) and len(out_tensor.size()) > 0)
         and out_tensor.is_contiguous()
         and (out_tensor.storage_offset() == 0)
-        and (out_tensor.dtype == torch.float16)
+        and out_tensor.dtype in SupportedDtypes.dispatch
     )
 
 

--- a/torch_rbln/_internal/register_custom_ops.py
+++ b/torch_rbln/_internal/register_custom_ops.py
@@ -124,8 +124,8 @@ def paged_attn_prefill_rbln(*args, **kwargs):
     # warning emitted via ``_maybe_warn_view_fallback``).
     (view_args, view_kwargs), view_recipes, _ = prepare_args_view_aware(args, kwargs)
 
-    # Result shape matches Q's user-visible (post-view) shape.
-    result_tensor = torch.empty(args[0].shape, dtype=torch.float16, device=args[0].device)
+    # Result shape, dtype, and device match Q's user-visible (post-view) form.
+    result_tensor = torch.empty_like(args[0], memory_format=torch.contiguous_format)
     assert result_tensor.size(-1) % 64 == 0
 
     with out_tensor_context(result_tensor):
@@ -181,7 +181,7 @@ def paged_attn_decode_rbln(*args, **kwargs):
 
     (view_args, view_kwargs), view_recipes, _ = prepare_args_view_aware(args, kwargs)
 
-    result_tensor = torch.empty(args[0].shape, dtype=torch.float16, device=args[0].device)
+    result_tensor = torch.empty_like(args[0], memory_format=torch.contiguous_format)
     assert result_tensor.size(-1) % 64 == 0
 
     with out_tensor_context(result_tensor):
@@ -251,7 +251,7 @@ def paged_causal_attn_prefill_rbln(*args, **kwargs):
 
     (view_args, view_kwargs), view_recipes, _ = prepare_args_view_aware(args, kwargs)
 
-    result_tensor = torch.empty(args[0].shape, dtype=torch.float16, device=args[0].device)
+    result_tensor = torch.empty_like(args[0], memory_format=torch.contiguous_format)
     assert result_tensor.size(-1) % 64 == 0
 
     with out_tensor_context(result_tensor):
@@ -314,7 +314,7 @@ def paged_causal_attn_decode_rbln(*args, **kwargs):
 
     (view_args, view_kwargs), view_recipes, _ = prepare_args_view_aware(args, kwargs)
 
-    result_tensor = torch.empty(args[0].shape, dtype=torch.float16, device=args[0].device)
+    result_tensor = torch.empty_like(args[0], memory_format=torch.contiguous_format)
     assert result_tensor.size(-1) % 64 == 0
 
     with out_tensor_context(result_tensor):
@@ -371,7 +371,7 @@ def flash_attention_naive_prefill_rbln(*args, **kwargs):
 
     (view_args, view_kwargs), view_recipes, _ = prepare_args_view_aware(args, kwargs)
 
-    result_tensor = torch.empty(args[0].shape, dtype=torch.float16, device=args[0].device)
+    result_tensor = torch.empty_like(args[0], memory_format=torch.contiguous_format)
     assert result_tensor.size(-1) % 64 == 0
 
     helper.set_out_tensor(result_tensor)
@@ -424,7 +424,7 @@ def flash_attention_naive_decode_rbln(*args, **kwargs):
 
     (view_args, view_kwargs), view_recipes, _ = prepare_args_view_aware(args, kwargs)
 
-    result_tensor = torch.empty(args[0].shape, dtype=torch.float16, device=args[0].device)
+    result_tensor = torch.empty_like(args[0], memory_format=torch.contiguous_format)
     assert result_tensor.size(-1) % 64 == 0
 
     helper.set_out_tensor(result_tensor)

--- a/torch_rbln/csrc/distributed/c10d/rbln/ProcessGroupRBLN.cpp
+++ b/torch_rbln/csrc/distributed/c10d/rbln/ProcessGroupRBLN.cpp
@@ -1110,7 +1110,7 @@ class AllreduceRBLNWork : public RBLNWork {
       // Handle remainder with padding (only copy the unaligned tail)
       if (needs_padding) {
         const auto device = c10::Device(c10::kPrivateUse1, static_cast<c10::DeviceIndex>(device_id_));
-        const auto options = c10::TensorOptions().device(device).dtype(c10::kHalf);
+        const auto options = c10::TensorOptions().device(device).dtype(input_flat.scalar_type());
         auto padded_tensor = at::empty({static_cast<int64_t>(align_numel)}, options);
 
         // Copy only the remainder elements to padded tensor
@@ -1608,6 +1608,7 @@ class BarrierRBLNWork : public RBLNWork {
       // Create a dummy tensor on RBLN device for all ranks
       // All ranks must have the same tensor shape and type for broadcast
       // RCCL requires 128-byte alignment, so use 64 float16 elements = 128 bytes
+      // Barrier value is discarded; the hardcoded `float16` is independent of the user's dtype.
       constexpr int64_t BARRIER_ALIGNED_NUMEL = RCCL_ALLGATHER_ALIGNMENT / sizeof(at::Half);
       const auto device = c10::Device(c10::kPrivateUse1, static_cast<c10::DeviceIndex>(device_id_));
       const auto options = c10::TensorOptions().device(device).dtype(c10::kHalf);

--- a/torch_rbln/csrc/rbln/DispatchShim.cpp
+++ b/torch_rbln/csrc/rbln/DispatchShim.cpp
@@ -6,6 +6,7 @@
 #include <ATen/native/rbln/RBLNCPUFallback.h>
 #include <ATen/ops/empty.h>
 #include <c10/rbln/RBLNFunctions.h>
+#include <c10/rbln/RBLNSupportedDtypes.h>
 #include <torch/csrc/jit/python/pybind_utils.h>
 #include <torch/library.h>
 
@@ -476,6 +477,16 @@ inline bool fp16_has_nan_or_inf(const uint16_t* data, size_t n) noexcept {
   return false;
 }
 
+using ScannerFn = bool (*)(const uint16_t*, size_t);
+inline ScannerFn scanner_for(c10::ScalarType scalar_type) {
+  switch (scalar_type) {
+    case c10::kHalf:
+      return fp16_has_nan_or_inf;
+    default:
+      TORCH_INTERNAL_ASSERT(false, "missing scanner for ScalarType");
+  }
+}
+
 // Scan a single tensor for NaN/Inf. Uses ``c10::rbln::borrow_host_ptr`` for
 // rbln tensors so a host-latest entry pays no D2H cost; device-latest entries
 // will trigger a D2H sync (this is the price of catching NaN/Inf in
@@ -495,8 +506,10 @@ bool tensor_has_nan_or_inf(const at::Tensor& t) {
   const auto numel = t.numel();
   if (numel == 0)
     return false;
-  if (t.scalar_type() != c10::kHalf)
+  if (!c10::rbln::is_dispatch_dtype(t.scalar_type())) {
     return false;
+  }
+  const auto scanner = scanner_for(t.scalar_type());
   if (!t.is_contiguous())
     return false;
 
@@ -508,7 +521,7 @@ bool tensor_has_nan_or_inf(const at::Tensor& t) {
     const uint16_t* data = static_cast<const uint16_t*>(t.data_ptr());
     if (data == nullptr)
       return false;
-    return fp16_has_nan_or_inf(data, n);
+    return scanner(data, n);
   }
 
   void* ptr = t.data_ptr();
@@ -527,10 +540,10 @@ bool tensor_has_nan_or_inf(const at::Tensor& t) {
     const uint16_t* host_data = static_cast<const uint16_t*>(cpu_copy.data_ptr());
     if (host_data == nullptr)
       return false;
-    return fp16_has_nan_or_inf(host_data, n);
+    return scanner(host_data, n);
   }
   void* host_raw = reinterpret_cast<void*>(borrowed->host_ptr); // NOLINT(performance-no-int-to-ptr)
-  const bool found = fp16_has_nan_or_inf(static_cast<const uint16_t*>(host_raw), n);
+  const bool found = scanner(static_cast<const uint16_t*>(host_raw), n);
   c10::rbln::return_borrowed(borrowed->borrow_id, /*updated=*/false);
   return found;
 }
@@ -607,7 +620,7 @@ bool quick_fallback_check(
       continue;
     }
     has_input_tensor = true;
-    if (t.scalar_type() != c10::kHalf) {
+    if (!c10::rbln::is_dispatch_dtype(t.scalar_type())) {
       return true;
     }
     if (t.dim() != 0) {

--- a/torch_rbln/csrc/rbln/Module.cpp
+++ b/torch_rbln/csrc/rbln/Module.cpp
@@ -6,6 +6,8 @@
 #include <c10/rbln/RBLNFallbackConfig.h>
 #include <c10/rbln/RBLNFunctions.h>
 #include <c10/rbln/RBLNLogging.h>
+#include <c10/rbln/RBLNSupportedDtypes.h>
+#include <torch/csrc/Dtype.h>
 #include <torch/csrc/utils/pybind.h>
 #include <torch_rbln/csrc/distributed/c10d/rbln/ProcessGroupRBLNModule.hpp>
 #include <torch_rbln/csrc/rbln/DispatchShim.h>
@@ -252,6 +254,37 @@ void register_internal_api(py::module_& module) {
       "Internal: enable or disable process-wide RBLN vmemory file offloading.");
 }
 
+py::tuple supported_dtypes_to_tuple(c10::ArrayRef<c10::ScalarType> scalar_types) {
+  const auto n = scalar_types.size();
+  py::tuple out(n);
+  for (size_t i = 0; i < n; ++i) {
+    // `getTHPDtype` returns a borrowed reference to a process-wide singleton.
+    auto* const dtype_obj = reinterpret_cast<PyObject*>(torch::getTHPDtype(scalar_types[i]));
+    out[i] = py::reinterpret_borrow<py::object>(dtype_obj);
+  }
+  return out;
+}
+
+/**
+ * @brief Register dtype tuple getters consumed by Python `SupportedDtypes`.
+ *
+ * @param module The Python module to register the functions with
+ */
+void register_supported_dtypes_api(py::module_& module) {
+  module.def(
+      "_dispatch_dtypes",
+      [] { return supported_dtypes_to_tuple(c10::rbln::kDispatchDtypes); },
+      "Internal: eager-dispatch supported dtypes");
+  module.def(
+      "_sdpa_dtypes",
+      [] { return supported_dtypes_to_tuple(c10::rbln::kSdpaDtypes); },
+      "Internal: SDPA kernel supported dtypes");
+  module.def(
+      "_amp_dtypes",
+      [] { return supported_dtypes_to_tuple(c10::rbln::kAmpDtypes); },
+      "Internal: AMP autocast supported dtypes");
+}
+
 /**
  * @brief Register distributed method definitions with the module
  *
@@ -291,6 +324,7 @@ static std::vector<PyMethodDef> global_method_definitions;
  *    - register_distributed_method(): Adds distributed method definitions
  *    - register_public_device_api(): Registers public device functions
  *    - register_internal_api(): Registers internal backend functions
+ *    - register_supported_dtypes_api(): Registers supported dtype getters
  *
  * This approach follows the ascend-torch pattern and ensures clean separation
  * of concerns while avoiding circular import issues.
@@ -321,6 +355,7 @@ extern "C" PyObject* initModule() {
   // Step 4: Register all RBLN components
   register_public_device_api(python_module);
   register_internal_api(python_module);
+  register_supported_dtypes_api(python_module);
 
   c10::rbln::register_rbln_device_mapping_initialized_callback([]() {
     py::gil_scoped_acquire gil;

--- a/torch_rbln/device/device.py
+++ b/torch_rbln/device/device.py
@@ -12,6 +12,7 @@ from typing import Any, List, Union  # noqa: UP035
 import torch
 
 import torch_rbln._C
+from torch_rbln._internal.ops_utils import SupportedDtypes
 
 
 __all__ = [
@@ -78,11 +79,8 @@ def get_amp_supported_dtype() -> List[torch.dtype]:
 
     Returns:
         List[torch.dtype]: A list of data types supported by AMP.
-
-    Note:
-        This function currently returns only `torch.float16`. It may need review to include other processable data types.
     """
-    return [torch.float16]  # TODO: Needs review regarding processable dtypes
+    return list(SupportedDtypes.amp)
 
 
 def set_device(device: Union[int, torch.device, str]) -> None:


### PR DESCRIPTION
## Summary of Changes

Refactors the dtype dispatch surface so adding a new dtype becomes a small, mechanical change. Consolidates the catalog into a single C++ header (`c10/rbln/RBLNSupportedDtypes.h`) and binds it to Python via `torch_rbln._C`.

Only float16 is admitted today, so the catalog refactor is behavior-preserving. The C++ header is the source of truth — the dispatch predicate stays `constexpr` and the tuples are cached at import; the alternative — a Python source of truth — would force a runtime lookup on every dispatch.

Also bundles three drive-by fixes. Two are latent float16-pinning in paged attention and the `AllReduce` op — no-ops today. The third fixes an active SDPA-fallback bug in `_sdpa_attn_weights_fallback`: a bool `attn_mask` left masked positions at `0.0` instead of `-inf`.

---

## Type of Change

- [x] `core` — Changes to RBLN backend, device layer, C++ extension, op registration, or `torch.compile` integration
- [x] `refactor` — Code improvement without behavior change

---

## Affected Modules

- [x] Backend
- [x] Device
- [x] Ops/Kernels
- [x] C++ extension (`torch_rbln/csrc`)
- [x] Docs

---

## Checklist

* [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
* [x] Linting passes — see [Linting](docs/LINTING.md)
* [x] All CI tests pass — see [CI/CD Workflows](docs/WORKFLOWS.md)
* [x] Relevant documentation has been updated (if applicable)

---
