### PR TITLE
feat(rbln): default to weight-free compilation (RBLN_WEIGHT_FREE=on)

### DIFF
--- a/constraints-build-dev.txt
+++ b/constraints-build-dev.txt
@@ -1,2 +1,2 @@
 # Build/dev dependency constraints (single source of truth).
-rebel-compiler==0.10.5.dev211+g588e481e.prod
+rebel-compiler==0.10.5.dev269+geebaa9d6

--- a/constraints-build-dev.txt
+++ b/constraints-build-dev.txt
@@ -1,2 +1,2 @@
 # Build/dev dependency constraints (single source of truth).
-rebel-compiler==0.10.5.dev293+gc9ed381a
+rebel-compiler==0.10.5.dev309+g611f1011

--- a/constraints-build-dev.txt
+++ b/constraints-build-dev.txt
@@ -1,2 +1,2 @@
 # Build/dev dependency constraints (single source of truth).
-rebel-compiler==0.10.5.dev269+geebaa9d6
+rebel-compiler==0.10.5.dev293+gc9ed381a

--- a/constraints-build-dev.txt
+++ b/constraints-build-dev.txt
@@ -1,2 +1,2 @@
 # Build/dev dependency constraints (single source of truth).
-rebel-compiler==0.10.5.dev337+a803cde65
+rebel-compiler==0.10.5.dev337+ga803cde6

--- a/constraints-build-dev.txt
+++ b/constraints-build-dev.txt
@@ -1,2 +1,2 @@
 # Build/dev dependency constraints (single source of truth).
-rebel-compiler==0.10.5.dev309+g611f1011
+rebel-compiler==0.10.5.dev337+a803cde65

--- a/test/rbln/test_weight_free.py
+++ b/test/rbln/test_weight_free.py
@@ -1,0 +1,48 @@
+# Owner(s): ["module: PrivateUse1"]
+
+"""Regression tests for weight-free (``RBLN_WEIGHT_FREE``) compilation."""
+
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+@pytest.mark.test_set_ci
+def test_weight_free_host_const_param_clean_teardown():
+    """A weight-free graph with host const params (a ``Linear`` bias) must exit
+    cleanly: the borrowed host weight must not be double-freed at teardown. Run in a
+    subprocess and checked via exit code (the crash happened at shutdown).
+    """
+    script = textwrap.dedent(
+        """
+        import torch
+        import torch.nn as nn
+        import torch_rbln  # noqa: F401
+
+        dev = torch.device("rbln:0")
+        model = nn.Linear(64, 32).to(dev, dtype=torch.float16)  # bias => host const param
+        x = torch.randn(4, 64, device=dev, dtype=torch.float16)
+        out = torch.compile(model, backend="rbln")(x)
+        assert tuple(out.shape) == (4, 32)
+        """
+    )
+    env = {**os.environ, "RBLN_WEIGHT_FREE": "on", "RBLN_DEVICES": "0"}
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert result.returncode == 0, (
+        f"weight-free teardown crashed (returncode={result.returncode}).\nSTDERR (tail):\n{result.stderr[-3000:]}"
+    )
+
+
+if __name__ == "__main__":
+    from torch.testing._internal.common_utils import run_tests
+
+    run_tests()

--- a/test/rbln/test_weight_free.py
+++ b/test/rbln/test_weight_free.py
@@ -42,6 +42,74 @@ def test_weight_free_host_const_param_clean_teardown():
     )
 
 
