### PR TITLE
perf(rbln): add CPU fast-path handlers for int sub/mul/clamp metadata ops

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -14,6 +14,7 @@ set(sources
   native/rbln/fast_paths/rsqrt_fp32.cpp
   native/rbln/fast_paths/pow_squared_fp32.cpp
   native/rbln/fast_paths/mean_lastdim_fp32.cpp
+  native/rbln/fast_paths/int_elementwise.cpp
 )
 set(headers
   native/rbln/RBLNCPUFallback.h

--- a/aten/src/ATen/native/rbln/fast_paths/int_elementwise.cpp
+++ b/aten/src/ATen/native/rbln/fast_paths/int_elementwise.cpp
@@ -1,0 +1,226 @@
+// Fast paths for the integer metadata arithmetic that the fp16-only RBLN
+// device cannot run natively and must fall back to CPU: sub.out / mul.out /
+// clamp.out on small int16/int32/int64 tensors.
+//
+// These show up every decode step in the attention metadata builder
+// (partition-size math: ``cs - pidx * partition_len``, ``clamp(.., 0, len)``)
+// and in ``logits_indices = query_start_loc[1:] - 1``. The generic
+// ``redispatchBoxed(CPU)`` path pays boxing + TensorIterator setup that
+// dominates the cost for these tiny tensors; a direct host loop skips it.
+//
+// Correctness: we compute in int64 and store in the output dtype, so mixed
+// int dtypes from scalar type-promotion (e.g. int32 * <int64 scalar>) are
+// handled. Any shape/dtype we do not explicitly support bails to the boxed
+// fallback (returns false), so results are never wrong -- only un-accelerated.
+#include <ATen/core/Tensor.h>
+#include <ATen/native/rbln/RBLNCPUFastPaths.h>
+#include <c10/util/ArrayRef.h>
+#include <torch/csrc/jit/runtime/operator.h>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace at::native::rbln {
+namespace {
+
+inline bool is_int_contig(const at::Tensor& t) {
+  if (!t.defined() || !t.is_contiguous()) {
+    return false;
+  }
+  const auto st = t.scalar_type();
+  return st == at::kShort || st == at::kInt || st == at::kLong;
+}
+
+inline int64_t load_i64(const void* base, at::ScalarType st, int64_t i) {
+  switch (st) {
+    case at::kShort:
+      return static_cast<const int16_t*>(base)[i];
+    case at::kInt:
+      return static_cast<const int32_t*>(base)[i];
+    case at::kLong:
+      return static_cast<const int64_t*>(base)[i];
+    default:
+      return 0; // unreachable: guarded by is_int_contig
+  }
+}
+
+inline void store_i64(void* base, at::ScalarType st, int64_t i, int64_t v) {
+  switch (st) {
+    case at::kShort:
+      static_cast<int16_t*>(base)[i] = static_cast<int16_t>(v);
+      break;
+    case at::kInt:
+      static_cast<int32_t*>(base)[i] = static_cast<int32_t>(v);
+      break;
+    case at::kLong:
+      static_cast<int64_t*>(base)[i] = static_cast<int64_t>(v);
+      break;
+    default:
+      break; // unreachable
+  }
+}
+
+// Broadcast mode of ``other`` against ``self`` for an element-wise binary op.
+//   0 = same shape, 1 = scalar (other.numel()==1),
+//   2 = last-dim broadcast (other is 1-D of size self.size(-1)),
+//  -1 = unsupported -> bail.
+inline int broadcast_mode(const at::Tensor& self, const at::Tensor& other) {
+  if (other.numel() == 1) {
+    return 1;
+  }
+  if (other.sizes() == self.sizes()) {
+    return 0;
+  }
+  if (self.dim() >= 1 && other.dim() == 1 && other.numel() == self.size(self.dim() - 1)) {
+    return 2;
+  }
+  return -1;
+}
+
+// other-index for element i under the given broadcast mode.
+inline int64_t other_index(int mode, int64_t i, int64_t inner) {
+  switch (mode) {
+    case 1:
+      return 0;
+    case 2:
+      return i % inner;
+    default:
+      return i;
+  }
+}
+
+template <typename BinOp>
+bool run_binary(
+    const at::Tensor& self,
+    const at::Tensor& other,
+    const at::Tensor& out,
+    torch::jit::Stack* stack,
+    size_t arguments_begin,
+    BinOp op) {
+  if (!is_int_contig(self) || !is_int_contig(other) || !is_int_contig(out)) {
+    return false;
+  }
+  if (out.sizes() != self.sizes() || out.numel() != self.numel()) {
+    return false;
+  }
+  const int mode = broadcast_mode(self, other);
+  if (mode < 0) {
+    return false;
+  }
+
+  const auto sdt = self.scalar_type();
+  const auto odt = other.scalar_type();
+  const auto rdt = out.scalar_type();
+  const void* sp = self.data_ptr();
+  const void* op_ = other.data_ptr();
+  void* rp = out.data_ptr();
+  const int64_t n = self.numel();
+  const int64_t inner = self.dim() >= 1 ? self.size(self.dim() - 1) : 1;
+
+  for (int64_t i = 0; i < n; ++i) {
+    const int64_t a = load_i64(sp, sdt, i);
+    const int64_t b = load_i64(op_, odt, other_index(mode, i, inner));
+    store_i64(rp, rdt, i, op(a, b));
+  }
+
+  stack->resize(arguments_begin);
+  stack->emplace_back(c10::IValue(out));
+  return true;
+}
+
+// schema: sub.out(Tensor self, Tensor other, *, Scalar alpha=1, Tensor(a!) out)
+bool sub_int_handler(c10::ArrayRef<at::Tensor> cpu_tensors, torch::jit::Stack* stack, size_t arguments_begin) {
+  if (cpu_tensors.size() < 3) {
+    return false;
+  }
+  // alpha lives on the stack right after self, other.
+  const auto& alpha_iv = (*stack)[arguments_begin + 2];
+  if (!alpha_iv.isScalar()) {
+    return false;
+  }
+  const auto alpha = alpha_iv.toScalar();
+  if (!(alpha.isIntegral(/*includeBool=*/false) && alpha.toLong() == 1)) {
+    return false;
+  }
+  return run_binary(
+      cpu_tensors[0], cpu_tensors[1], cpu_tensors.back(), stack, arguments_begin, [](int64_t a, int64_t b) {
+        return a - b;
+      });
+}
+
+// schema: mul.out(Tensor self, Tensor other, *, Tensor(a!) out)
+bool mul_int_handler(c10::ArrayRef<at::Tensor> cpu_tensors, torch::jit::Stack* stack, size_t arguments_begin) {
+  if (cpu_tensors.size() < 3) {
+    return false;
+  }
+  return run_binary(
+      cpu_tensors[0], cpu_tensors[1], cpu_tensors.back(), stack, arguments_begin, [](int64_t a, int64_t b) {
+        return a * b;
+      });
+}
+
+// schema: clamp.out(Tensor self, Scalar? min=None, Scalar? max=None, *, Tensor(a!) out)
+bool clamp_int_handler(c10::ArrayRef<at::Tensor> cpu_tensors, torch::jit::Stack* stack, size_t arguments_begin) {
+  if (cpu_tensors.size() < 2) {
+    return false;
+  }
+  const auto& self = cpu_tensors[0];
+  const auto& out = cpu_tensors.back();
+  if (!is_int_contig(self) || !is_int_contig(out)) {
+    return false;
+  }
+  if (out.sizes() != self.sizes() || out.numel() != self.numel()) {
+    return false;
+  }
+
+  const auto& min_iv = (*stack)[arguments_begin + 1];
+  const auto& max_iv = (*stack)[arguments_begin + 2];
+  bool has_min = false;
+  bool has_max = false;
+  int64_t lo = 0;
+  int64_t hi = 0;
+  if (!min_iv.isNone()) {
+    if (!min_iv.isScalar() || !min_iv.toScalar().isIntegral(/*includeBool=*/false)) {
+      return false;
+    }
+    has_min = true;
+    lo = min_iv.toScalar().toLong();
+  }
+  if (!max_iv.isNone()) {
+    if (!max_iv.isScalar() || !max_iv.toScalar().isIntegral(/*includeBool=*/false)) {
+      return false;
+    }
+    has_max = true;
+    hi = max_iv.toScalar().toLong();
+  }
+  if (!has_min && !has_max) {
+    return false;
+  }
+
+  const auto sdt = self.scalar_type();
+  const auto rdt = out.scalar_type();
+  const void* sp = self.data_ptr();
+  void* rp = out.data_ptr();
+  const int64_t n = self.numel();
+  for (int64_t i = 0; i < n; ++i) {
+    int64_t v = load_i64(sp, sdt, i);
+    if (has_min && v < lo) {
+      v = lo;
+    }
+    if (has_max && v > hi) {
+      v = hi;
+    }
+    store_i64(rp, rdt, i, v);
+  }
+
+  stack->resize(arguments_begin);
+  stack->emplace_back(c10::IValue(out));
+  return true;
+}
+
+REGISTER_RBLN_CPU_FAST_PATH("aten::sub.out", sub_int_handler);
+REGISTER_RBLN_CPU_FAST_PATH("aten::mul.out", mul_int_handler);
+REGISTER_RBLN_CPU_FAST_PATH("aten::clamp.out", clamp_int_handler);
+
+} // namespace
+} // namespace at::native::rbln

