### PR TITLE
fix: default RBLN control-plane IPs to loopback in rbln-ccl backend init

### DIFF
--- a/test/distributed/test_control_plane_ip_default.py
+++ b/test/distributed/test_control_plane_ip_default.py
@@ -1,0 +1,68 @@
+# Owner(s): ["module: PrivateUse1"]
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from test.utils import configure_master_port_for_rccl_tests, requires_logical_devices, spawn_target_with_clean_exit
+
+
+def _run_allreduce_with_unset_control_plane_ips(rank: int, world_size: int, backend: str) -> None:
+    # The IPs must be unset on entry: this is the production path that the
+    # autoport helper masks by pre-setting them. Do NOT set them here.
+    assert not os.environ.get("RBLN_ROOT_IP"), "test precondition: RBLN_ROOT_IP must be unset"
+    assert not os.environ.get("RBLN_LOCAL_IP"), "test precondition: RBLN_LOCAL_IP must be unset"
+
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    torch.rbln.set_device(rank)
+
+    dist.init_process_group(backend=backend, rank=rank, world_size=world_size)
+    try:
+        # The fix defaults both to loopback during process-group construction.
+        assert os.environ.get("RBLN_ROOT_IP") == "127.0.0.1"
+        assert os.environ.get("RBLN_LOCAL_IP") == "127.0.0.1"
+
+        tensor = torch.full([64], rank + 1.0, dtype=torch.float16, device=torch.device(f"rbln:{rank}"))
+        dist.all_reduce(tensor, op=dist.ReduceOp.SUM)
+        expected = sum(range(1, world_size + 1))
+        assert tensor[0] == expected, f"all_reduce failed on rank {rank}: expected={expected}, actual={tensor[0]}"
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.single_worker
+@pytest.mark.test_set_ci
+@requires_logical_devices(2)
+def test_rbln_ccl_defaults_control_plane_ips_when_unset(monkeypatch):
+    """rbln-ccl must init + run a collective with RBLN_ROOT_IP/RBLN_LOCAL_IP unset.
+
+    Reproduces the production failure: the autoport helper that pre-sets the IPs
+    is test-only, so a normal run leaves them unset and rank 0's rcclGetUniqueId
+    fails, taking every peer down with an opaque c10d recv error. The test
+    passing is also the empirical proof that rccl reads these at process-group
+    construction time, not at librbln load.
+    """
+    monkeypatch.delenv("RBLN_ROOT_IP", raising=False)
+    monkeypatch.delenv("RBLN_LOCAL_IP", raising=False)
+    monkeypatch.setenv("MASTER_ADDR", "127.0.0.1")
+    monkeypatch.setenv("RCCL_FORCE_EXPORT_MEM", "1")
+    monkeypatch.setenv("TORCH_RBLN_C10D_ASYNC", "0")
+    configure_master_port_for_rccl_tests()
+
+    world_size = 2
+    mp.spawn(
+        spawn_target_with_clean_exit,
+        args=(_run_allreduce_with_unset_control_plane_ips, world_size, "rbln-ccl"),
+        nprocs=world_size,
+        join=True,
+    )
+
+
+if __name__ == "__main__":
+    from torch.testing._internal.common_utils import run_tests
+
+    run_tests()

--- a/torch_rbln/__init__.py
+++ b/torch_rbln/__init__.py
@@ -165,6 +165,10 @@ def _create_process_group_rbln(dist_backend_opts, pg_options):
     """
     import torch_rbln._C
 
+    from torch_rbln._internal.rdma_env import _apply_control_plane_ips
+
+    _apply_control_plane_ips()
+
     # Extract parameters from dist_backend_opts
     store = dist_backend_opts.store
     group_rank = dist_backend_opts.group_rank

--- a/torch_rbln/__init__.py
+++ b/torch_rbln/__init__.py
@@ -34,8 +34,6 @@ def torch_backends_entry_point() -> None:
         import torch
 
         # Load shared objects ##################################################
-        global library_names, libraries
-
         # Ensure dependent shared library is loaded before importing native extension
         find_and_load_tvm_library("librbln.so")
 
@@ -164,7 +162,6 @@ def _create_process_group_rbln(dist_backend_opts, pg_options):
         ProcessGroupRBLN: A new ProcessGroupRBLN instance
     """
     import torch_rbln._C
-
     from torch_rbln._internal.rdma_env import _apply_control_plane_ips
 
     _apply_control_plane_ips()


### PR DESCRIPTION
## Summary of Changes

Default the rbln-ccl control-plane IPs (`RBLN_ROOT_IP` / `RBLN_LOCAL_IP`) on the production path so single-node distributed runs no longer die during process-group setup.

1. **Problem:** `apply_default_rbln_network_environment()` (which defaults these to `127.0.0.1`) only runs in autoport tests — never on a normal `init_process_group(backend="rbln-ccl")` path. So both vars stayed unset.
2. **Failure chain:** With them unset, rank 0's `rcclGetUniqueId` fails (`ExportMem` passes, failure only at unique_id), `broadcastUniqueId` throws `GetUniqueIdForBroadcast failed`, rank 0 dies, its rendezvous TCPStore closes, and every peer then dies with the misleading `c10d ... Failed to recv, got 0 bytes. Connection was likely closed` — making an IP-config problem look like a network/crash.
3. **Fix:** Call `_apply_control_plane_ips()` in `_create_process_group_rbln` before constructing `ProcessGroupRBLN`. Unset → `127.0.0.1`; pre-set values respected (multi-node); `RBLN_FORCE_LOOPBACK_CONTROL_PLANE=1` honored. Runs on every rank, so the rendezvous never starts half-configured.

---

## Related Issues / Tickets

* Related to # <!-- TODO: link issue -->

---

## Type of Change

- [x] `fix` — Bug fix

---

## Affected Modules

- [x] Backend

---

## How to Test (if applicable)

1. Single node, `RBLN_ROOT_IP` / `RBLN_LOCAL_IP` unset, run a TP>1 `rbln-ccl` workload (e.g. Qwen1.5-MoE TP=2).
2. Before: rank 0 logs `[Rccl] fail rcclGetUniqueId` + `GetUniqueIdForBroadcast failed`; peers cascade with `Failed to recv, got 0 bytes`.
3. After: both vars auto-default to `127.0.0.1`, `rcclGetUniqueId` succeeds, process group initializes.

---

## Screenshots / Logs (if applicable)

Before (root cause):
```
[E] [runtime] [Rccl] fail rcclGetUniqueId (rank: -1, size: -1, ...)
[E] ProcessGroupRBLN: GetUniqueIdForBroadcast failed (call after PrepareContextAndExportMem)
... peers: torch.distributed.DistNetworkError: Failed to recv, got 0 bytes. Connection was likely closed.
```

---

## Notes

`_apply_control_plane_ips()` is an `_internal` helper; this wires the already-existing default logic into the live backend path instead of leaving it test-only. No native/C++ change — Python-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