+# Probe the *default* selection logic in a fresh interpreter: importing torch_rbln
+# runs torch_backends_entry_point(), which sets RBLN_WEIGHT_FREE when unset. A
+# subprocess is required because the entry point is once-guarded, so the unset path
+# can only be exercised by a fresh process. Markers are unique strings so log lines
+# (which may themselves contain "RBLN_WEIGHT_FREE=...") cannot pollute parsing.
+_DEFAULT_PROBE = textwrap.dedent(
+    """
+    import os
+    import torch_rbln  # noqa: F401  -- torch_backends_entry_point() runs on import
+
+    print("__WF_ENV__=" + os.environ.get("RBLN_WEIGHT_FREE", "<unset>"))
+    try:
+        import rebel
+
+        if hasattr(rebel, "get_weight_free_mode"):
+            print("__WF_MODE__=" + str(rebel.get_weight_free_mode()))
+    except Exception:
+        pass
+    """
+)
+
+
+def _probe_weight_free_default(env_override):
+    """Run the probe with RBLN_WEIGHT_FREE forced to ``env_override`` (or removed when
+    it is not provided), returning the parsed ``__WF_ENV__`` / ``__WF_MODE__`` values."""
+    env = {k: v for k, v in os.environ.items() if k != "RBLN_WEIGHT_FREE"}
+    env.update(env_override)
+    result = subprocess.run(
+        [sys.executable, "-c", _DEFAULT_PROBE],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, (
+        f"weight-free default probe failed (returncode={result.returncode}).\nSTDERR (tail):\n{result.stderr[-2000:]}"
+    )
+    out = {}
+    for line in result.stdout.splitlines():
+        for key in ("__WF_ENV__", "__WF_MODE__"):
+            prefix = key + "="
+            if line.startswith(prefix):
+                out[key] = line[len(prefix) :]
+    return out
+
+
+@pytest.mark.test_set_ci
+def test_weight_free_default_on_when_unset():
+    """With RBLN_WEIGHT_FREE unset, importing torch_rbln must default it to ``on``
+    (the torch-like behavior). The optional MODE assertion guards that rebel actually
+    observes the value the entry point set -- i.e. it is read lazily at compile time,
+    not snapshotted before our default is applied. This breaks in CI (not in prod) if
+    a future rebel build starts caching the value earlier."""
+    out = _probe_weight_free_default({})
+    assert out.get("__WF_ENV__") == "on"
+    if "__WF_MODE__" in out:  # only on rebel builds exposing the query API
+        assert out["__WF_MODE__"] == "on"
+
+
+@pytest.mark.test_set_ci
+def test_weight_free_user_off_wins():
+    """An explicit ``RBLN_WEIGHT_FREE=off`` must win over the default."""
+    out = _probe_weight_free_default({"RBLN_WEIGHT_FREE": "off"})
+    assert out.get("__WF_ENV__") == "off"
+    if "__WF_MODE__" in out:
+        assert out["__WF_MODE__"] == "off"
+
+
 if __name__ == "__main__":
     from torch.testing._internal.common_utils import run_tests
 

--- a/test/rbln/test_weight_free.py
+++ b/test/rbln/test_weight_free.py
@@ -9,6 +9,8 @@ import textwrap
 
 import pytest
 
+import torch_rbln
+
 
 @pytest.mark.test_set_ci
 def test_weight_free_host_const_param_clean_teardown():
@@ -42,72 +44,28 @@ def test_weight_free_host_const_param_clean_teardown():
     )
 
 
-# Probe the *default* selection logic in a fresh interpreter: importing torch_rbln
-# runs torch_backends_entry_point(), which sets RBLN_WEIGHT_FREE when unset. A
-# subprocess is required because the entry point is once-guarded, so the unset path
-# can only be exercised by a fresh process. Markers are unique strings so log lines
-# (which may themselves contain "RBLN_WEIGHT_FREE=...") cannot pollute parsing.
-_DEFAULT_PROBE = textwrap.dedent(
-    """
-    import os
-    import torch_rbln  # noqa: F401  -- torch_backends_entry_point() runs on import
-
-    print("__WF_ENV__=" + os.environ.get("RBLN_WEIGHT_FREE", "<unset>"))
-    try:
-        import rebel
-
-        if hasattr(rebel, "get_weight_free_mode"):
-            print("__WF_MODE__=" + str(rebel.get_weight_free_mode()))
-    except Exception:
-        pass
-    """
-)
-
-
-def _probe_weight_free_default(env_override):
-    """Run the probe with RBLN_WEIGHT_FREE forced to ``env_override`` (or removed when
-    it is not provided), returning the parsed ``__WF_ENV__`` / ``__WF_MODE__`` values."""
-    env = {k: v for k, v in os.environ.items() if k != "RBLN_WEIGHT_FREE"}
-    env.update(env_override)
-    result = subprocess.run(
-        [sys.executable, "-c", _DEFAULT_PROBE],
-        env=env,
-        capture_output=True,
-        text=True,
-        timeout=120,
-    )
-    assert result.returncode == 0, (
-        f"weight-free default probe failed (returncode={result.returncode}).\nSTDERR (tail):\n{result.stderr[-2000:]}"
-    )
-    out = {}
-    for line in result.stdout.splitlines():
-        for key in ("__WF_ENV__", "__WF_MODE__"):
-            prefix = key + "="
-            if line.startswith(prefix):
-                out[key] = line[len(prefix) :]
-    return out
+# The default-selection logic is unit-tested in-process against the pure helper
+# ``torch_rbln._apply_weight_free_default()``. monkeypatch isolates RBLN_WEIGHT_FREE
+# per test and restores it afterwards. (In-process avoids coupling to subprocess
+# import resolution -- a fresh `python -c "import torch_rbln"` resolves the *installed*
+# package, which may differ from the source tree under test.)
 
 
 @pytest.mark.test_set_ci