--- a/test/rbln/test_cpu_fast_paths.py
+++ b/test/rbln/test_cpu_fast_paths.py
@@ -53,6 +53,15 @@ class TestCPUFastPathRegistration(TestCase):
     def test_mean_out_registered(self):
         self.assertTrue(_C._cpu_fast_path_registered("aten::mean.out"))
 
+    def test_sub_out_registered(self):
+        self.assertTrue(_C._cpu_fast_path_registered("aten::sub.out"))
+
+    def test_mul_out_registered(self):
+        self.assertTrue(_C._cpu_fast_path_registered("aten::mul.out"))
+
+    def test_clamp_out_registered(self):
+        self.assertTrue(_C._cpu_fast_path_registered("aten::clamp.out"))
+
     def test_unregistered_op_returns_false(self):
         # add.out goes through the dispatch shim, not the cpu_fallback fast-path
         # registry — should not be present here.
@@ -150,9 +159,96 @@ class TestMeanLastDimFastPath(TestCase):
         self.assertEqual(rbln_out.cpu(), cpu_x.mean(dim=-1, keepdim=False), rtol=1e-5, atol=1e-6)
 
 
+@pytest.mark.test_set_ci
+class TestIntSubFastPath(TestCase):
+    """`aten::sub.out` integer fast path. The fp16-only device falls int ops back
+    to CPU; the handler runs a host loop (int64 accumulate, stored in out dtype).
+    Covers same-shape, scalar/last-dim broadcast, all int widths, and the
+    alpha != 1 guard fall-through."""
+
+    def test_int32_same_shape_matches_cpu(self):
+        cpu_a = torch.tensor([5, 3, 9, 1], dtype=torch.int32)
+        cpu_b = torch.tensor([1, 2, 3, 4], dtype=torch.int32)
+        ra, rb = cpu_a.to("rbln"), cpu_b.to("rbln")
+        self.assertEqual((ra - rb).cpu(), cpu_a - cpu_b)
+
+    def test_int64_same_shape_matches_cpu(self):
+        cpu_a = torch.tensor([5, 3, 9, 1], dtype=torch.int64)
+        cpu_b = torch.tensor([1, 2, 3, 4], dtype=torch.int64)
+        ra, rb = cpu_a.to("rbln"), cpu_b.to("rbln")
+        self.assertEqual((ra - rb).cpu(), cpu_a - cpu_b)
+
+    def test_int16_same_shape_matches_cpu(self):
+        cpu_a = torch.tensor([5, 3, 9, 1], dtype=torch.int16)
+        cpu_b = torch.tensor([1, 2, 3, 4], dtype=torch.int16)
+        ra, rb = cpu_a.to("rbln"), cpu_b.to("rbln")
+        self.assertEqual((ra - rb).cpu(), cpu_a - cpu_b)
+
+    def test_int32_scalar_broadcast_matches_cpu(self):
+        # `logits_indices = query_start_loc[1:] - 1` shape.
+        cpu_a = torch.tensor([5, 3, 9], dtype=torch.int32)
+        ra = cpu_a.to("rbln")
+        self.assertEqual((ra - 1).cpu(), cpu_a - 1)
+
+    def test_int32_lastdim_broadcast_matches_cpu(self):
+        # `cs - pidx * partition_len` shape: [num_reqs, num_partition] - [num_partition].
+        cpu_a = torch.tensor([[10, 20, 30]], dtype=torch.int32)
+        cpu_b = torch.tensor([1, 2, 3], dtype=torch.int32)
+        ra, rb = cpu_a.to("rbln"), cpu_b.to("rbln")
+        self.assertEqual((ra - rb).cpu(), cpu_a - cpu_b)
+
+    def test_alpha_not_one_falls_through(self):
+        # Handler guards on alpha == 1; alpha=2 must take the generic path.
+        cpu_a = torch.tensor([5, 3, 9, 1], dtype=torch.int32)
+        cpu_b = torch.tensor([1, 2, 3, 4], dtype=torch.int32)
+        ra, rb = cpu_a.to("rbln"), cpu_b.to("rbln")
+        self.assertEqual(torch.sub(ra, rb, alpha=2).cpu(), torch.sub(cpu_a, cpu_b, alpha=2))
+
+
+@pytest.mark.test_set_ci
+class TestIntMulFastPath(TestCase):
+    """`aten::mul.out` integer fast path; same-shape and scalar broadcast."""
+
+    def test_int32_same_shape_matches_cpu(self):
+        cpu_a = torch.tensor([5, 3, 9, 1], dtype=torch.int32)
+        cpu_b = torch.tensor([1, 2, 3, 4], dtype=torch.int32)
+        ra, rb = cpu_a.to("rbln"), cpu_b.to("rbln")
+        self.assertEqual((ra * rb).cpu(), cpu_a * cpu_b)
+
+    def test_int32_scalar_broadcast_matches_cpu(self):
+        # `pidx * partition_len` shape.
+        cpu_a = torch.tensor([0, 1, 2, 3], dtype=torch.int32)
+        ra = cpu_a.to("rbln")
+        self.assertEqual((ra * 1024).cpu(), cpu_a * 1024)
+
+
+@pytest.mark.test_set_ci
+class TestIntClampFastPath(TestCase):
+    """`aten::clamp.out` integer fast path; min+max, min-only, max-only."""
+
+    def test_int32_min_max_matches_cpu(self):
+        # `clamp(.., 0, partition_len)` shape.
+        cpu_x = torch.tensor([-5, 0, 500, 2000], dtype=torch.int32)
+        rx = cpu_x.to("rbln")
+        self.assertEqual(torch.clamp(rx, 0, 1024).cpu(), torch.clamp(cpu_x, 0, 1024))
+
+    def test_int32_min_only_matches_cpu(self):
+        cpu_x = torch.tensor([-5, 0, 7], dtype=torch.int32)
+        rx = cpu_x.to("rbln")
+        self.assertEqual(torch.clamp(rx, min=0).cpu(), torch.clamp(cpu_x, min=0))
+
+    def test_int32_max_only_matches_cpu(self):
+        cpu_x = torch.tensor([-5, 0, 2000], dtype=torch.int32)
+        rx = cpu_x.to("rbln")
+        self.assertEqual(torch.clamp(rx, max=1024).cpu(), torch.clamp(cpu_x, max=1024))
+
+
 instantiate_device_type_tests(TestRsqrtFastPath, globals(), only_for="privateuse1")
 instantiate_device_type_tests(TestPowSquaredFastPath, globals(), only_for="privateuse1")
 instantiate_device_type_tests(TestMeanLastDimFastPath, globals(), only_for="privateuse1")
