### PR TITLE
feat(memory): support pinned host memory and torch.Event

### DIFF
--- a/aten/src/ATen/native/rbln/RBLNCopy.cpp
+++ b/aten/src/ATen/native/rbln/RBLNCopy.cpp
@@ -13,7 +13,6 @@
 #include <rebel/runtime/api/rbln_runtime_api.h>
 
 #include <cstddef>
-#include <cstdlib>
 
 namespace at::native::rbln {
 
@@ -206,19 +205,11 @@ void copy_impl_rbln_async(const at::Tensor& src, const at::Tensor& dst) {
     return;
   }
 
-  // CUDA semantics: async dispatch only when the host side is pinned. A
-  // pageable host tensor is read/written by plain CPU code that never passes
-  // through RBLN, so nothing can drain a still-pending transfer before the
-  // access; downgrading to a sync copy makes such code correct by
-  // construction. Pinned host memory opts in to true async (caller
-  // synchronizes before touching it). Set TORCH_RBLN_PAGEABLE_ASYNC=1 to
-  // restore unconditional async dispatch during migration.
-  static const bool pageable_async = []() {
-    const auto* env = std::getenv("TORCH_RBLN_PAGEABLE_ASYNC");
-    return env != nullptr && env[0] == '1';
-  }();
+  // CUDA semantics: async only when the host side is pinned. Host reads never
+  // pass through RBLN, so nothing can drain a pending transfer first — sync
+  // for pageable makes that safe; pinned opts in (caller synchronizes).
   const at::Tensor& host = src_device.is_cpu() ? src : dst;
-  if (!pageable_async && host.device().is_cpu() && !c10::rbln::is_pinned_ptr(host.data_ptr())) {
+  if (host.device().is_cpu() && !c10::rbln::is_pinned_ptr(host.data_ptr())) {
     RBLN_LOG_DEBUG("Pageable host tensor, downgrading non_blocking copy to sync");
     copy_impl_rbln(src, dst);
     return;

--- a/aten/src/ATen/native/rbln/RBLNCopy.cpp
+++ b/aten/src/ATen/native/rbln/RBLNCopy.cpp
@@ -9,9 +9,11 @@
 #include <c10/rbln/RBLNFallbackConfig.h>
 #include <c10/rbln/RBLNFunctions.h>
 #include <c10/rbln/RBLNLogging.h>
+#include <c10/rbln/RBLNPinnedAllocator.h>
 #include <rebel/runtime/api/rbln_runtime_api.h>
 
 #include <cstddef>
+#include <cstdlib>
 
 namespace at::native::rbln {
 
@@ -201,6 +203,24 @@ void copy_impl_rbln_async(const at::Tensor& src, const at::Tensor& dst) {
   const auto nbytes = at::detail::computeStorageNbytes(src.sizes(), src.strides(), src.element_size());
   if (nbytes == 0) {
     RBLN_LOG_DEBUG("No bytes to copy");
+    return;
+  }
+
+  // CUDA semantics: async dispatch only when the host side is pinned. A
+  // pageable host tensor is read/written by plain CPU code that never passes
+  // through RBLN, so nothing can drain a still-pending transfer before the
+  // access; downgrading to a sync copy makes such code correct by
+  // construction. Pinned host memory opts in to true async (caller
+  // synchronizes before touching it). Set TORCH_RBLN_PAGEABLE_ASYNC=1 to
+  // restore unconditional async dispatch during migration.
+  static const bool pageable_async = []() {
+    const auto* env = std::getenv("TORCH_RBLN_PAGEABLE_ASYNC");
+    return env != nullptr && env[0] == '1';
+  }();
+  const at::Tensor& host = src_device.is_cpu() ? src : dst;
+  if (!pageable_async && host.device().is_cpu() && !c10::rbln::is_pinned_ptr(host.data_ptr())) {
+    RBLN_LOG_DEBUG("Pageable host tensor, downgrading non_blocking copy to sync");
+    copy_impl_rbln(src, dst);
     return;
   }
 

--- a/c10/rbln/CMakeLists.txt
+++ b/c10/rbln/CMakeLists.txt
@@ -8,6 +8,7 @@ set(sources
   RBLNGenerator.cpp
   RBLNHooksInterface.cpp
   RBLNLogging.cpp
+  RBLNPinnedAllocator.cpp
   RBLNV2VBatch.cpp
 )
 set(headers
@@ -19,6 +20,7 @@ set(headers
   RBLNHooksInterface.h
   RBLNLogging.h
   RBLNMacros.h
+  RBLNPinnedAllocator.h
   RBLNSupportedDtypes.h
   RBLNV2VBatch.h
 )

--- a/c10/rbln/RBLNHooksInterface.cpp
+++ b/c10/rbln/RBLNHooksInterface.cpp
@@ -3,6 +3,7 @@
 #include <c10/rbln/RBLNGenerator.h>
 #include <c10/rbln/RBLNHooksInterface.h>
 #include <c10/rbln/RBLNLogging.h>
+#include <c10/rbln/RBLNPinnedAllocator.h>
 #include <c10/util/CallOnce.h>
 
 namespace c10::rbln {
@@ -91,6 +92,14 @@ void RBLNHooksInterface::resizePrivateUse1Bytes(const c10::Storage& storage, siz
   RBLN_LOG_DEBUG("Updating storage with new data pointer and nbytes");
   storage.set_data_ptr_noswap(std::move(new_data_ptr));
   storage.set_nbytes(new_nbytes);
+}
+
+c10::Allocator* RBLNHooksInterface::getPinnedMemoryAllocator() const {
+  return c10::rbln::get_pinned_memory_allocator();
+}
+
+bool RBLNHooksInterface::isPinnedPtr(const void* data) const {
+  return c10::rbln::is_pinned_ptr(data);
 }
 
 at::Generator RBLNHooksInterface::getNewGenerator(c10::DeviceIndex device_index) const {

--- a/c10/rbln/RBLNHooksInterface.h
+++ b/c10/rbln/RBLNHooksInterface.h
@@ -48,6 +48,23 @@ struct C10_RBLN_API RBLNHooksInterface : public at::PrivateUse1HooksInterface {
   bool hasPrimaryContext(c10::DeviceIndex device_index) const override;
 
   /**
+   * @brief Returns the host allocator used for CPU tensors created with
+   * `pin_memory=True` while RBLN is the active accelerator.
+   *
+   * @return The pinned host allocator. Never null.
+   */
+  c10::Allocator* getPinnedMemoryAllocator() const override;
+
+  /**
+   * @brief Checks whether the given host pointer was allocated by the pinned
+   * host allocator. This function should NEVER throw.
+   *
+   * @param data A host pointer.
+   * @return True if the pointer belongs to a pinned allocation.
+   */
+  bool isPinnedPtr(const void* data) const override;
+
+  /**
    * @brief Resizes the storage to the specified number of bytes.
    *
    * @param storage The storage to resize.

--- a/c10/rbln/RBLNPinnedAllocator.cpp
+++ b/c10/rbln/RBLNPinnedAllocator.cpp
@@ -1,0 +1,103 @@
+#include <c10/rbln/RBLNLogging.h>
+#include <c10/rbln/RBLNPinnedAllocator.h>
+
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <cstdlib>
+#include <map>
+#include <mutex>
+
+namespace c10::rbln {
+
+namespace {
+
+// Allocation base -> size. Ordered so any interior pointer can be matched via
+// upper_bound; protected by a mutex because tensors are allocated and freed
+// from arbitrary threads (e.g. DataLoader pin-memory workers).
+std::mutex pinned_registry_mutex;
+std::map<uintptr_t, size_t> pinned_registry;
+
+void raw_pinned_delete(void* data) {
+  if (data == nullptr) {
+    return;
+  }
+  RBLN_LOG_DEBUG("Freeing pinned host memory at {}", fmt::ptr(data));
+  size_t nbytes = 0;
+  {
+    const std::lock_guard<std::mutex> guard(pinned_registry_mutex);
+    auto it = pinned_registry.find(reinterpret_cast<uintptr_t>(data));
+    if (it != pinned_registry.end()) {
+      nbytes = it->second;
+      pinned_registry.erase(it);
+    }
+  }
+  if (nbytes > 0) {
+    munlock(data, nbytes); // best-effort, mirrors the mlock in allocate
+  }
+  std::free(data);
+}
+
+struct RBLNPinnedAllocator final : public c10::Allocator {
+  /**
+   * @brief Allocates page-aligned host memory and page-locks it (best effort).
+   *
+   * The DataPtr device is CPU: pinned tensors are host tensors regardless of
+   * the accelerator that pins them.
+   *
+   * @param nbytes The number of bytes to allocate.
+   * @return A data pointer to the pinned host memory.
+   */
+  c10::DataPtr allocate(size_t nbytes) override {
+    void* data = nullptr;
+    if (nbytes > 0) {
+      static const size_t page_size = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+      if (posix_memalign(&data, page_size, nbytes) != 0) {
+        TORCH_CHECK(false, "Failed to allocate ", nbytes, " bytes of pinned host memory");
+      }
+      // mlock keeps the pages resident, which is all "pinned" can mean until
+      // the UMD exposes DMA-mapped host allocation. Failure (RLIMIT_MEMLOCK)
+      // is non-fatal: the tensor still works and stays semantically pinned.
+      if (mlock(data, nbytes) != 0) {
+        RBLN_LOG_DEBUG("mlock of {} bytes failed (errno={}); continuing unlocked", nbytes, errno);
+      }
+      RBLN_LOG_DEBUG("Allocated {} bytes of pinned host memory at {}", nbytes, fmt::ptr(data));
+      const std::lock_guard<std::mutex> guard(pinned_registry_mutex);
+      pinned_registry.emplace(reinterpret_cast<uintptr_t>(data), nbytes);
+    }
+    return c10::DataPtr(data, data, &raw_pinned_delete, c10::Device(c10::kCPU));
+  }
+
+  c10::DeleterFnPtr raw_deleter() const override {
+    return &raw_pinned_delete;
+  }
+
+  void copy_data(void* dst_data, const void* src_data, size_t nbytes) const override {
+    if (nbytes > 0) {
+      std::memcpy(dst_data, src_data, nbytes);
+    }
+  }
+};
+
+} // namespace
+
+c10::Allocator* get_pinned_memory_allocator() {
+  static RBLNPinnedAllocator allocator;
+  return &allocator;
+}
+
+bool is_pinned_ptr(const void* data) {
+  if (data == nullptr) {
+    return false;
+  }
+  const auto addr = reinterpret_cast<uintptr_t>(data);
+  const std::lock_guard<std::mutex> guard(pinned_registry_mutex);
+  auto it = pinned_registry.upper_bound(addr);
+  if (it == pinned_registry.begin()) {
+    return false;
+  }
+  --it;
+  return addr < it->first + it->second;
+}
+
+} // namespace c10::rbln

--- a/c10/rbln/RBLNPinnedAllocator.cpp
+++ b/c10/rbln/RBLNPinnedAllocator.cpp
@@ -33,7 +33,8 @@ void raw_pinned_delete(void* data) {
   if (nbytes > 0) {
     munlock(data, nbytes); // best-effort, mirrors the mlock in allocate
   }
-  std::free(data);
+  // Allocator deleters work on raw pointers from posix_memalign; RAII does not apply.
+  std::free(data); // NOLINT(cppcoreguidelines-no-malloc)
 }
 
 struct RBLNPinnedAllocator final : public c10::Allocator {

--- a/c10/rbln/RBLNPinnedAllocator.cpp
+++ b/c10/rbln/RBLNPinnedAllocator.cpp
@@ -12,9 +12,7 @@ namespace c10::rbln {
 
 namespace {
 
-// Allocation base -> size. Ordered so any interior pointer can be matched via
-// upper_bound; protected by a mutex because tensors are allocated and freed
-// from arbitrary threads (e.g. DataLoader pin-memory workers).
+// Allocation base -> size; ordered so interior pointers match via upper_bound.
 std::mutex pinned_registry_mutex;
 std::map<uintptr_t, size_t> pinned_registry;
 
@@ -42,11 +40,8 @@ struct RBLNPinnedAllocator final : public c10::Allocator {
   /**
    * @brief Allocates page-aligned host memory and page-locks it (best effort).
    *
-   * The DataPtr device is CPU: pinned tensors are host tensors regardless of
-   * the accelerator that pins them.
-   *
    * @param nbytes The number of bytes to allocate.
-   * @return A data pointer to the pinned host memory.
+   * @return A data pointer to the pinned host memory (device is CPU).
    */
   c10::DataPtr allocate(size_t nbytes) override {
     void* data = nullptr;
@@ -55,9 +50,7 @@ struct RBLNPinnedAllocator final : public c10::Allocator {
       if (posix_memalign(&data, page_size, nbytes) != 0) {
         TORCH_CHECK(false, "Failed to allocate ", nbytes, " bytes of pinned host memory");
       }
-      // mlock keeps the pages resident, which is all "pinned" can mean until
-      // the UMD exposes DMA-mapped host allocation. Failure (RLIMIT_MEMLOCK)
-      // is non-fatal: the tensor still works and stays semantically pinned.
+      // RLIMIT_MEMLOCK failure is non-fatal: stays semantically pinned.
       if (mlock(data, nbytes) != 0) {
         RBLN_LOG_DEBUG("mlock of {} bytes failed (errno={}); continuing unlocked", nbytes, errno);
       }

--- a/c10/rbln/RBLNPinnedAllocator.h
+++ b/c10/rbln/RBLNPinnedAllocator.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <c10/core/Allocator.h>
+#include <c10/rbln/RBLNMacros.h>
+
+namespace c10::rbln {
+
+/**
+ * @brief Returns the host allocator backing CPU tensors created with
+ * `pin_memory=True` while the RBLN backend is the active accelerator.
+ *
+ * The RBLN UMD has no DMA-mapped host allocation API yet, so allocations are
+ * page-aligned host memory page-locked via best-effort `mlock`. This keeps
+ * the full `pin_memory` UX working with standard semantics; when the runtime
+ * grows a pinned-host API, only this allocator changes.
+ *
+ * @return The pinned host allocator. Never null.
+ */
+C10_RBLN_API c10::Allocator* get_pinned_memory_allocator();
+
+/**
+ * @brief Checks whether `data` lies inside an allocation made by the pinned
+ * host allocator. Never throws; null and foreign pointers return false.
+ *
+ * @param data A host pointer (any offset within an allocation is accepted).
+ * @return True if the pointer is inside a pinned allocation.
+ */
+C10_RBLN_API bool is_pinned_ptr(const void* data);
+
+} // namespace c10::rbln

--- a/c10/rbln/RBLNPinnedAllocator.h
+++ b/c10/rbln/RBLNPinnedAllocator.h
@@ -9,10 +9,8 @@ namespace c10::rbln {
  * @brief Returns the host allocator backing CPU tensors created with
  * `pin_memory=True` while the RBLN backend is the active accelerator.
  *
- * The RBLN UMD has no DMA-mapped host allocation API yet, so allocations are
- * page-aligned host memory page-locked via best-effort `mlock`. This keeps
- * the full `pin_memory` UX working with standard semantics; when the runtime
- * grows a pinned-host API, only this allocator changes.
+ * The UMD has no DMA-mapped host allocation API yet, so this is page-aligned
+ * host memory with best-effort `mlock`; swap in the UMD API here when it lands.
  *
  * @return The pinned host allocator. Never null.
  */

--- a/c10/rbln/impl/RBLNGuardImpl.cpp
+++ b/c10/rbln/impl/RBLNGuardImpl.cpp
@@ -93,4 +93,63 @@ c10::Stream RBLNGuardImpl::exchangeStream(c10::Stream stream) const {
   return original_stream;
 }
 
+namespace {
+
+// Opaque payload behind the void* handles in the event API: the device the
+// event was last recorded on, or -1 while never recorded.
+struct RBLNEvent {
+  c10::DeviceIndex device_index = -1;
+
+  bool recorded() const {
+    return device_index >= 0;
+  }
+};
+
+void drain_if_recorded(void* event) {
+  const auto* rbln_event = static_cast<const RBLNEvent*>(event);
+  if (rbln_event != nullptr && rbln_event->recorded()) {
+    c10::rbln::synchronize(rbln_event->device_index);
+  }
+}
+
+} // namespace
+
+void RBLNGuardImpl::record(
+    void** event,
+    const c10::Stream& stream,
+    c10::DeviceIndex device_index,
+    c10::EventFlag flag) const {
+  (void)flag; // RBLN events carry no timing.
+  if (*event == nullptr) {
+    *event = new RBLNEvent();
+  }
+  auto* rbln_event = static_cast<RBLNEvent*>(*event);
+  rbln_event->device_index = device_index >= 0 ? device_index : stream.device_index();
+  RBLN_LOG_DEBUG("Recorded event on device {}", static_cast<int>(rbln_event->device_index));
+}
+
+void RBLNGuardImpl::block(void* event, const c10::Stream& stream) const {
+  (void)stream; // Single in-order queue: a host-side drain orders everything.
+  drain_if_recorded(event);
+}
+
+bool RBLNGuardImpl::queryEvent(void* event) const {
+  drain_if_recorded(event);
+  return true;
+}
+
+void RBLNGuardImpl::synchronizeEvent(void* event) const {
+  drain_if_recorded(event);
+}
+
+void RBLNGuardImpl::destroyEvent(void* event, c10::DeviceIndex device_index) const noexcept {
+  (void)device_index;
+  delete static_cast<RBLNEvent*>(event);
+}
+
+void RBLNGuardImpl::synchronizeDevice(c10::DeviceIndex device_index) const {
+  RBLN_LOG_DEBUG("Synchronizing device {}", static_cast<int>(device_index));
+  c10::rbln::synchronize(device_index);
+}
+
 } // namespace c10::rbln::impl

--- a/c10/rbln/impl/RBLNGuardImpl.cpp
+++ b/c10/rbln/impl/RBLNGuardImpl.cpp
@@ -114,11 +114,8 @@ void drain_if_recorded(void* event) {
 
 } // namespace
 
-void RBLNGuardImpl::record(
-    void** event,
-    const c10::Stream& stream,
-    c10::DeviceIndex device_index,
-    c10::EventFlag flag) const {
+void RBLNGuardImpl::record(void** event, const c10::Stream& stream, c10::DeviceIndex device_index, c10::EventFlag flag)
+    const {
   (void)flag; // RBLN events carry no timing.
   if (*event == nullptr) {
     *event = new RBLNEvent();

--- a/c10/rbln/impl/RBLNGuardImpl.h
+++ b/c10/rbln/impl/RBLNGuardImpl.h
@@ -70,6 +70,65 @@ struct RBLNGuardImpl final : public c10::impl::DeviceGuardImplInterface {
    * @return The previous stream.
    */
   c10::Stream exchangeStream(c10::Stream stream) const override;
+
+  // Events (torch.Event). RBLN has a single in-order copy queue per device and
+  // the UMD exposes only a whole-device drain, so an event records the device
+  // it was captured on and every wait maps to synchronize(device). This
+  // over-synchronizes relative to CUDA's per-event waits but is correct: the
+  // queue is in-order, so draining it covers everything recorded before.
+
+  /**
+   * @brief Marks the event as recorded on the device of the input stream.
+   * Allocates the event on first record.
+   *
+   * @param event In/out opaque event handle.
+   * @param stream The stream to record on (only its device is used).
+   * @param device_index The device index, or -1 for the stream's device.
+   * @param flag Ignored (RBLN events carry no timing).
+   */
+  void record(void** event, const c10::Stream& stream, c10::DeviceIndex device_index, c10::EventFlag flag)
+      const override;
+
+  /**
+   * @brief Makes the stream wait for the event. Host-blocks on the recorded
+   * device's queue (stronger than a device-side wait, hence correct).
+   *
+   * @param event An opaque event handle. May be null (never recorded).
+   * @param stream Unused.
+   */
+  void block(void* event, const c10::Stream& stream) const override;
+
+  /**
+   * @brief Returns true once the recorded work has completed. Drains the
+   * recorded device's queue first, so unlike CUDA this may block; it never
+   * returns false for a recorded event.
+   *
+   * @param event An opaque event handle. May be null (never recorded).
+   * @return True.
+   */
+  bool queryEvent(void* event) const override;
+
+  /**
+   * @brief Blocks the host until the recorded work has completed.
+   *
+   * @param event An opaque event handle. May be null (never recorded).
+   */
+  void synchronizeEvent(void* event) const override;
+
+  /**
+   * @brief Frees the event.
+   *
+   * @param event An opaque event handle. May be null.
+   * @param device_index Unused.
+   */
+  void destroyEvent(void* event, c10::DeviceIndex device_index) const noexcept override;
+
+  /**
+   * @brief Blocks the host until all pending work on the device has completed.
+   *
+   * @param device_index The device to synchronize.
+   */
+  void synchronizeDevice(c10::DeviceIndex device_index) const override;
 };
 
 } // namespace c10::rbln::impl

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -5,6 +5,7 @@ set(sources
   core/RBLNDeviceGuardTest.cpp
   core/RBLNFunctionsTest.cpp
   core/RBLNLoggingTest.cpp
+  core/RBLNPinnedAllocatorTest.cpp
   core/RBLNSupportedDtypesTest.cpp
   core/RBLNTensorUtilsTest.cpp
   core/RBLNV2VBatchTest.cpp

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -3,6 +3,7 @@ set(sources
   core/RBLNAllocatorTest.cpp
   core/RBLNCopyOpTest.cpp
   core/RBLNDeviceGuardTest.cpp
+  core/RBLNEventTest.cpp
   core/RBLNFunctionsTest.cpp
   core/RBLNLoggingTest.cpp
   core/RBLNPinnedAllocatorTest.cpp

--- a/test/cpp/core/RBLNEventTest.cpp
+++ b/test/cpp/core/RBLNEventTest.cpp
@@ -1,0 +1,77 @@
+#include <c10/core/impl/VirtualGuardImpl.h>
+#include <c10/rbln/RBLNFunctions.h>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <vector>
+
+class RBLNEventTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    c10::register_privateuse1_backend("rbln");
+    ASSERT_TRUE(c10::is_privateuse1_backend_registered());
+  }
+
+  void SetUp() override {
+    c10::rbln::set_device_index(0);
+  }
+};
+
+TEST_F(RBLNEventTest, NeverRecordedEventIsComplete) {
+  const c10::impl::VirtualGuardImpl impl(c10::kPrivateUse1);
+  void* event = nullptr;
+  EXPECT_TRUE(impl.queryEvent(event));
+  impl.synchronizeEvent(event); // must be a no-op, not a crash
+  impl.destroyEvent(event, 0);
+}
+
+TEST_F(RBLNEventTest, RecordSynchronizeOrdersAsyncCopy) {
+  const c10::impl::VirtualGuardImpl impl(c10::kPrivateUse1);
+  constexpr c10::DeviceIndex device_index = 0;
+  constexpr size_t nbytes = 4096;
+
+  std::vector<int8_t> src_cpu(nbytes);
+  for (size_t i = 0; i < nbytes; ++i) {
+    src_cpu[i] = static_cast<int8_t>(i % 127);
+  }
+  auto* rbln_data = c10::rbln::malloc(device_index, nbytes);
+  ASSERT_NE(rbln_data, nullptr);
+  c10::rbln::memcpy_h2v_async(rbln_data, src_cpu.data(), nbytes);
+
+  std::vector<int8_t> dst_cpu(nbytes, 0);
+  c10::rbln::memcpy_v2h_async(dst_cpu.data(), rbln_data, nbytes);
+
+  void* event = nullptr;
+  const auto stream = impl.getStream(c10::Device(c10::kPrivateUse1, device_index));
+  impl.record(&event, stream, device_index, c10::EventFlag::PYTORCH_DEFAULT);
+  impl.synchronizeEvent(event);
+  EXPECT_EQ(dst_cpu, src_cpu);
+  EXPECT_TRUE(impl.queryEvent(event));
+
+  // Recording again must reuse the handle, and block() must drain too.
+  c10::rbln::memcpy_v2h_async(dst_cpu.data(), rbln_data, nbytes);
+  impl.record(&event, stream, device_index, c10::EventFlag::PYTORCH_DEFAULT);
+  impl.block(event, stream);
+  EXPECT_EQ(dst_cpu, src_cpu);
+
+  impl.destroyEvent(event, device_index);
+  c10::rbln::free(rbln_data);
+}
+
+TEST_F(RBLNEventTest, SynchronizeDeviceDrainsQueue) {
+  const c10::impl::VirtualGuardImpl impl(c10::kPrivateUse1);
+  constexpr c10::DeviceIndex device_index = 0;
+  constexpr size_t nbytes = 4096;
+
+  std::vector<int8_t> src_cpu(nbytes, 42);
+  auto* rbln_data = c10::rbln::malloc(device_index, nbytes);
+  ASSERT_NE(rbln_data, nullptr);
+  c10::rbln::memcpy_h2v_async(rbln_data, src_cpu.data(), nbytes);
+
+  std::vector<int8_t> dst_cpu(nbytes, 0);
+  c10::rbln::memcpy_v2h_async(dst_cpu.data(), rbln_data, nbytes);
+  impl.synchronizeDevice(device_index);
+  EXPECT_EQ(dst_cpu, src_cpu);
+
+  c10::rbln::free(rbln_data);
+}

--- a/test/cpp/core/RBLNPinnedAllocatorTest.cpp
+++ b/test/cpp/core/RBLNPinnedAllocatorTest.cpp
@@ -1,0 +1,51 @@
+#include <c10/rbln/RBLNPinnedAllocator.h>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+
+class RBLNPinnedAllocatorTest : public ::testing::Test {};
+
+TEST_F(RBLNPinnedAllocatorTest, AllocateRegistersPinnedRange) {
+  auto* allocator = c10::rbln::get_pinned_memory_allocator();
+  ASSERT_NE(allocator, nullptr);
+
+  constexpr size_t nbytes = 4097; // deliberately unaligned size
+  auto data_ptr = allocator->allocate(nbytes);
+  auto* base = static_cast<uint8_t*>(data_ptr.get());
+  ASSERT_NE(base, nullptr);
+  EXPECT_EQ(data_ptr.device().type(), c10::DeviceType::CPU);
+
+  // Base, interior, and last byte resolve as pinned; one-past-end does not.
+  EXPECT_TRUE(c10::rbln::is_pinned_ptr(base));
+  EXPECT_TRUE(c10::rbln::is_pinned_ptr(base + nbytes / 2));
+  EXPECT_TRUE(c10::rbln::is_pinned_ptr(base + nbytes - 1));
+  EXPECT_FALSE(c10::rbln::is_pinned_ptr(base + nbytes));
+
+  // The memory must be writable end to end.
+  std::memset(base, 0xAB, nbytes);
+  EXPECT_EQ(base[nbytes - 1], 0xAB);
+}
+
+TEST_F(RBLNPinnedAllocatorTest, FreeUnregistersPinnedRange) {
+  auto* allocator = c10::rbln::get_pinned_memory_allocator();
+  void* base = nullptr;
+  {
+    auto data_ptr = allocator->allocate(1024);
+    base = data_ptr.get();
+    EXPECT_TRUE(c10::rbln::is_pinned_ptr(base));
+  }
+  EXPECT_FALSE(c10::rbln::is_pinned_ptr(base));
+}
+
+TEST_F(RBLNPinnedAllocatorTest, NullAndForeignPointersAreNotPinned) {
+  EXPECT_FALSE(c10::rbln::is_pinned_ptr(nullptr));
+  int local = 0;
+  EXPECT_FALSE(c10::rbln::is_pinned_ptr(&local));
+}
+
+TEST_F(RBLNPinnedAllocatorTest, ZeroByteAllocationIsNull) {
+  auto data_ptr = c10::rbln::get_pinned_memory_allocator()->allocate(0);
+  EXPECT_EQ(data_ptr.get(), nullptr);
+  EXPECT_FALSE(c10::rbln::is_pinned_ptr(data_ptr.get()));
+}

--- a/test/rbln/test_event.py
+++ b/test/rbln/test_event.py
@@ -1,0 +1,71 @@
+# Owner(s): ["module: PrivateUse1"]
+
+"""
+Test suite for torch.Event with the RBLN backend.
+
+RBLN has a single in-order copy queue per device, so an event records the
+device it was captured on and every wait drains that device's queue. This
+gives `torch.Event` the CUDA usage pattern (record after a `non_blocking`
+copy, synchronize before reading the host buffer) without per-event fences.
+"""
+
+import pytest
+import torch
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+@pytest.mark.test_set_ci
+class TestEvent(TestCase):
+    def test_event_default_device_is_rbln(self):
+        event = torch.Event()
+        self.assertEqual(event.device.type, "rbln")
+        self.assertIs(torch.rbln.Event, torch.Event)
+
+    def test_query_before_record_is_true(self):
+        self.assertTrue(torch.Event().query())
+
+    def test_synchronize_before_record_is_noop(self):
+        torch.Event().synchronize()
+
+    def test_record_synchronize_d2h_pinned(self):
+        # The vllm-rbln transfer_event pattern: non_blocking D2H into a pinned
+        # buffer, record, synchronize, then read on the host.
+        src = torch.randn(256, 256)
+        dev = src.to("rbln")
+        pinned = torch.empty_like(src, pin_memory=True)
+        event = torch.Event()
+        pinned.copy_(dev, non_blocking=True)
+        event.record()
+        event.synchronize()
+        self.assertEqual(pinned, src)
+        self.assertTrue(event.query())
+
+    def test_record_synchronize_h2d_pinned(self):
+        src = torch.randn(128, 128).pin_memory()
+        dev = src.to("rbln", non_blocking=True)
+        event = torch.Event()
+        event.record()
+        event.synchronize()
+        self.assertEqual(dev.cpu(), src)
+
+    def test_event_is_reusable(self):
+        src = torch.arange(1024, dtype=torch.int64).reshape(-1, 1)
+        dev = src.to("rbln")
+        pinned = torch.empty_like(src, pin_memory=True)
+        event = torch.Event()
+        for _ in range(4):
+            pinned.copy_(dev, non_blocking=True)
+            event.record()
+            event.synchronize()
+            self.assertEqual(pinned.flatten().tolist(), list(range(1024)))
+
+    def test_elapsed_time_unsupported(self):
+        start, end = torch.Event(enable_timing=True), torch.Event(enable_timing=True)
+        start.record()
+        end.record()
+        with self.assertRaisesRegex(RuntimeError, "elapsedTime"):
+            start.elapsed_time(end)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/rbln/test_event.py
+++ b/test/rbln/test_event.py
@@ -19,7 +19,6 @@ class TestEvent(TestCase):
     def test_event_default_device_is_rbln(self):
         event = torch.Event()
         self.assertEqual(event.device.type, "rbln")
-        self.assertIs(torch.rbln.Event, torch.Event)
 
     def test_query_before_record_is_true(self):
         self.assertTrue(torch.Event().query())

--- a/test/rbln/test_pin_memory.py
+++ b/test/rbln/test_pin_memory.py
@@ -107,6 +107,19 @@ class TestPinMemoryCopy(TestCase):
         torch.rbln.synchronize()
         self.assertEqual(dst, src)
 
+    def test_pageable_non_blocking_safe_without_sync(self, device):
+        # CUDA semantics: a non_blocking copy to pageable host downgrades to
+        # sync, so reading the result immediately (no synchronize) is correct.
+        src = torch.randn(256, 256)
+        dev = src.to(device)
+        host = dev.to("cpu", non_blocking=True)
+        self.assertEqual(host, src)
+
+    def test_pageable_non_blocking_h2d(self, device):
+        src = torch.randn(128, 128)
+        dev = src.to(device, non_blocking=True)
+        self.assertEqual(dev.cpu(), src)
+
 
 instantiate_device_type_tests(TestPinMemoryCopy, globals(), only_for="privateuse1")
 

--- a/test/rbln/test_pin_memory.py
+++ b/test/rbln/test_pin_memory.py
@@ -1,0 +1,114 @@
+# Owner(s): ["module: PrivateUse1"]
+
+"""
+Test suite for pinned host memory with the RBLN backend.
+
+Covers the standard `pin_memory` UX while RBLN is the active accelerator:
+1. `torch.tensor(..., pin_memory=True)` and `torch.empty(..., pin_memory=True)`
+2. `Tensor.pin_memory()` / `Tensor.is_pinned()`
+3. DataLoader with `pin_memory=True`
+4. `non_blocking=True` copies from/to pinned host tensors
+"""
+
+import pytest
+import torch
+from torch.testing._internal.common_device_type import dtypes, instantiate_device_type_tests
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+from test.utils import SUPPORTED_DTYPES
+
+
+@pytest.mark.test_set_ci
+class TestPinMemory(TestCase):
+    """Pinned host allocation and is_pinned semantics (no device transfer involved)."""
+
+    def test_tensor_factory_pin_memory(self):
+        # Repro of vllm-rbln-internal#122: must not raise NotImplementedError.
+        t = torch.tensor([[1], [2], [3]], dtype=torch.long, device="cpu", pin_memory=True)
+        self.assertEqual(t.device.type, "cpu")
+        self.assertTrue(t.is_pinned())
+        self.assertEqual(t.cpu(), torch.tensor([[1], [2], [3]], dtype=torch.long))
+
+    def test_empty_factory_pin_memory(self):
+        t = torch.empty(64, 64, pin_memory=True)
+        self.assertEqual(t.device.type, "cpu")
+        self.assertTrue(t.is_pinned())
+
+    def test_pin_memory_method(self):
+        t = torch.randn(16, 16)
+        self.assertFalse(t.is_pinned())
+        pinned = t.pin_memory()
+        self.assertTrue(pinned.is_pinned())
+        self.assertEqual(pinned, t)
+        # pin_memory() on an already-pinned tensor must be a no-op alias.
+        self.assertIs(pinned.pin_memory(), pinned)
+
+    def test_view_of_pinned_is_pinned(self):
+        t = torch.randn(8, 8, pin_memory=True)
+        self.assertTrue(t[2:5].is_pinned())
+        self.assertTrue(t.view(-1)[7:].is_pinned())
+
+    def test_zero_size_tensor(self):
+        t = torch.empty(0, pin_memory=True)
+        self.assertEqual(t.numel(), 0)
+
+    def test_pageable_is_not_pinned(self):
+        self.assertFalse(torch.randn(8).is_pinned())
+
+    def test_pinned_freed_then_pageable_not_pinned(self):
+        # After a pinned tensor is freed its address must leave the registry.
+        for _ in range(4):
+            t = torch.empty(1024, pin_memory=True)
+            self.assertTrue(t.is_pinned())
+            del t
+            self.assertFalse(torch.empty(1024).is_pinned())
+
+    def test_dataloader_pin_memory(self):
+        dataset = torch.utils.data.TensorDataset(torch.arange(32, dtype=torch.float32).reshape(8, 4))
+        loader = torch.utils.data.DataLoader(dataset, batch_size=4, pin_memory=True)
+        batches = [b[0] for b in loader]
+        self.assertTrue(all(b.is_pinned() for b in batches))
+        self.assertEqual(torch.cat(batches), torch.arange(32, dtype=torch.float32).reshape(8, 4))
+
+
+@pytest.mark.test_set_ci
+class TestPinMemoryCopy(TestCase):
+    """Pinned host <-> RBLN device transfers, including the non_blocking path."""
+
+    @dtypes(*SUPPORTED_DTYPES)
+    def test_h2d_from_pinned(self, device, dtype):
+        src = torch.randn(64, 64).to(dtype).pin_memory()
+        dev = src.to(device)
+        self.assertEqual(dev.cpu(), src)
+
+    @dtypes(*SUPPORTED_DTYPES)
+    def test_h2d_from_pinned_non_blocking(self, device, dtype):
+        src = torch.randn(64, 64).to(dtype).pin_memory()
+        dev = src.to(device, non_blocking=True)
+        torch.rbln.synchronize()
+        self.assertEqual(dev.cpu(), src)
+
+    @dtypes(*SUPPORTED_DTYPES)
+    def test_d2h_to_pinned_non_blocking(self, device, dtype):
+        src = torch.randn(64, 64).to(dtype)
+        dev = src.to(device)
+        dst = torch.empty_like(src, pin_memory=True)
+        dst.copy_(dev, non_blocking=True)
+        torch.rbln.synchronize()
+        self.assertTrue(dst.is_pinned())
+        self.assertEqual(dst, src)
+
+    def test_pinned_roundtrip_unaligned(self, device):
+        # Odd byte count exercises the unaligned D2H bounce path under pinned dst.
+        src = torch.randn(4097).to(torch.float16).pin_memory()
+        dev = src.to(device)
+        dst = torch.empty_like(src, pin_memory=True)
+        dst.copy_(dev, non_blocking=True)
+        torch.rbln.synchronize()
+        self.assertEqual(dst, src)
+
+
+instantiate_device_type_tests(TestPinMemoryCopy, globals(), only_for="privateuse1")
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch_rbln/device/device.py
+++ b/torch_rbln/device/device.py
@@ -26,7 +26,14 @@ __all__ = [
     "device",
     "device_of",
     "device_summary",
+    "Event",
 ]
+
+# RBLN device events, e.g. to synchronize a `non_blocking` copy into a pinned
+# host tensor before reading it (mirrors the `torch.cuda.Event` pattern).
+# RBLN has a single in-order copy queue, so waiting on an event drains the
+# device queue; `enable_timing` is not supported.
+Event = torch.Event
 
 
 def current_device() -> int:

--- a/torch_rbln/device/device.py
+++ b/torch_rbln/device/device.py
@@ -26,14 +26,7 @@ __all__ = [
     "device",
     "device_of",
     "device_summary",
-    "Event",
 ]
-
-# RBLN device events, e.g. to synchronize a `non_blocking` copy into a pinned
-# host tensor before reading it (mirrors the `torch.cuda.Event` pattern).
-# RBLN has a single in-order copy queue, so waiting on an event drains the
-# device queue; `enable_timing` is not supported.
-Event = torch.Event
 
 
 def current_device() -> int:


### PR DESCRIPTION
## Summary of Changes

This PR adds pinned host memory and `torch.Event` support to the RBLN backend, completing the `pin_memory` + `non_blocking` copy path. Motivation: vllm-rbln currently disables `is_pin_memory_available()` and keeps its `transfer_event` record/synchronize lines commented out because RBLN lacked both pieces (rebellions-sw/vllm-rbln-internal#122); enabling them is a vllm-rbln follow-up PR.

**Problem 1 — pin_memory crashes.** Importing `torch_rbln` registers RBLN as the PrivateUse1 accelerator, which routes every CPU `pin_memory=True` allocation to the PrivateUse1 hooks' `getPinnedMemoryAllocator()`. RBLN did not implement it, so **creating a plain CPU tensor with `pin_memory=True` raised `NotImplementedError`**.

**Problem 2 — pageable non_blocking host-read race.** #13 dispatches `non_blocking=True` async regardless of the host memory type. Reading a pageable dst without `torch.rbln.synchronize()` races (no auto-drain on host read; rebellions-sw/rebel_compiler#11343 covers device-side hazards only). vllm-rbln has 27 such call sites today. Gating on pinned was deferred in the #13 review solely because no pinned allocator existed.

**Problem 3 — no event to fence an async copy.** Once pinned copies are truly async, the caller must fence before reading. The device-agnostic pattern is `pinned.copy_(t, non_blocking=True); event.record(); event.synchronize()` — but `torch.Event` raised "Backend doesn't support events" on RBLN. Whole-device `torch.rbln.synchronize()` existed, but events are what device-agnostic callers (vLLM, torch.accelerator) actually use.

**Solution.**

| Commit | Change |
|---|---|
| `feat(memory)` | `RBLNPinnedAllocator`: page-aligned + best-effort `mlock`; base→size registry backs `isPinnedPtr` (interior pointers / views work); hooks overrides |
| `feat(copy)` | Gate non_blocking on host memory type, matching PyTorch's documented CUDA semantics: pageable host → sync (safe to read without synchronize); pinned host → async (caller fences) |
| `feat(event)` | `torch.Event`: single in-order copy queue → an event records its device, every wait maps to `synchronize(device)`. Also `synchronizeDevice`, so `torch.accelerator.synchronize()` works |

```
non_blocking=True ──► host pinned? ──► yes ──► async dispatch (record event, sync before read)
                              └─────► no  ──► sync copy (read immediately)
```

Design notes:
- UMD has no DMA-mapped host alloc yet; stage 1 is `mlock` page locking. When the API lands only allocate/free change.
- DataPtr device is CPU — pinned tensors keep standard semantics.
- Events carry no timing (`elapsed_time` raises); `query()` drains then returns true, so it may block — review polling loops when adopting.
- Event waits drain the whole device queue (no per-event fences); correct by queue order, just over-synchronizes.
- Streams stay default-only; per-stream events and `wait_stream` are no-ops by queue order. Separate issue if multi-queue ever lands.

---

## Related Issues / Tickets

* Resolves rebellions-sw/vllm-rbln-internal#122
* Related to #13 (stacked PR — retarget to dev after #13 merges)

---

## Type of Change

- [x] `feature` — New capability or functionality
- [x] `core` — Changes to RBLN backend, device layer, C++ extension, op registration, or `torch.compile` integration

---

## Affected Modules

- [x] Backend
- [x] Memory
- [x] C++ extension (`torch_rbln/csrc`)

---

## How to Test (if applicable)

1. Issue repro: `python -c "import torch_rbln, torch; t = torch.tensor([[1],[2],[3]], dtype=torch.long, pin_memory=True); print(t.is_pinned())"` → `True` (previously NotImplementedError)
2. `pytest test/rbln/test_pin_memory.py` → 14 passed (incl. pageable non_blocking read-without-sync correctness)
3. `pytest test/rbln/test_event.py` → 7 passed (incl. pinned D2H → record → synchronize → tolist)
4. `ctest --test-dir ./build -R Pinned` → 4 passed; `test_cpp_RBLNEventTest` → 3 passed
5. Regression: `pytest test/rbln/test_pin_memory.py test/rbln/test_tensor_copy.py test/rbln/test_rbln_apis.py` → 328 passed

Verified with rebel-compiler==0.10.5.dev187+g95f45d1f, ATOM, torch 2.11.0+cpu.

---

## Checklist

* [x] PR title follows Conventional Commits format
* [x] This PR is linked to a corresponding issue
* [x] Linting passes (ruff, clang-format)
* [ ] All CI tests pass
* [x] The test method is described, and the expected result is clearly stated
* [x] Relevant documentation has been updated (if applicable)

---

## Notes

The gate downgrades today's pageable non_blocking copies (1.35–2.5x in #13) to sync until callers pin. This trades that speedup for correctness-by-construction; perf-sensitive paths opt back in via `.pin_memory()` + event sync.

Reviewer — Primary: (TBD) / Secondary: (code owners). Please assign a primary reviewer before merge.
