### PR TITLE
fix: unpin mypy Python version

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -46,7 +46,8 @@ files =
 #
 exclude = torch/include/|torch/csrc/|torch/distributed/elastic/agent/server/api.py|torch/testing/_internal|torch/distributed/fsdp/fully_sharded_data_parallel.py
 
-python_version = 3.11
+# Do not set python_version: mypy then targets the Python version it runs under.
+# Pinning an older Python version can fail to parse dependency stubs that use newer syntax.
 
 
 #


### PR DESCRIPTION
## Summary of Changes

Removes the `python_version = 3.11` pin from `mypy.ini` so `mypy` targets the interpreter it runs under.

Under the 3.11 target, `mypy` cannot parse `numpy` 2.5.0's PEP 695 `type`-alias stubs (3.12 syntax), so the `MYPY` linter reports `command-failed` and fails CI.

---

## Type of Change

- [x] `fix` — Bug fix

---

## Affected Modules

- [x] Build/Tools

---

## Checklist

* [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
* [x] Linting passes — see [Linting](docs/LINTING.md)
* [x] All CI tests pass — see [CI/CD Workflows](docs/WORKFLOWS.md)
* [x] Relevant documentation has been updated (if applicable)

---