+instantiate_device_type_tests(TestIntSubFastPath, globals(), only_for="privateuse1")
+instantiate_device_type_tests(TestIntMulFastPath, globals(), only_for="privateuse1")
+instantiate_device_type_tests(TestIntClampFastPath, globals(), only_for="privateuse1")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary of Changes

The fp16-only RBLN device cannot run integer element-wise ops natively, so `aten::sub.out` / `aten::mul.out` / `aten::clamp.out` on int16/int32/int64 tensors fall back to CPU via `redispatchBoxed(CPU)`. For the tiny integer tensors that appear every decode step in the attention metadata builder (partition-size math and `logits_indices`), that path's boxing + `TensorIterator` setup dominates the cost.

This adds host micro-kernels for those three ops to the existing `CPUFastPathRegistry` (same pattern as the `rsqrt`/`pow`/`mean` fast paths). The handlers:

- compute in int64 and store in the output dtype, so mixed-dtype scalar promotion (e.g. `int32 * <int64 scalar>`) is handled correctly;
- support scalar / same-shape / last-dim broadcast;
- bail to the boxed fallback on any unsupported shape/dtype, so results are never wrong — only un-accelerated.

Files: new `aten/src/ATen/native/rbln/fast_paths/int_elementwise.cpp` + its entry in `aten/src/ATen/CMakeLists.txt`.

## Related Issues / Tickets

* Related to #<!-- TODO: link tracking issue -->

## Type of Change

- [x] `perf` — Performance improvement

## Affected Modules

- [x] Backend
- [x] Ops/Kernels

## How to Test

1. `pytest test/rbln/test_cpu_fast_paths.py` — added registration checks for `aten::sub.out` / `mul.out` / `clamp.out` plus numerical-correctness tests (same-shape, scalar / last-dim broadcast, int16/int32/int64, and the `alpha != 1` guard fall-through), mirroring the existing rsqrt/pow/mean coverage.
2. On Llama-3.2-1B decode, the per-step `cpu_fallback` wall time drops from ~117 to ~78 us/step (sub/mul/clamp no longer pay `redispatchBoxed`).

## Checklist

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to a corresponding issue
* [x] Linting passes (clang-format)
* [ ] All CI tests pass
* [x] The test method is described — unit tests added in `test/rbln/test_cpu_fast_paths.py`

## Notes

Pure addition — no existing op behavior changes. Unregistered ops and unsupported shapes/dtypes keep the current boxed fallback path.
