### PR TITLE
test: add per-architecture xfail markers

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 
 import torch_rbln
-from test.utils import set_deterministic_seeds
+from test.utils import set_deterministic_seeds, xfail_rebel
 from torch_rbln._internal.log_utils import rbln_log_debug
 
 
@@ -90,3 +90,31 @@ def enable_eager_malloc(monkeypatch):
     original_env = os.getenv("TORCH_RBLN_EAGER_MALLOC", "")
     rbln_log_debug(f"Setting TORCH_RBLN_EAGER_MALLOC=1 (was '{original_env}')")
     monkeypatch.setenv("TORCH_RBLN_EAGER_MALLOC", "1")
+
+
+# REBEL-failing tests keyed by fully expanded name -> (test file, reason). Keying on
+# the name pins one parametrization across separate ``@parametrize`` axes, which a
+# per-parameter mark cannot.
+_REBEL_XFAILS = {
+    "test_allgather_float16_unaligned_size_67109568_c10d_async_env_0_rbln": (
+        "test/distributed/test_process_group.py",
+        "REBEL: float16 unaligned all-gather fails at size 67109568 (64 MiB)",
+    ),
+}
+
+
+def pytest_collection_modifyitems(items):
+    matched = set()
+    for item in items:
+        entry = _REBEL_XFAILS.get(item.name)
+        if entry is not None:
+            _, reason = entry
+            item.add_marker(xfail_rebel(reason))
+            matched.add(item.name)
+
+    # Key whose file was collected but whose name no longer matches = stale (renamed or
+    # re-parametrized); fail loudly instead of silently dropping the xfail.
+    collected_files = {item.nodeid.split("::", 1)[0] for item in items}
+    stale = [name for name, (path, _) in _REBEL_XFAILS.items() if name not in matched and path in collected_files]
+    if stale:
+        raise pytest.UsageError(f"Stale _REBEL_XFAILS keys (file collected, name unmatched): {stale}")

--- a/test/internal/test_device_arch.py
+++ b/test/internal/test_device_arch.py
@@ -1,0 +1,87 @@
+# Owner(s): ["module: PrivateUse1"]
+
+from unittest.mock import patch
+
+import pytest
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+from test.utils import _arch_from_npu_name, is_atom_device, is_rebel_device, xfail_atom, xfail_rebel
+
+
+@pytest.mark.test_set_ci
+class TestArchFromNpuName(TestCase):
+    """Maps an NPU name to a device family."""
+
+    def test_atom_name(self):
+        self.assertEqual(_arch_from_npu_name("RBLN-CA12"), "atom")
+
+    def test_rebel_name(self):
+        self.assertEqual(_arch_from_npu_name("RBLN-CR03"), "rebel")
+
+    def test_name_is_case_insensitive(self):
+        self.assertEqual(_arch_from_npu_name("rbln-cr03"), "rebel")
+
+    def test_empty_name(self):
+        self.assertEqual(_arch_from_npu_name(""), "unknown")
+
+    def test_unrecognized_name(self):
+        self.assertEqual(_arch_from_npu_name("RBLN-XX99"), "unknown")
+
+
+@pytest.mark.test_set_ci
+class TestArchPredicates(TestCase):
+    """``is_rebel_device`` / ``is_atom_device`` reflect ``get_device_arch``."""
+
+    def test_is_rebel_device_true_on_rebel(self):
+        with patch("test.utils.get_device_arch", return_value="rebel"):
+            self.assertTrue(is_rebel_device())
+
+    def test_is_rebel_device_false_on_atom(self):
+        with patch("test.utils.get_device_arch", return_value="atom"):
+            self.assertFalse(is_rebel_device())
+
+    def test_is_atom_device_true_on_atom(self):
+        with patch("test.utils.get_device_arch", return_value="atom"):
+            self.assertTrue(is_atom_device())
+
+    def test_is_atom_device_false_on_rebel(self):
+        with patch("test.utils.get_device_arch", return_value="rebel"):
+            self.assertFalse(is_atom_device())
+
+
+@pytest.mark.test_set_ci
+class TestArchXfailMarkers(TestCase):
+    """xfail markers set ``condition`` per arch and ``strict=True``."""
+
+    def test_xfail_rebel_active_on_rebel(self):
+        with patch("test.utils.get_device_arch", return_value="rebel"):
+            mark = xfail_rebel("REBEL: feature not yet supported")
+        self.assertTrue(mark.mark.kwargs["condition"])
+        self.assertTrue(mark.mark.kwargs["strict"])
+        self.assertEqual(mark.mark.kwargs["reason"], "REBEL: feature not yet supported")
+
+    def test_xfail_rebel_inert_on_atom(self):
+        with patch("test.utils.get_device_arch", return_value="atom"):
+            mark = xfail_rebel("REBEL: feature not yet supported")
+        self.assertFalse(mark.mark.kwargs["condition"])
+
+    def test_xfail_atom_active_on_atom(self):
+        with patch("test.utils.get_device_arch", return_value="atom"):
+            mark = xfail_atom("ATOM: feature not yet supported")
+        self.assertTrue(mark.mark.kwargs["condition"])
+        self.assertTrue(mark.mark.kwargs["strict"])
+
+    def test_xfail_atom_inert_on_rebel(self):
+        with patch("test.utils.get_device_arch", return_value="rebel"):
+            mark = xfail_atom("ATOM: feature not yet supported")
+        self.assertFalse(mark.mark.kwargs["condition"])
+
+
+instantiate_device_type_tests(TestArchFromNpuName, globals(), only_for="privateuse1")
+instantiate_device_type_tests(TestArchPredicates, globals(), only_for="privateuse1")
+instantiate_device_type_tests(TestArchXfailMarkers, globals(), only_for="privateuse1")
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,3 +1,4 @@
+import functools
 import multiprocessing
 import os
 import random
