### PR TITLE
fix: chunk AllGather to a CS-safe size to fix REBEL tail corruption

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -95,12 +95,12 @@ def enable_eager_malloc(monkeypatch):
 # REBEL-failing tests keyed by fully expanded name -> (test file, reason). Keying on
 # the name pins one parametrization across separate ``@parametrize`` axes, which a
 # per-parameter mark cannot.
-_REBEL_XFAILS = {
-    "test_allgather_float16_unaligned_size_67109568_c10d_async_env_0_rbln": (
-        "test/distributed/test_process_group.py",
-        "REBEL: float16 unaligned all-gather fails at size 67109568 (64 MiB)",
-    ),
-}
+#
+# The float16 unaligned all-gather at size 67109568 (64 MiB) used to be xfailed
+# here; it is now fixed (AllGather is chunked to a CS-safe size, see
+# RCCL_ALLGATHER_MAX_OUTPUT_BYTES in ProcessGroupRBLN.cpp / fsw-inference#324),
+# so its strict-xfail entry was removed.
+_REBEL_XFAILS: dict[str, tuple[str, str]] = {}
 
 
 def pytest_collection_modifyitems(items):

--- a/test/distributed/test_process_group.py
+++ b/test/distributed/test_process_group.py
@@ -585,7 +585,21 @@ class TestAllGatherRBLN(TestProcessGroupRBLNBase):
         )
 
     @parametrize(
-        "size", [256, 512, (512 * KiB), MiB, (2 * MiB), (4 * MiB), (8 * MiB), (16 * MiB), (32 * MiB), (64 * MiB)]
+        "size",
+        [
+            256,
+            512,
+            (512 * KiB),
+            MiB,
+            (2 * MiB),
+            (4 * MiB),
+            (8 * MiB),
+            (16 * MiB),
+            (32 * MiB),
+            (64 * MiB),
+            (256 * MiB),
+            (512 * MiB),
+        ],
     )
     @parametrize("c10d_async_env", TestProcessGroupRBLNBase.c10d_async_envs)
     def test_allgather_float16_aligned(self, size, c10d_async_env):
@@ -604,6 +618,8 @@ class TestAllGatherRBLN(TestProcessGroupRBLNBase):
             (16 * MiB + 176),  # unaligned 16 MiB
             (32 * MiB + 352),  # unaligned 32 MiB
             (64 * MiB + 704),  # unaligned 64 MiB
+            (256 * MiB + 2816),  # unaligned 256 MiB
+            (512 * MiB + 5632),  # unaligned 512 MiB
         ],
     )
     @parametrize("c10d_async_env", TestProcessGroupRBLNBase.c10d_async_envs)

--- a/torch_rbln/csrc/distributed/c10d/rbln/ProcessGroupRBLN.cpp
+++ b/torch_rbln/csrc/distributed/c10d/rbln/ProcessGroupRBLN.cpp
@@ -67,8 +67,20 @@ constexpr size_t RCCL_ALLREDUCE_MAX_BYTES_PER_RANK = 1ULL * 1024ULL * 1024ULL;
 constexpr size_t RCCL_REDUCE_SCATTER_MAX_BYTES_PER_WORLD = 32ULL * 1024ULL * 1024ULL;
 constexpr size_t RCCL_MAX_BYTES_PER_REDUCE_SCATTER_OP = 2ULL * 1024ULL * 1024ULL;
 constexpr size_t RCCL_MAX_COMMAND_BUFFER_SUB_COMMANDS_COUNT = 15ULL;
-// AllGather size limit: output size <= 1GB (can be performed in a single allgather operation)
-constexpr size_t RCCL_ALLGATHER_MAX_OUTPUT_BYTES = 1ULL * 1024ULL * 1024ULL * 1024ULL;
+// AllGather per-call output-size limit (drives the chunked multi-call path).
+//
+// The REBEL/UMD AllGather builds its *entire* command stream into a single
+// fixed-size CS chunk (RCCL_CS_CHUNK_SIZE = 32 KiB) and ships exactly that many
+// bytes to the device. A transfer large enough that its per-page DMA
+// descriptors overflow 32 KiB has the tail descriptors silently dropped, so the
+// recv-buffer tail is left stale (or the op errors with -ENOMEM). Empirically
+// (world_size = 2) a 256 MiB output already overflows on REBEL while 128 MiB is
+// safe — see fsw-inference#324. CS size scales with the per-call *output* bytes,
+// so capping each AllGather call's output keeps the generated CS within budget;
+// anything larger is split into <= this many bytes per call by the chunked path
+// below. 64 MiB leaves ~2x margin under the observed overflow point and absorbs
+// the per-step sync/header overhead for larger world sizes.
+constexpr size_t RCCL_ALLGATHER_MAX_OUTPUT_BYTES = 64ULL * 1024ULL * 1024ULL;
 
 /**
  * @brief Get element size for RCCL operations based on dtype


### PR DESCRIPTION
## Summary

On **REBEL (CR03)**, `dist.all_gather` corrupted the **tail** of large per-rank tensors — data past ~63 MiB came back stale/swapped. Deterministic, independent of rebel-compiler version. Tracked in **rebellions-sw/fsw-inference#324**.

## Root cause

It is **not** an alignment requirement per se — it's a **command-stream (CS) size limit** in the UMD AllGather:

- The whole AllGather CS is generated into a single fixed `RCCL_CS_CHUNK_SIZE` (**32 KiB**) chunk, and exactly that many bytes are shipped to the device (`allgather.c`: `*cs_size = RCCL_CS_CHUNK_SIZE; rccl_h2d_memcpy(..., RCCL_CS_CHUNK_SIZE)`; both ring and reverse-recursive-doubling paths).
- A transfer large enough that its per-2 MiB-page DMA descriptors overflow 32 KiB has its **tail descriptors dropped** → recv-buffer tail never DMA'd (left stale), or the op errors with `-ENOMEM`.
- CS size scales with the per-call **output** bytes. Empirically (world_size=2): **256 MiB output overflows, 128 MiB is safe**. A non-2 MiB-aligned tail adds one extra descriptor, which is why a borderline *aligned* size passes while the *unaligned* one fails.

## Fix

Lower `RCCL_ALLGATHER_MAX_OUTPUT_BYTES` **1 GiB → 64 MiB** so large transfers are split through the **existing chunked multi-call path**, keeping each call's CS well within the 32 KiB budget.

- No alignment change → **no small-tensor padding overhead**.
- A 2 MiB-alignment workaround alone would *not* help large **aligned** transfers, which still overflow the CS — chunking is the correct fix.
- 64 MiB leaves ~2× margin under the observed overflow point and absorbs per-step sync/header overhead for larger world sizes.

## Tests

Added 256 MiB / 512 MiB **aligned and unaligned** cases to `test_allgather_float16_{aligned,unaligned}`.

## Verification (RBLN-CR03, world_size=2, rebel-compiler 0.10.5.dev241)

- unaligned **32/32 OK** (incl. new 256/512 MiB)
- aligned **24/24 OK** (incl. new 256/512 MiB)
- previously-failing `numel 67109568` → **OK**

🤖 Generated with [Claude Code](https://claude.com/claude-code)