### PR TITLE
fix: use lightweight get_torch_device_id on copy hot paths

### DIFF
--- a/c10/rbln/RBLNFunctions.cpp
+++ b/c10/rbln/RBLNFunctions.cpp
@@ -183,9 +183,26 @@ c10::DeviceIndex exchange_device_index(c10::DeviceIndex device_index) {
   return original_device_index;
 }
 
+c10::DeviceIndex get_torch_device_id(const void* data) {
+  RBLN_LOG_DEBUG("data={}", fmt::ptr(data));
+  RBLN_CHECK(data != nullptr, "data cannot be nullptr");
+
+  const auto vaddr = reinterpret_cast<uint64_t>(data);
+  uint32_t torch_device_id = 0;
+  RBLN_CHECK(!::rbln::rbln_get_torch_device_id_from_vaddr(vaddr, torch_device_id));
+  return static_cast<c10::DeviceIndex>(torch_device_id);
+}
+
 ::rbln::MemoryInfo get_memory_info(const void* data) {
   RBLN_LOG_DEBUG("data={}", fmt::ptr(data));
   RBLN_CHECK(data != nullptr, "data cannot be nullptr");
+  // get_memory_info() does a full VMemory JSON serialize+parse round-trip on
+  // every call. Warn so unexpected hot-path callers are easy to spot in logs;
+  // when only the device id is needed, get_torch_device_id() is the cheap path.
+  RBLN_LOG_WARN(
+      "get_memory_info({}) performs a full VMemory JSON round-trip (slow) — avoid on performance hot paths; "
+      "use get_torch_device_id() when only the device id is needed",
+      fmt::ptr(data));
 
   const auto vaddr = reinterpret_cast<uint64_t>(data);
   ::rbln::MemoryInfo memory_info;
@@ -294,10 +311,8 @@ void memcpy_v2v(void* rbln_dst_data, const void* rbln_src_data, size_t nbytes) {
   const auto dst_vaddr = reinterpret_cast<uint64_t>(rbln_dst_data);
   const auto size = static_cast<uint64_t>(nbytes);
 
-  uint32_t src_torch_device_id = 0;
-  uint32_t dst_torch_device_id = 0;
-  RBLN_CHECK(!::rbln::rbln_get_torch_device_id_from_vaddr(src_vaddr, src_torch_device_id));
-  RBLN_CHECK(!::rbln::rbln_get_torch_device_id_from_vaddr(dst_vaddr, dst_torch_device_id));
+  const auto src_torch_device_id = get_torch_device_id(rbln_src_data);
+  const auto dst_torch_device_id = get_torch_device_id(rbln_dst_data);
 
   RBLN_LOG_DEBUG(
       "src=rbln:{}, dst=rbln:{}", static_cast<int>(src_torch_device_id), static_cast<int>(dst_torch_device_id));

--- a/c10/rbln/RBLNFunctions.cpp
+++ b/c10/rbln/RBLNFunctions.cpp
@@ -386,10 +386,8 @@ void memcpy_v2v_async(void* rbln_dst_data, const void* rbln_src_data, size_t nby
   const auto dst_vaddr = reinterpret_cast<uint64_t>(rbln_dst_data);
   const auto size = static_cast<uint64_t>(nbytes);
 
-  uint32_t src_torch_device_id = 0;
-  uint32_t dst_torch_device_id = 0;
-  RBLN_CHECK(!::rbln::rbln_get_torch_device_id_from_vaddr(src_vaddr, src_torch_device_id));
-  RBLN_CHECK(!::rbln::rbln_get_torch_device_id_from_vaddr(dst_vaddr, dst_torch_device_id));
+  const auto src_torch_device_id = get_torch_device_id(rbln_src_data);
+  const auto dst_torch_device_id = get_torch_device_id(rbln_dst_data);
 
   if (src_torch_device_id != dst_torch_device_id) {
     // rbln_memcpy_v2v_async only handles same-device copies; cross-device needs

--- a/c10/rbln/RBLNFunctions.h
+++ b/c10/rbln/RBLNFunctions.h
@@ -89,7 +89,24 @@ C10_RBLN_API void set_device_index(c10::DeviceIndex device_index);
 C10_RBLN_API c10::DeviceIndex exchange_device_index(c10::DeviceIndex device_index);
 
 /**
+ * @brief Returns the torch device id backing a device pointer.
+ *
+ * Lightweight counterpart to get_memory_info() for the common case where only
+ * the owning device is needed: it calls rbln_get_torch_device_id_from_vaddr()
+ * directly and avoids the full VMemory JSON round-trip that get_memory_info()
+ * performs. Prefer this on performance hot paths.
+ *
+ * @param data A pointer to device memory.
+ * @return The torch device id (as a c10::DeviceIndex) backing the pointer.
+ */
+C10_RBLN_API c10::DeviceIndex get_torch_device_id(const void* data);
+
+/**
  * @brief Retrieves memory information for a given data pointer.
+ *
+ * @note This performs a full VMemory JSON round-trip and is expensive — keep it
+ * off performance hot paths. When only the owning device is needed, use
+ * get_torch_device_id() instead.
  *
  * @param data A pointer to device memory.
  * @return Memory information associated with the given data pointer.

--- a/c10/rbln/RBLNHooksInterface.cpp
+++ b/c10/rbln/RBLNHooksInterface.cpp
@@ -44,12 +44,7 @@ bool RBLNHooksInterface::hasRBLN() const {
 
 c10::Device RBLNHooksInterface::getDeviceFromPtr(void* data) const {
   RBLN_LOG_DEBUG("data={}", fmt::ptr(data));
-
-  const auto memory_info = c10::rbln::get_memory_info(data);
-  RBLN_LOG_DEBUG("memory_info={}", c10::rbln::to_string(memory_info));
-
-  const auto torch_device_id = memory_info.torch_device_id;
-  const auto device_index = static_cast<c10::DeviceIndex>(torch_device_id);
+  const auto device_index = c10::rbln::get_torch_device_id(data);
   const auto device = c10::Device(c10::kPrivateUse1, device_index);
   RBLN_LOG_DEBUG("device={}", c10::str(device));
   return device;

--- a/c10/rbln/RBLNV2VBatch.cpp
+++ b/c10/rbln/RBLNV2VBatch.cpp
@@ -34,14 +34,14 @@ inline void update_homogeneity(bool& homogeneous, c10::DeviceIndex& anchor, cons
   if (!homogeneous) {
     return;
   }
-  const auto s = static_cast<c10::DeviceIndex>(get_memory_info(src).torch_device_id);
+  const auto s = get_torch_device_id(src);
   if (anchor < 0) {
     anchor = s;
   } else if (anchor != s) {
     homogeneous = false;
     return;
   }
-  const auto d = static_cast<c10::DeviceIndex>(get_memory_info(dst).torch_device_id);
+  const auto d = get_torch_device_id(dst);
   if (s != d) {
     homogeneous = false;
   }

--- a/test/cpp/core/RBLNFunctionsTest.cpp
+++ b/test/cpp/core/RBLNFunctionsTest.cpp
@@ -285,6 +285,27 @@ TEST_F(RBLNFunctionsTest, GetUninitializedMemoryInfo) {
   }
 }
 
+TEST_F(RBLNFunctionsTest, GetTorchDeviceId) {
+  const auto device_count = c10::rbln::get_device_count();
+  EXPECT_GE(device_count, 1);
+  for (c10::DeviceIndex device_index = 0; device_index < device_count; ++device_index) {
+    const auto data = c10::rbln::malloc(device_index, size_1gib_);
+    EXPECT_TRUE(data != nullptr);
+
+    // The lightweight helper must report the owning device...
+    EXPECT_EQ(c10::rbln::get_torch_device_id(data), device_index);
+    // ...and agree with the full get_memory_info() round-trip it replaces.
+    EXPECT_EQ(c10::rbln::get_torch_device_id(data), static_cast<c10::DeviceIndex>(c10::rbln::get_memory_info(data).torch_device_id));
+
+    c10::rbln::free(data);
+  }
+}
+
+TEST_F(RBLNFunctionsTest, GetTorchDeviceIdNullPtr) {
+  void* data = nullptr;
+  EXPECT_THROW(c10::rbln::get_torch_device_id(data), c10::Error);
+}
+
 TEST_F(RBLNFunctionsTest, Synchronize) {
   const auto device_count = c10::rbln::get_device_count();
   EXPECT_GE(device_count, 1);

--- a/test/cpp/core/RBLNFunctionsTest.cpp
+++ b/test/cpp/core/RBLNFunctionsTest.cpp
@@ -295,7 +295,9 @@ TEST_F(RBLNFunctionsTest, GetTorchDeviceId) {
     // The lightweight helper must report the owning device...
     EXPECT_EQ(c10::rbln::get_torch_device_id(data), device_index);
     // ...and agree with the full get_memory_info() round-trip it replaces.
-    EXPECT_EQ(c10::rbln::get_torch_device_id(data), static_cast<c10::DeviceIndex>(c10::rbln::get_memory_info(data).torch_device_id));
+    EXPECT_EQ(
+        c10::rbln::get_torch_device_id(data),
+        static_cast<c10::DeviceIndex>(c10::rbln::get_memory_info(data).torch_device_id));
 
     c10::rbln::free(data);
   }


### PR DESCRIPTION
<!--
Thank you for contributing to torch-rbln!
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: docs/CONTRIBUTING.md
-->

## Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format.
see: https://www.conventionalcommits.org/en/v1.0.0/
-->

<!-- Describe your changes in detail -->

`get_memory_info()` does a full VMemory JSON serialize+parse round-trip, yet several call sites only needed the owning device id — which is just `GetTorchDeviceIdFromVAddr(vaddr)` underneath.
Added a lightweight `get_torch_device_id()` helper and routed `getDeviceFromPtr`, `memcpy_v2v`, and `V2VBatch` through it (dropping the expensive `get_memory_info()` from the hot path), plus a warning on `get_memory_info()` to flag any future hot-path callers.

---

## Related Issues / Tickets

<!--
All pull requests must have a corresponding issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
see: docs/CONTRIBUTING.md#pull-request-guidelines
-->

* Resolves #
* Related to #

---

## Type of Change

<!--
Select the type that best describes your PR. This should match the issue label.
see: docs/CONTRIBUTING.md#development-related-issue
-->

- [ ] `feature` — New capability or functionality
- [ ] `core` — Changes to RBLN backend, device layer, C++ extension, op registration, or `torch.compile` integration
- [x] `fix` — Bug fix
- [x] `perf` — Performance improvement
- [ ] `refactor` — Code improvement without behavior change
- [ ] `docs` — Documentation only
- [ ] `other` — Other (describe below)

---

## Affected Modules

<!--
Check all modules affected by this change.
-->

- [x] Backend
- [ ] Device
- [ ] Ops/Kernels
- [ ] `torch.compile`
- [ ] C++ extension (`torch_rbln/csrc`)
- [ ] Memory
- [ ] Build/Tools
- [ ] Docs

---

## How to Test (if applicable)

<!--
Describe the steps to verify your changes. Include expected results.
see: docs/TEST_GUIDE.md
-->

1. Run `...`
2. Verify output: `...`
3. Edge case tested: `...`

---

## Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

## Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
* [ ] This PR is linked to a corresponding issue — see [Contributing to torch-rbln](docs/CONTRIBUTING.md)
* [ ] Linting passes — see [Linting](docs/LINTING.md)
* [ ] All CI tests pass — see [CI/CD Workflows](docs/WORKFLOWS.md)
* [ ] The test method is described, and the expected result is clearly stated (if applicable)
* [ ] Relevant documentation has been updated (if applicable)

---

## Notes

<!-- Anything reviewers should pay extra attention to? -->

---
