### PR TITLE
feat(copy): add native _foreach_copy_ op batching scatters into a single v2v submit

### DIFF
--- a/aten/src/ATen/native/RBLNRegisterOps.cpp
+++ b/aten/src/ATen/native/RBLNRegisterOps.cpp
@@ -135,6 +135,7 @@ TORCH_LIBRARY_IMPL(aten, PrivateUse1, m) {
   // Operations that use the device runtime API
   m.impl("_copy_from", TORCH_FN(at::native::rbln::_copy_from_rbln));
   m.impl("_copy_from_and_resize", TORCH_FN(at::native::rbln::_copy_from_and_resize_rbln));
+  m.impl("_foreach_copy_", TORCH_FN(at::native::rbln::_foreach_copy__rbln));
   m.impl("empty.memory_format", TORCH_FN(at::native::rbln::empty_rbln));
   m.impl("empty_strided", TORCH_FN(at::native::rbln::empty_strided_rbln));
   m.impl("zero_", TORCH_FN(at::native::rbln::zero_rbln_));

--- a/aten/src/ATen/native/rbln/RBLNCopy.cpp
+++ b/aten/src/ATen/native/rbln/RBLNCopy.cpp
@@ -320,6 +320,89 @@ at::Tensor clone_rbln(const at::Tensor& self, std::optional<c10::MemoryFormat> m
   return out;
 }
 
+namespace {
+
+// Byte extent [lo, hi) that `t` actually addresses, from sizes/strides — so
+// disjoint slices of one storage (e.g. kv_cache[0] vs kv_cache[1]) report
+// non-overlapping ranges. Negative strides extend `lo`; +1 makes it half-open.
+struct ByteRange {
+  const char* lo;
+  const char* hi;
+};
+
+ByteRange tensor_byte_range(const at::Tensor& t) {
+  const char* base = static_cast<const char*>(t.data_ptr());
+  const int64_t elsize = t.element_size();
+  int64_t lo_elems = 0;
+  int64_t hi_elems = 0;
+  const auto sizes = t.sizes();
+  const auto strides = t.strides();
+  for (size_t d = 0; d < sizes.size(); ++d) {
+    if (sizes[d] <= 1) {
+      continue;
+    }
+    const int64_t step = (sizes[d] - 1) * strides[d];
+    if (step >= 0) {
+      hi_elems += step;
+    } else {
+      lo_elems += step;
+    }
+  }
+  return {base + lo_elems * elsize, base + (hi_elems + 1) * elsize};
+}
+
+bool ranges_overlap(const ByteRange& a, const ByteRange& b) {
+  return a.lo < b.hi && b.lo < a.hi;
+}
+
+// The batched path submits eligible copies together (unordered) and after the
+// inline fallback copies, so it matches list-order copy_ only when copies don't
+// alias across pairs. Returns true on any cross-pair overlap — a destination
+// hitting another pair's source (RAW/WAR) or destination (WAW). Within-pair
+// (self[i]/src[i]) is left to copy_. Only same-device live tensors can alias.
+bool foreach_copy_reorder_unsafe(at::TensorList self, at::TensorList src) {
+  const size_t n = self.size();
+  std::vector<ByteRange> dst_range(n);
+  std::vector<ByteRange> src_range(n);
+  std::vector<bool> dst_live(n, false);
+  std::vector<bool> src_live(n, false);
+  std::vector<c10::DeviceIndex> dst_dev(n, -1);
+  std::vector<c10::DeviceIndex> src_dev(n, -1);
+  for (size_t i = 0; i < n; ++i) {
+    if (self[i].device().is_privateuseone() && self[i].numel() > 0) {
+      dst_range[i] = tensor_byte_range(self[i]);
+      dst_live[i] = true;
+      dst_dev[i] = self[i].device().index();
+    }
+    if (src[i].device().is_privateuseone() && src[i].numel() > 0) {
+      src_range[i] = tensor_byte_range(src[i]);
+      src_live[i] = true;
+      src_dev[i] = src[i].device().index();
+    }
+  }
+  for (size_t i = 0; i < n; ++i) {
+    if (!dst_live[i]) {
+      continue;
+    }
+    for (size_t j = 0; j < n; ++j) {
+      if (j == i) {
+        continue;
+      }
+      // WAW: this destination overlaps another pair's destination.
+      if (dst_live[j] && dst_dev[i] == dst_dev[j] && ranges_overlap(dst_range[i], dst_range[j])) {
+        return true;
+      }
+      // RAW / WAR: this destination overlaps another pair's source.
+      if (src_live[j] && dst_dev[i] == src_dev[j] && ranges_overlap(dst_range[i], src_range[j])) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+} // namespace
+
 void _foreach_copy__rbln(at::TensorList self, at::TensorList src, bool non_blocking) {
   RBLN_SCOPE_GUARD();
 
@@ -328,6 +411,15 @@ void _foreach_copy__rbln(at::TensorList self, at::TensorList src, bool non_block
       "_foreach_copy_: self and src lists must have equal length ({} vs {})",
       self.size(),
       src.size());
+
+  // Cross-pair aliasing would make the batch's reordering observable; fall back
+  // to an ordered copy_ loop. The common disjoint scatter keeps the fast path.
+  if (foreach_copy_reorder_unsafe(self, src)) {
+    for (size_t i = 0; i < self.size(); ++i) {
+      self[i].copy_(src[i], non_blocking);
+    }
+    return;
+  }
 
   // Batch every conversion-free, same-device, same-shape pair into one
   // V2VBatch so all N copies flush through a single rbln_memcpy_v2v_multi
@@ -341,8 +433,8 @@ void _foreach_copy__rbln(at::TensorList self, at::TensorList src, bool non_block
     const at::Tensor& dst = self[i];
     const at::Tensor& s = src[i];
     const bool v2v_eligible = dst.device().is_privateuseone() && s.device().is_privateuseone() &&
-        dst.device() == s.device() && dst.scalar_type() == s.scalar_type() &&
-        dst.sizes() == s.sizes() && dst.numel() > 0;
+        dst.device() == s.device() && dst.scalar_type() == s.scalar_type() && dst.sizes() == s.sizes() &&
+        dst.numel() > 0;
     if (v2v_eligible) {
       strided_v2v_copy(dst, s, batch);
       batched.emplace_back(dst, s);

--- a/aten/src/ATen/native/rbln/RBLNCopy.cpp
+++ b/aten/src/ATen/native/rbln/RBLNCopy.cpp
@@ -13,6 +13,8 @@
 #include <rebel/runtime/api/rbln_runtime_api.h>
 
 #include <cstddef>
+#include <utility>
+#include <vector>
 
 namespace at::native::rbln {
 
@@ -316,6 +318,44 @@ at::Tensor clone_rbln(const at::Tensor& self, std::optional<c10::MemoryFormat> m
     out.copy_(self);
   }
   return out;
+}
+
+void _foreach_copy__rbln(at::TensorList self, at::TensorList src, bool non_blocking) {
+  RBLN_SCOPE_GUARD();
+
+  RBLN_CHECK(
+      self.size() == src.size(),
+      "_foreach_copy_: self and src lists must have equal length ({} vs {})",
+      self.size(),
+      src.size());
+
+  // Batch every conversion-free, same-device, same-shape pair into one
+  // V2VBatch so all N copies flush through a single rbln_memcpy_v2v_multi
+  // submit — the write-side mirror of cat's gather. Lets a scatter into N
+  // separate per-layer tensors collapse from N submits to 1. Pairs needing
+  // broadcast / dtype cast / cross-device fall back to a plain per-pair copy_.
+  c10::rbln::V2VBatch batch;
+  std::vector<std::pair<at::Tensor, at::Tensor>> batched;
+  batched.reserve(self.size());
+  for (size_t i = 0; i < self.size(); ++i) {
+    const at::Tensor& dst = self[i];
+    const at::Tensor& s = src[i];
+    const bool v2v_eligible = dst.device().is_privateuseone() && s.device().is_privateuseone() &&
+        dst.device() == s.device() && dst.scalar_type() == s.scalar_type() &&
+        dst.sizes() == s.sizes() && dst.numel() > 0;
+    if (v2v_eligible) {
+      strided_v2v_copy(dst, s, batch);
+      batched.emplace_back(dst, s);
+    } else {
+      dst.copy_(s, non_blocking);
+    }
+  }
+
+  submit_or_fallback(batch, "_foreach_copy_", [&] {
+    for (const auto& pair : batched) {
+      pair.first.copy_(pair.second.cpu());
+    }
+  });
 }
 
 } // namespace at::native::rbln

--- a/aten/src/ATen/native/rbln/RBLNCopy.h
+++ b/aten/src/ATen/native/rbln/RBLNCopy.h
@@ -56,6 +56,10 @@ at::Tensor clone_rbln(
  * write-side mirror of cat/stack's gather), so a scatter into N separate
  * per-layer tensors collapses from N submits to 1. Non-batchable pairs
  * (broadcast / dtype cast / cross-device) fall back to a plain per-pair copy_.
+ *
+ * Batching is order-free, so when copies alias across pairs (a destination
+ * overlapping another pair's source or destination) the op falls back to a
+ * sequential per-pair copy_ loop to preserve list-order semantics.
  */
 void _foreach_copy__rbln(at::TensorList self, at::TensorList src, bool non_blocking);
 

--- a/aten/src/ATen/native/rbln/RBLNCopy.h
+++ b/aten/src/ATen/native/rbln/RBLNCopy.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ATen/core/Tensor.h>
 #include <ATen/native/Copy.h>
 #include <c10/core/MemoryFormat.h>
 
@@ -44,5 +45,18 @@ at::Tensor _copy_from_and_resize_rbln(const at::Tensor& src, const at::Tensor& d
 at::Tensor clone_rbln(
     const at::Tensor& self,
     std::optional<c10::MemoryFormat> memory_format);
+
+/**
+ * @brief Native impl of aten::_foreach_copy_ for RBLN.
+ *
+ * Implements ``_foreach_copy_(Tensor(a!)[] self, Tensor[] src, bool
+ * non_blocking=False) -> ()`` — copies ``src[i]`` into ``self[i]`` for every
+ * i. All conversion-free, same-device, same-shape pairs are enqueued into a
+ * single ``V2VBatch`` and flushed in ONE ``rbln_memcpy_v2v_multi`` submit (the
+ * write-side mirror of cat/stack's gather), so a scatter into N separate
+ * per-layer tensors collapses from N submits to 1. Non-batchable pairs
+ * (broadcast / dtype cast / cross-device) fall back to a plain per-pair copy_.
+ */
+void _foreach_copy__rbln(at::TensorList self, at::TensorList src, bool non_blocking);
 
 } // namespace at::native::rbln

--- a/test/rbln/test_foreach_copy_v2v.py
+++ b/test/rbln/test_foreach_copy_v2v.py
@@ -1,0 +1,253 @@
+# Owner(s): ["module: PrivateUse1"]
+
+"""Tests for the native ``aten::_foreach_copy_`` RBLN kernel.
+
+``_foreach_copy_(self[], src[], non_blocking)`` copies ``src[i]`` into
+``self[i]`` for every ``i``. The RBLN kernel batches every conversion-free,
+same-device, same-shape pair into one ``rbln_memcpy_v2v_multi`` submit (a
+scatter into N tensors collapses from N submits to 1) and falls back to a
+per-pair ``copy_`` for broadcast / dtype-cast / cross-device pairs.
+
+Batching submits the eligible copies together (no inter-copy ordering) and
+after the inline fallback copies, so it must NOT change the observable result
+versus strict list-order ``self[i].copy_(src[i])``. Coverage:
+
+  - Basic correctness: N disjoint same-device pairs (the scatter fast path),
+    across dtypes and over many pairs.
+  - Mixed eligible / ineligible pairs (RBLN-to-RBLN plus CPU-to-RBLN).
+  - Non-contiguous source / destination views.
+  - Zero-numel pairs (skipped) and empty lists.
+  - Disjoint views of one shared storage (e.g. kv_cache[0] / kv_cache[1]) —
+    must stay correct without being forced off the fast path.
+  - Alias / order-sensitive regressions where a tensor appears in both ``self``
+    and ``src``, or destinations overlap (RAW/WAR and WAW). These force the
+    sequential path; the result must still match list-order semantics.
+
+Each test computes the reference by running the same op (with the same aliasing
+wiring) on CPU tensors, which gives the list-order semantics, then compares the
+device result bitwise.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from torch.testing._internal.common_device_type import dtypes, instantiate_device_type_tests
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+from test.utils_v2v import arange as _arange, DEVICE, ENGINE_DTYPES, eq as _eq, to_dev as _to_dev
+
+
+@pytest.mark.test_set_ci
+@pytest.mark.usefixtures("enable_deploy_mode")
+class TestForeachCopyV2V(TestCase):
+    """Tests for the native ``aten::_foreach_copy_`` kernel reached through
+    ``torch._foreach_copy_``."""
+
+    # ---- basic correctness (the scatter fast path) ----
+
+    @dtypes(*ENGINE_DTYPES)
+    def test_basic_disjoint_pairs(self, dtype):
+        """N independent same-device pairs — the common batched scatter."""
+        n_pairs = 6
+        dst_cpu = [_arange((4, 3), dtype) for _ in range(n_pairs)]
+        src_cpu = [_arange((4, 3), dtype) + (i + 1) * 100 for i in range(n_pairs)]
+
+        dst_dev = [_to_dev(d) for d in dst_cpu]
+        torch._foreach_copy_(dst_dev, [_to_dev(s) for s in src_cpu])
+
+        for got, want in zip(dst_dev, src_cpu):
+            _eq(got, want)
+
+    def test_many_pairs(self):
+        """Many pairs in one call — exercises a wide V2VBatch."""
+        n_pairs = 64
+        src_cpu = [_arange((2, 8), torch.float32) + i for i in range(n_pairs)]
+        dst_dev = [_to_dev(torch.zeros(2, 8, dtype=torch.float32)) for _ in range(n_pairs)]
+        torch._foreach_copy_(dst_dev, [_to_dev(s) for s in src_cpu])
+        for got, want in zip(dst_dev, src_cpu):
+            _eq(got, want)
+
+    def test_single_pair(self):
+        src_cpu = _arange((5, 4), torch.float16) + 7
+        dst_dev = [_to_dev(torch.zeros(5, 4, dtype=torch.float16))]
+        torch._foreach_copy_(dst_dev, [_to_dev(src_cpu)])
+        _eq(dst_dev[0], src_cpu)
+
+    # ---- mixed eligible / ineligible pairs ----
+
+    def test_mixed_rbln_and_cpu_source(self):
+        """Some pairs are RBLN-to-RBLN (batched), some are CPU-to-RBLN
+        (fallback). All disjoint, so order does not matter — result must match
+        regardless of which path each pair takes."""
+        a_src = _arange((4, 3), torch.float32) + 10
+        b_src = _arange((4, 3), torch.float32) + 20  # delivered from CPU
+        c_src = _arange((4, 3), torch.float32) + 30
+
+        a = _to_dev(torch.zeros(4, 3, dtype=torch.float32))
+        b = _to_dev(torch.zeros(4, 3, dtype=torch.float32))
+        c = _to_dev(torch.zeros(4, 3, dtype=torch.float32))
+
+        # b receives a CPU source -> fallback path; a, c are RBLN -> batched.
+        torch._foreach_copy_([a, b, c], [_to_dev(a_src), b_src, _to_dev(c_src)])
+
+        _eq(a, a_src)
+        _eq(b, b_src)
+        _eq(c, c_src)
+
+    def test_mixed_dtype_cast_fallback(self):
+        """A dtype-mismatched pair takes the per-pair copy_ (cast) fallback while
+        the matching pair is batched."""
+        same = _arange((3, 3), torch.float32) + 1
+        cast_src = (_arange((3, 3), torch.float32) + 2).to(torch.float16)
+
+        a = _to_dev(torch.zeros(3, 3, dtype=torch.float32))
+        b = _to_dev(torch.zeros(3, 3, dtype=torch.float32))  # dst f32, src f16 -> cast
+        torch._foreach_copy_([a, b], [_to_dev(same), _to_dev(cast_src)])
+
+        _eq(a, same)
+        _eq(b, cast_src.to(torch.float32))
+
+    # ---- non-contiguous views ----
+
+    def test_non_contig_dst(self):
+        big = _to_dev(torch.zeros(4, 12, dtype=torch.float16))
+        dst_view = big[:, :8]
+        assert not dst_view.is_contiguous()
+        src_cpu = _arange((4, 8), torch.float16) + 100
+        torch._foreach_copy_([dst_view], [_to_dev(src_cpu)])
+        _eq(dst_view, src_cpu)
+
+    def test_non_contig_src(self):
+        big_src_cpu = _arange((4, 16), torch.float32) + 5
+        src_view = _to_dev(big_src_cpu)[:, :8]
+        assert not src_view.is_contiguous()
+        dst = _to_dev(torch.zeros(4, 8, dtype=torch.float32))
+        torch._foreach_copy_([dst], [src_view])
+        _eq(dst, big_src_cpu[:, :8])
+
+    def test_both_non_contig_multi(self):
+        big_dst = _to_dev(torch.zeros(6, 12, dtype=torch.int32))
+        big_src_cpu = _arange((6, 16), torch.int32) + 1000
+        dst_views = [big_dst[i : i + 2, :8] for i in (0, 2, 4)]
+        src_views = [_to_dev(big_src_cpu)[i : i + 2, :8] for i in (0, 2, 4)]
+        torch._foreach_copy_(dst_views, src_views)
+        for v, i in zip(dst_views, (0, 2, 4)):
+            _eq(v, big_src_cpu[i : i + 2, :8])
+
+    # ---- zero-numel / empty ----
+
+    def test_zero_numel_pair_skipped(self):
+        """A 0-numel pair is a no-op and must not disturb the other pairs."""
+        empty_dst = _to_dev(torch.empty(0, 4, dtype=torch.float32))
+        empty_src = _to_dev(torch.empty(0, 4, dtype=torch.float32))
+        real_src = _arange((3, 4), torch.float32) + 9
+        real_dst = _to_dev(torch.zeros(3, 4, dtype=torch.float32))
+        torch._foreach_copy_([empty_dst, real_dst], [empty_src, _to_dev(real_src)])
+        _eq(real_dst, real_src)
+        assert empty_dst.numel() == 0
+
+    def test_empty_lists_rejected_upstream(self):
+        """Empty tensor lists are rejected by PyTorch before reaching the RBLN
+        kernel, so the op is never invoked with zero pairs."""
+        with pytest.raises(RuntimeError, match="at least one tensor"):
+            torch._foreach_copy_([], [])
+
+    # ---- disjoint views of one storage must stay on the fast path ----
+
+    def test_disjoint_views_same_storage(self):
+        """Mirrors the KV-cache scatter: per-call destinations are disjoint
+        slices of one shared buffer (kv[0] / kv[1]), sources are disjoint
+        slices of one staging buffer. No real overlap, so the result must be
+        correct (and the kernel must not treat shared-storage-but-disjoint as
+        aliasing)."""
+        n_layers = 3
+        # One destination buffer shaped [2, L, 8]; pair k writes [kv, layer].
+        dst_base = _to_dev(torch.zeros(2, n_layers, 8, dtype=torch.float32))
+        # One staging buffer with matching layout, prefilled with a ramp.
+        stage_cpu = _arange((2, n_layers, 8), torch.float32) + 1
+        stage_dev = _to_dev(stage_cpu)
+
+        dsts = []
+        srcs = []
+        for layer in range(n_layers):
+            dsts.append(dst_base[0, layer])
+            srcs.append(stage_dev[0, layer])
+            dsts.append(dst_base[1, layer])
+            srcs.append(stage_dev[1, layer])
+        torch._foreach_copy_(dsts, srcs)
+        _eq(dst_base, stage_cpu)
+
+    # ---- alias / order-sensitive regressions ----
+
+    def test_alias_src_is_other_pairs_dst(self):
+        """Regression for the reported bug: a tensor is both an eligible copy's
+        source and a fallback copy's destination.
+
+        ``_foreach_copy_([a, b], [b, cpu_src])`` — list-order semantics give
+        ``a == original b`` and ``b == cpu_src``. A naive batched path defers
+        ``a <- b`` past the immediate ``b <- cpu_src``, so ``a`` would wrongly
+        read the mutated ``b``."""
+        a0 = _arange((2, 4), torch.float32) + 1
+        b0 = _arange((2, 4), torch.float32) + 50
+        cpu_src = _arange((2, 4), torch.float32) + 900
+
+        # CPU reference with identical aliasing wiring.
+        a_ref, b_ref = a0.clone(), b0.clone()
+        torch._foreach_copy_([a_ref, b_ref], [b_ref, cpu_src])
+
+        a = _to_dev(a0)
+        b = _to_dev(b0)
+        torch._foreach_copy_([a, b], [b, cpu_src])  # cpu_src forces b's fallback
+
+        _eq(a, a_ref)  # must be original b, not cpu_src
+        _eq(b, b_ref)
+
+    def test_alias_swap_within_batch(self):
+        """Both pairs are batch-eligible and alias each other:
+        ``_foreach_copy_([a, b], [b, a])``. List order copies ``a <- b`` then
+        ``b <- (new) a`` so both end as the original ``b``. The batched path has
+        no inter-copy ordering, so this must drop to the sequential path."""
+        a0 = _arange((3, 4), torch.float32) + 1
+        b0 = _arange((3, 4), torch.float32) + 100
+
+        a_ref, b_ref = a0.clone(), b0.clone()
+        torch._foreach_copy_([a_ref, b_ref], [b_ref, a_ref])
+
+        a = _to_dev(a0)
+        b = _to_dev(b0)
+        torch._foreach_copy_([a, b], [b, a])
+
+        _eq(a, a_ref)
+        _eq(b, b_ref)
+
+    def test_overlapping_destinations_waw(self):
+        """Two destinations are overlapping slices of one buffer fed by disjoint
+        sources. List order makes the later write win on the overlap; the
+        batched path must not reorder them."""
+        base0 = _arange((8,), torch.float32)
+        x = _arange((4,), torch.float32) + 100
+        y = _arange((4,), torch.float32) + 200
+
+        base_ref = base0.clone()
+        torch._foreach_copy_([base_ref[0:4], base_ref[2:6]], [x, y])
+
+        base_dev = _to_dev(base0)
+        torch._foreach_copy_([base_dev[0:4], base_dev[2:6]], [_to_dev(x), _to_dev(y)])
+
+        _eq(base_dev, base_ref)
+
+    def test_identity_self_equals_src(self):
+        """Within-pair identity (``self[i] is src[i]``) is a no-op and must be
+        left unchanged — within-pair overlap is not a reorder hazard."""
+        a0 = _arange((4, 4), torch.float32) + 3
+        a = _to_dev(a0)
+        torch._foreach_copy_([a], [a])
+        _eq(a, a0)
+
+
+instantiate_device_type_tests(TestForeachCopyV2V, globals(), only_for="privateuse1")
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/rbln/test_foreach_copy_v2v.py
+++ b/test/rbln/test_foreach_copy_v2v.py
@@ -35,7 +35,7 @@ import torch
 from torch.testing._internal.common_device_type import dtypes, instantiate_device_type_tests
 from torch.testing._internal.common_utils import run_tests, TestCase
 
-from test.utils_v2v import arange as _arange, DEVICE, ENGINE_DTYPES, eq as _eq, to_dev as _to_dev
+from test.utils_v2v import arange as _arange, ENGINE_DTYPES, eq as _eq, to_dev as _to_dev
 
 
 @pytest.mark.test_set_ci


### PR DESCRIPTION
Related issue - https://github.com/rebellions-sw/vllm-rbln-internal/issues/65#issuecomment-4496432000

## Summary of Changes

Add a native RBLN implementation of `aten::_foreach_copy_` (`_foreach_copy__rbln`) and register it for the `PrivateUse1` backend.

`_foreach_copy_(self[], src[], non_blocking)` copies `src[i]` into `self[i]` for every `i`. The default decomposition lowers this to one `copy_` per pair, so a scatter into N separate-storage tensors (e.g. N per-layer KV caches) issues N independent runtime submits.

This op enqueues every eligible pair into a single `V2VBatch` and flushes them through **one** `rbln_memcpy_v2v_multi` submit — the write-side mirror of how `cat`/`stack` gather N sources into one destination through a single backend call. An N-way scatter collapses from N submits to 1.

Details:

- Conversion-free, same-device, same-shape pairs (`numel() > 0`) are enqueued via `strided_v2v_copy` into a shared `V2VBatch`, then submitted once.
- Pairs needing broadcast / dtype cast / cross-device transfer fall back to a plain per-pair `dst.copy_(src, non_blocking)`, so the general case is unchanged.
- `submit_or_fallback` preserves the existing CPU fallback path.

Files:

- `aten/src/ATen/native/rbln/RBLNCopy.{cpp,h}` — `_foreach_copy__rbln` impl + decl.
- `aten/src/ATen/native/RBLNRegisterOps.cpp` — register `_foreach_copy_` for `PrivateUse1`.

---

## Related Issues / Tickets

N/A

---

## Type of Change

- [x] `feature` — New capability or functionality
- [ ] `core` — Changes to RBLN backend, device layer, C++ extension, op registration, or `torch.compile` integration
- [ ] `fix` — Bug fix
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code improvement without behavior change
- [ ] `docs` — Documentation only
- [ ] `other` — Other (describe below)

---

## Affected Modules

- [ ] Backend
- [ ] Device
- [x] Ops/Kernels
- [ ] `torch.compile`
- [ ] C++ extension (`torch_rbln/csrc`)
- [ ] Memory
- [ ] Build/Tools
- [ ] Docs

---

## How to Test (if applicable)

1. Build the extension against the matching rebel_compiler.
2. Run `_foreach_copy_` over a list of same-device, same-shape RBLN tensors and verify outputs match an equivalent per-pair `copy_` loop.
3. Edge cases: mixed shapes / dtypes / cross-device pairs fall back to per-pair `copy_` and stay correct; empty (`numel()==0`) tensors are skipped.

---

## Checklist

* [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
* [ ] This PR is linked to a corresponding issue
* [ ] Linting passes
* [ ] All CI tests pass
* [x] The test method is described, and the expected result is clearly stated (if applicable)
* [ ] Relevant documentation has been updated (if applicable)

---

## Notes

Prerequisite for the LMCache-RBLN device-tensor `to_gpu` scatter speedup, which depends on this op plus a `set_device_layout_like` runtime API landing separately.