-def test_weight_free_default_on_when_unset():
-    """With RBLN_WEIGHT_FREE unset, importing torch_rbln must default it to ``on``
-    (the torch-like behavior). The optional MODE assertion guards that rebel actually
-    observes the value the entry point set -- i.e. it is read lazily at compile time,
-    not snapshotted before our default is applied. This breaks in CI (not in prod) if
-    a future rebel build starts caching the value earlier."""
-    out = _probe_weight_free_default({})
-    assert out.get("__WF_ENV__") == "on"
-    if "__WF_MODE__" in out:  # only on rebel builds exposing the query API
-        assert out["__WF_MODE__"] == "on"
+def test_weight_free_default_on_when_unset(monkeypatch):
+    """With RBLN_WEIGHT_FREE unset, the selection logic defaults it to ``on`` (the
+    torch-like behavior)."""
+    monkeypatch.delenv("RBLN_WEIGHT_FREE", raising=False)
+    torch_rbln._apply_weight_free_default()
+    assert os.environ["RBLN_WEIGHT_FREE"] == "on"
 
 
 @pytest.mark.test_set_ci
-def test_weight_free_user_off_wins():
+def test_weight_free_user_off_wins(monkeypatch):
     """An explicit ``RBLN_WEIGHT_FREE=off`` must win over the default."""
-    out = _probe_weight_free_default({"RBLN_WEIGHT_FREE": "off"})
-    assert out.get("__WF_ENV__") == "off"
-    if "__WF_MODE__" in out:
-        assert out["__WF_MODE__"] == "off"
+    monkeypatch.setenv("RBLN_WEIGHT_FREE", "off")
+    torch_rbln._apply_weight_free_default()
+    assert os.environ["RBLN_WEIGHT_FREE"] == "off"
 
 
 if __name__ == "__main__":

--- a/torch_rbln/__init__.py
+++ b/torch_rbln/__init__.py
@@ -5,6 +5,7 @@ from importlib.metadata import PackageNotFoundError, version
 from typing import Any  # noqa: UP035
 
 from torch_rbln._internal.env_utils import is_diagnose_mode
+from torch_rbln._internal.log_utils import rbln_log_debug
 from torch_rbln._internal.tvm_libinfo import get_dll_directories, get_dll_directory_candidates
 
 
@@ -25,6 +26,16 @@ def torch_backends_entry_point() -> None:
     if status != "uninitialized":
         return
     status = "initializing"
+
+    # Default to weight-free compilation (weights applied at runtime, not baked into
+    # the .rbln artifact) — the more torch-like behavior. "on" is rebel's canonical
+    # value; set it only when the user hasn't, so RBLN_WEIGHT_FREE=off still wins.
+    if "RBLN_WEIGHT_FREE" not in os.environ:
+        os.environ["RBLN_WEIGHT_FREE"] = "on"
+        rbln_log_debug(
+            "Defaulting RBLN_WEIGHT_FREE='on' (weight-free compilation); set RBLN_WEIGHT_FREE=off to opt out."
+        )
+
     try:
         # Import torch early so libtorch.so / libc10.so are loaded before our
         # native extensions (which link against them).  When the wheel is built

--- a/torch_rbln/__init__.py
+++ b/torch_rbln/__init__.py
@@ -19,6 +19,28 @@ libraries: list[ctypes.CDLL] = []
 status: str = "uninitialized"
 
 