@@ -88,22 +89,58 @@ def requires_physical_devices(num_devices):
     )
 
 
-def is_rebel_device() -> bool:
-    """True on the REBEL lineup (RBLN-CR03/CR13/CR23).
+def _arch_from_npu_name(name: str) -> str:
+    """Map an RBLN NPU name to a device family: ``RBLN-CA*`` -> ``"atom"``,
+    ``RBLN-CR*`` -> ``"rebel"``, anything else -> ``"unknown"``.
+    """
+    name = name.upper()
+    if name.startswith("RBLN-CA"):
+        return "atom"
+    if name.startswith("RBLN-CR"):
+        return "rebel"
+    return "unknown"
 
-    REBEL differs from ATOM in ways the model suite must account for: TP>1 is
-    not supported yet (a single device is a quad chiplet, 1->4), and its 140 GB
-    DRAM makes vLLM's default ``gpu_memory_utilization`` KV-cache budget
-    oversized. Returns False when the NPU name can't be queried.
+
+@functools.lru_cache(maxsize=1)
+def get_device_arch() -> str:
+    """Identify the current NPU family (``"atom"``/``"rebel"``/``"unknown"``) via
+    ``get_npu_name`` from ``rebel-compiler`` (cached). Returns ``"unknown"`` if the
+    NPU name can't be queried.
     """
     try:
         from rebel.device_info import get_npu_name
 
-        name = (get_npu_name(0) or "").upper()
+        return _arch_from_npu_name(get_npu_name(0) or "")
     except Exception:
-        return False
-    # ATOM = RBLN-CA*, REBEL = RBLN-CR* (CR03/CR13/CR23).
-    return name.startswith("RBLN-CR")
+        return "unknown"
+
+
+def is_atom_device() -> bool:
+    """True on the ATOM lineup (``RBLN-CA*``); thin wrapper over :func:`get_device_arch`."""
+    return get_device_arch() == "atom"
+
+
+def is_rebel_device() -> bool:
+    """True on the REBEL lineup (``RBLN-CR*``); thin wrapper over :func:`get_device_arch`."""
+    return get_device_arch() == "rebel"
+
+
+def xfail_atom(reason: str):
+    """Strict xfail on ATOM, inert elsewhere.
+
+    An unexpected pass fails the suite, signalling the marker can be removed
+    once ATOM gains support.
+    """
+    return pytest.mark.xfail(condition=is_atom_device(), reason=reason, strict=True)
+
+
+def xfail_rebel(reason: str):
+    """Strict xfail on REBEL, inert elsewhere.
+
+    An unexpected pass fails the suite, signalling the marker can be removed
+    once REBEL gains support.
+    """
+    return pytest.mark.xfail(condition=is_rebel_device(), reason=reason, strict=True)
 
 
 def spawn_target_with_clean_exit(rank: int, test_func, *args) -> None:


### PR DESCRIPTION
## Summary of Changes

Adds per-architecture `xfail` markers (`xfail_rebel` / `xfail_atom`) that fire only on the matching NPU architecture and are strict, so an unexpected pass fails the suite and flags the marker for removal.

On the REBEL NPU, `test_allgather_float16_unaligned` currently fails at its largest size (64 MiB) in sync mode. Because size and sync/async mode are independent `@parametrize` axes, no inline mark can isolate that combination, so a `pytest_collection_modifyitems` hook applies the xfail by matching the fully expanded test name against a registry. A registry entry whose file is collected but whose name no longer matches fails the run loudly, instead of silently dropping the xfail.

---

## Type of Change

- [x] `other` — Other (describe below)

Test code change only.

---

## Affected Modules

- [x] Device
- [x] Ops/Kernels

---

## Checklist

* [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
* [x] Linting passes — see [Linting](docs/LINTING.md)
* [x] All CI tests pass — see [CI/CD Workflows](docs/WORKFLOWS.md)
* [x] Relevant documentation has been updated (if applicable)

---