+def _apply_weight_free_default() -> None:
+    """Default ``RBLN_WEIGHT_FREE`` to ``on`` (weight-free, the torch-like default) when
+    the user hasn't set it; an explicit value always wins. Weight-free keeps weights as
+    host tensors applied to the runtime at load time instead of baking them into the
+    ``.rbln`` artifact; ``on`` is rebel's canonical value.
+
+    Logged at INFO so the decision is discoverable at ``TORCH_RBLN_LOG_LEVEL=INFO``
+    without spamming the default (``WARNING``) level. Weight-free is the norm, so the
+    opt-out (``off``) gets its own note. Extracted as a pure helper so the selection
+    logic is unit-testable in-process (no subprocess needed)."""
+    if "RBLN_WEIGHT_FREE" not in os.environ:
+        os.environ["RBLN_WEIGHT_FREE"] = "on"
+        rbln_log_info(
+            "Defaulting RBLN_WEIGHT_FREE='on' (weight-free compilation); set RBLN_WEIGHT_FREE=off to opt out."
+        )
+    elif os.environ["RBLN_WEIGHT_FREE"].lower() == "off":
+        rbln_log_info(
+            "RBLN_WEIGHT_FREE=off: weight-free compilation disabled; using weight-baked "
+            "compilation (the default is weight-free)."
+        )
+
+
 def torch_backends_entry_point() -> None:
     # Begin initialization #####################################################
     # For once call
@@ -27,20 +49,7 @@ def torch_backends_entry_point() -> None:
         return
     status = "initializing"
 
-    # Default to weight-free compilation (weights applied at runtime, not baked into
-    # the .rbln artifact) — the more torch-like behavior. "on" is rebel's canonical
-    # value; set it only when the user hasn't, so RBLN_WEIGHT_FREE=off still wins.
-    if "RBLN_WEIGHT_FREE" not in os.environ:
-        os.environ["RBLN_WEIGHT_FREE"] = "on"
-        rbln_log_info(
-            "Defaulting RBLN_WEIGHT_FREE='on' (weight-free compilation); set RBLN_WEIGHT_FREE=off to opt out."
-        )
-    elif os.environ["RBLN_WEIGHT_FREE"].lower() == "off":
-        # Weight-free is the torch-like default; surface only the opt-out (the exception).
-        rbln_log_info(
-            "RBLN_WEIGHT_FREE=off: weight-free compilation disabled; using weight-baked "
-            "compilation (the default is weight-free)."
-        )
+    _apply_weight_free_default()
 
     try:
         # Import torch early so libtorch.so / libc10.so are loaded before our
@@ -51,6 +60,8 @@ def torch_backends_entry_point() -> None:
         import torch
 
         # Load shared objects ##################################################
+        global library_names, libraries  # noqa: F824  (kept for documentation; both are mutated in place)
+
         # Ensure dependent shared library is loaded before importing native extension
         find_and_load_tvm_library("librbln.so")
 

--- a/torch_rbln/__init__.py
+++ b/torch_rbln/__init__.py
@@ -5,7 +5,7 @@ from importlib.metadata import PackageNotFoundError, version
 from typing import Any  # noqa: UP035
 
 from torch_rbln._internal.env_utils import is_diagnose_mode
-from torch_rbln._internal.log_utils import rbln_log_debug
+from torch_rbln._internal.log_utils import rbln_log_info
 from torch_rbln._internal.tvm_libinfo import get_dll_directories, get_dll_directory_candidates
 
 
@@ -32,8 +32,14 @@ def torch_backends_entry_point() -> None:
     # value; set it only when the user hasn't, so RBLN_WEIGHT_FREE=off still wins.
     if "RBLN_WEIGHT_FREE" not in os.environ:
         os.environ["RBLN_WEIGHT_FREE"] = "on"
-        rbln_log_debug(
+        rbln_log_info(
             "Defaulting RBLN_WEIGHT_FREE='on' (weight-free compilation); set RBLN_WEIGHT_FREE=off to opt out."
+        )
+    elif os.environ["RBLN_WEIGHT_FREE"].lower() == "off":
+        # Weight-free is the torch-like default; surface only the opt-out (the exception).
+        rbln_log_info(
+            "RBLN_WEIGHT_FREE=off: weight-free compilation disabled; using weight-baked "
+            "compilation (the default is weight-free)."
         )
 
     try:
@@ -45,8 +51,6 @@ def torch_backends_entry_point() -> None:
         import torch
 
         # Load shared objects ##################################################
-        global library_names, libraries
-
         # Ensure dependent shared library is loaded before importing native extension
         find_and_load_tvm_library("librbln.so")
 


### PR DESCRIPTION
## Summary
Enables weight-free ("weightless") compilation by default. In this mode rebel-compiler does not bake parameters/buffers into the compiled `.rbln` artifact; the weights stay as host PyTorch tensors on the `nn.Module` and are applied to the runtime at load time. This is the more torch-like behavior (the module stays the single source of truth for parameters) and matches the policy rebel-compiler already uses in its vLLM/dynamo CI.

It is wired in `torch_backends_entry_point()` (before the backend is registered and before any `torch.compile` runs), setting `RBLN_WEIGHT_FREE="on"` — rebel's canonical value (`Config` accepts `on`/`off`/`debug`) — **only when the user hasn't set it**, so an explicit `RBLN_WEIGHT_FREE=off` still wins. The default log level is `WARNING`, so the weight-free decision is logged at `INFO` — discoverable when `TORCH_RBLN_LOG_LEVEL=INFO` (or lower) without spamming the default level: one line when defaulting to `on` (unset), and one line on the opt-out (`RBLN_WEIGHT_FREE=off`).

## Dependencies (already landed)
Flipping this default surfaces rebel-compiler bugs that must be present in the pinned build. Both required fixes are already in the pin (`rebel-compiler==0.10.5.dev337+ga803cde6`):

- **rebellions-sw/rebel_compiler#11451** — meta-NDArray double-free (`SelfDeleter`). Merged 2026-06-15. Without it, WF=1 + device-resident weights SIGABRT at teardown for any graph carrying host const params (e.g. a `+bias`).
- **rebellions-sw/rebel_compiler#11525** — weight-sharing identity gate: gate `reuse` on weight-tensor `data_ptr` (object identity) instead of sampled parameter values. Merged 2026-06-18; the pinned `ga803cde6` is its merge commit. Supersedes the earlier #11449 (closed, not merged). Without it, two separately-instantiated same-value models collide on the same name and fall back / fail under WF=1.

(#11450 — WeightPool exception-safety — was closed unmerged and is no longer needed after #11525.)

## Known limitation (inherited from #11525)
#11525 gates weight-sharing on weight-tensor identity (`data_ptr`) rather than weight values. Within a single process / single live module (the normal vLLM path), prefill and decode reference the same tensors → same identity → weight-sharing is unaffected. However, in a **cross-process partial-cache** scenario — prefill loaded from the disk cache while decode is compiled fresh in another process — the two graphs get different identities and no longer share on-device weights, so each holds its own copy (≈2× weight memory). This is a behavioral trade-off, not a crash; the disk (content) cache still hits for prefill. Recovering cross-process sharing is being explored separately (torch mega cache).

## Implementation
- `torch_rbln/__init__.py`: in `torch_backends_entry_point()`, default `RBLN_WEIGHT_FREE="on"` when unset via the extracted pure helper `_apply_weight_free_default()`; log the weight-free decision at `INFO` (the default-on note and the explicit-`off` note).
- `constraints-build-dev.txt`: bump rebel-compiler to `0.10.5.dev337+ga803cde6` (carries #11451 + #11525).
- `test/rbln/test_weight_free.py`: regression tests (below).

## Verification
With the pinned rebel build, the full `test/rbln` suite is **identical under weight-free and weight-baked — 2448 passed / 20 skipped / 0 failed** (4-device, `RBLN_DEVICES=0,1,2,3`). No new regressions, no crashes; the previously-failing `test_07` weight-sharing case now passes on NPU with no fallback. Confirmed (no explicit env, relying solely on this default): `RBLN_WEIGHT_FREE=on` is set and a compile with `TORCH_RBLN_DISABLE_FALLBACK=compile_error` succeeds on NPU (i.e. no silent CPU fallback).

New tests in `test/rbln/test_weight_free.py`:
- `test_weight_free_host_const_param_clean_teardown` — a WF graph with host const params (a `Linear` bias) must exit cleanly at teardown (subprocess + exit-code check; guards #11451).
- `test_weight_free_default_on_when_unset` / `test_weight_free_user_off_wins` — the default-selection logic itself (unset → `on`, explicit `off` wins), tested in-process against the extracted helper `_apply_weight_free_default()` with `monkeypatch` for env isolation. (Earlier subprocess probes were dropped: a fresh `python -c "import torch_rbln"` resolves the *installed* package, which can differ from the source tree under test.)

## TODO
- [ ] vLLM end-to-end regression pass — the largest weight-free consumer. Should specifically exercise the cross-process partial-cache path above (watch on-device weight memory, not just pass/fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
