### PR TITLE
feat(profiler): add torch.profiler support via libkineto bridge

### DIFF
--- a/cmake/FindRebel.cmake
+++ b/cmake/FindRebel.cmake
@@ -37,10 +37,12 @@ if(_REBEL_USE_EXTERNAL OR _REBEL_HOME)
   message(STATUS "FindRebel: EXTERNAL (REBEL_HOME) -- include: ${rebel_include_dir}, library: ${rebel_library_path}")
 # 2) Vendored: use third_party/rebel_compiler/include (external dependency vendored in-tree)
 else()
-  if(NOT EXISTS "${REBEL_INCLUDE_DIR_VENDORED}/rebel/runtime/api/rbln_runtime_api.h")
+  if(NOT EXISTS "${REBEL_INCLUDE_DIR_VENDORED}/rebel/runtime/api/rbln_runtime_api.h"
+     OR NOT EXISTS "${REBEL_INCLUDE_DIR_VENDORED}/rebel/runtime/api/rbln_kineto_api.h")
     message(FATAL_ERROR
       "FindRebel: Vendored Rebel headers not found at ${REBEL_INCLUDE_DIR_VENDORED}. "
-      "Ensure third_party/rebel_compiler/include/rebel/runtime/ is present.")
+      "Ensure the API headers are present under "
+      "third_party/rebel_compiler/include/rebel/runtime/.")
   endif()
   set(rebel_include_dir "${REBEL_INCLUDE_DIR_VENDORED}")
   find_package(Python3 COMPONENTS Interpreter REQUIRED)

--- a/constraints-build-dev.txt
+++ b/constraints-build-dev.txt
@@ -1,2 +1,2 @@
 # Build/dev dependency constraints (single source of truth).
-rebel-compiler==0.10.5.dev542+ga36f81e2
+rebel-compiler==0.11.1.dev185+g828646e3

--- a/constraints-build-dev.txt
+++ b/constraints-build-dev.txt
@@ -1,2 +1,2 @@
 # Build/dev dependency constraints (single source of truth).
-rebel-compiler==0.10.5.dev269+g6431aa72
+rebel-compiler==0.10.5.dev490+g6b6865d2

--- a/constraints-build-dev.txt
+++ b/constraints-build-dev.txt
@@ -1,2 +1,2 @@
 # Build/dev dependency constraints (single source of truth).
-rebel-compiler==0.10.5.dev540+g73659d95
+rebel-compiler==0.10.5.dev542+ga36f81e2

--- a/constraints-build-dev.txt
+++ b/constraints-build-dev.txt
@@ -1,2 +1,2 @@
 # Build/dev dependency constraints (single source of truth).
-rebel-compiler==0.10.5.dev490+g6b6865d2
+rebel-compiler==0.10.5.dev540+g73659d95

--- a/third_party/rebel_compiler/include/rebel/runtime/api/rbln_kineto_api.h
+++ b/third_party/rebel_compiler/include/rebel/runtime/api/rbln_kineto_api.h
@@ -1,0 +1,148 @@
+#ifndef REBEL_RUNTIME_API_RBLN_KINETO_API_H
+#define REBEL_RUNTIME_API_RBLN_KINETO_API_H
+
+// C-ABI for delivering one rbln profiler scope to an external consumer. It maps
+// onto the Perfetto / chrome-trace model: a Device is a "process" row, a Lane a
+// "thread" sub-row, and Slices are the timed bars laid on a lane. Returned as
+// flat device/lane/slice arrays linked by id.
+
+#include <stdint.h>
+
+#include "rebel/runtime/api/rbln_retcode.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// One device row in the trace.
+typedef struct {
+  int32_t pid;       // unique id of this device row
+  const char* name;  // valid only during the sink call
+} RblnKinetoDevice;
+
+// One lane within a device row.
+typedef struct {
+  int32_t device_pid;    // pid of the owning device row
+  int32_t resource_tid;  // unique id of this lane within the device row
+  const char* name;      // valid only during the sink call
+} RblnKinetoLane;
+
+// A key/value annotation attached to a slice.
+typedef struct {
+  const char* name;         // valid only during the sink call
+  const char* value;        // valid only during the sink call
+  int32_t value_is_quoted;  // 1 if `value` is a string literal, 0 if raw (number/json)
+} RblnKinetoAnnotation;
+
+// Coarse activity class, set by the producer (which owns the category vocabulary).
+// The consumer maps these to its own activity types and needs no knowledge of the
+// rbln category strings; `categories` (below) are display-only.
+typedef enum {
+  RBLN_KINETO_KIND_RUNTIME = 0,  // default; host-runtime-like
+  RBLN_KINETO_KIND_COMPUTE,      // neural-engine / cluster compute
+  RBLN_KINETO_KIND_DMA,          // DMA copy engines
+  RBLN_KINETO_KIND_SYNC,         // device sync / nop
+} RblnKinetoActivityKind;
+
+// One slice (a single timed activity on a lane).
+//
+// start_steady_ns/end_steady_ns are absolute steady_clock (monotonic) nanoseconds,
+// not wall-clock/system time.
+typedef struct {
+  int32_t device_pid;             // pid of the owning device row
+  int32_t resource_tid;           // tid of the owning lane
+  const char* name;               // valid only during the sink call
+  const char* const* categories;  // display-only strings; classify via `kind`
+  uint32_t categories_count;
+  int64_t start_steady_ns;
+  int64_t end_steady_ns;
+  const RblnKinetoAnnotation* annotations;  // array of `annotations_count`
+  uint32_t annotations_count;
+  int64_t corr_id;              // correlation id, or 0 if unset
+  RblnKinetoActivityKind kind;  // activity class (categories are display-only)
+} RblnKinetoSlice;
+
+// The full result of one profiling scope, delivered to the sink in one call.
+// Every pointer below (and every string it reaches) is valid ONLY for the
+// duration of the sink call; copy anything that must outlive it.
+typedef struct {
+  const RblnKinetoDevice* devices;  // sorted by pid
+  uint32_t devices_count;
+  const RblnKinetoLane* lanes;
+  uint32_t lanes_count;
+  const RblnKinetoSlice* slices;
+  uint32_t slices_count;
+} RblnKinetoExport;
+
+// Callback invoked once per scope with the fully materialized export. Every
+// pointer it receives is valid only until it returns.
+typedef void (*RblnKinetoExportSink)(const RblnKinetoExport* exp, void* user_data);
+
+// Opaque per-scope exporter handle.
+typedef struct RblnKinetoExporter RblnKinetoExporter;
+
+/**
+ * @brief Reports whether the rbln profiler runtime is currently active.
+ *
+ * @param active_out [out] Set to 1 if profiling is active, 0 otherwise.
+ *
+ * @return 0 on success, or an error code on failure.
+ */
+RBLNRetCode rbln_kineto_is_active(int32_t* active_out);
+
+/**
+ * @brief Creates a per-scope exporter handle.
+ *
+ * @param exporter_out [out] Receives the new handle, owned by the caller.
+ *
+ * @return 0 on success, or an error code on failure.
+ */
+RBLNRetCode rbln_kineto_exporter_create(RblnKinetoExporter** exporter_out);
+
+/**
+ * @brief Destroys an exporter handle created by rbln_kineto_exporter_create.
+ *
+ * @param exporter [in] Handle to destroy; may be NULL.
+ *
+ * @return 0 on success, or an error code on failure.
+ */
+RBLNRetCode rbln_kineto_exporter_destroy(RblnKinetoExporter* exporter);
+
+/**
+ * @brief Begins one profiling scope.
+ *
+ * @details Discards any data captured before this call and starts a fresh
+ * capture. Trace output is written under the directory named by the
+ * RBLN_PROFILER_DIR environment variable.
+ *
+ * @param exporter [in] Exporter handle for this scope.
+ *
+ * @return 0 on success, or an error code on failure.
+ */
+RBLNRetCode rbln_kineto_begin_scope(RblnKinetoExporter* exporter);
+
+/**
+ * @brief Ends one profiling scope and delivers its result.
+ *
+ * @details Invokes `sink` exactly once, synchronously, with the materialized
+ * export before returning; all pointers passed to `sink` are valid only during
+ * that call. If the scope captured nothing, `sink` is not called and
+ * `*exported_out` is set to 0; otherwise it is set to 1. The scope is reset for
+ * reuse afterward.
+ *
+ * @param exporter [in] Exporter handle for this scope.
+ * @param sink [in] Callback that receives the export.
+ * @param user_data [in] Opaque pointer passed through to `sink`.
+ * @param exported_out [out] Set to 1 if `sink` was invoked, 0 otherwise.
+ *
+ * @return 0 on success, or an error code on failure.
+ */
+RBLNRetCode rbln_kineto_end_scope_and_export(RblnKinetoExporter* exporter,
+                                             RblnKinetoExportSink sink, void* user_data,
+                                             int32_t* exported_out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // REBEL_RUNTIME_API_RBLN_KINETO_API_H

--- a/third_party/rebel_compiler/include/rebel/runtime/api/rbln_kineto_api.h
+++ b/third_party/rebel_compiler/include/rebel/runtime/api/rbln_kineto_api.h
@@ -78,9 +78,6 @@ typedef struct {
 // pointer it receives is valid only until it returns.
 typedef void (*RblnKinetoExportSink)(const RblnKinetoExport* exp, void* user_data);
 
-// Opaque per-scope exporter handle.
-typedef struct RblnKinetoExporter RblnKinetoExporter;
-
 /**
  * @brief Reports whether the rbln profiler runtime is currently active.
  *
@@ -91,35 +88,15 @@ typedef struct RblnKinetoExporter RblnKinetoExporter;
 RBLNRetCode rbln_kineto_is_active(int32_t* active_out);
 
 /**
- * @brief Creates a per-scope exporter handle.
- *
- * @param exporter_out [out] Receives the new handle, owned by the caller.
- *
- * @return 0 on success, or an error code on failure.
- */
-RBLNRetCode rbln_kineto_exporter_create(RblnKinetoExporter** exporter_out);
-
-/**
- * @brief Destroys an exporter handle created by rbln_kineto_exporter_create.
- *
- * @param exporter [in] Handle to destroy; may be NULL.
- *
- * @return 0 on success, or an error code on failure.
- */
-RBLNRetCode rbln_kineto_exporter_destroy(RblnKinetoExporter* exporter);
-
-/**
  * @brief Begins one profiling scope.
  *
  * @details Discards any data captured before this call and starts a fresh
  * capture. Trace output is written under the directory named by the
  * RBLN_PROFILER_DIR environment variable.
  *
- * @param exporter [in] Exporter handle for this scope.
- *
  * @return 0 on success, or an error code on failure.
  */
-RBLNRetCode rbln_kineto_begin_scope(RblnKinetoExporter* exporter);
+RBLNRetCode rbln_kineto_begin_scope(void);
 
 /**
  * @brief Ends one profiling scope and delivers its result.
@@ -130,15 +107,13 @@ RBLNRetCode rbln_kineto_begin_scope(RblnKinetoExporter* exporter);
  * `*exported_out` is set to 0; otherwise it is set to 1. The scope is reset for
  * reuse afterward.
  *
- * @param exporter [in] Exporter handle for this scope.
  * @param sink [in] Callback that receives the export.
  * @param user_data [in] Opaque pointer passed through to `sink`.
  * @param exported_out [out] Set to 1 if `sink` was invoked, 0 otherwise.
  *
  * @return 0 on success, or an error code on failure.
  */
-RBLNRetCode rbln_kineto_end_scope_and_export(RblnKinetoExporter* exporter,
-                                             RblnKinetoExportSink sink, void* user_data,
+RBLNRetCode rbln_kineto_end_scope_and_export(RblnKinetoExportSink sink, void* user_data,
                                              int32_t* exported_out);
 
 #ifdef __cplusplus

--- a/third_party/rebel_compiler/include/rebel/runtime/api/rbln_kineto_api.h
+++ b/third_party/rebel_compiler/include/rebel/runtime/api/rbln_kineto_api.h
@@ -57,7 +57,6 @@ typedef struct {
   int64_t end_steady_ns;
   const RblnKinetoAnnotation* annotations;  // array of `annotations_count`
   uint32_t annotations_count;
-  int64_t corr_id;              // correlation id, or 0 if unset
   RblnKinetoActivityKind kind;  // activity class (categories are display-only)
 } RblnKinetoSlice;
 

--- a/third_party/rebel_compiler/include/rebel/runtime/api/rbln_kineto_api.h
+++ b/third_party/rebel_compiler/include/rebel/runtime/api/rbln_kineto_api.h
@@ -1,14 +1,13 @@
 #ifndef REBEL_RUNTIME_API_RBLN_KINETO_API_H
 #define REBEL_RUNTIME_API_RBLN_KINETO_API_H
 
-// C-ABI for delivering one rbln profiler scope to an external consumer. It maps
+// C-ABI for delivering one rbln profiler session to an external consumer. It maps
 // onto the Perfetto / chrome-trace model: a Device is a "process" row, a Lane a
 // "thread" sub-row, and Slices are the timed bars laid on a lane. Returned as
 // flat device/lane/slice arrays linked by id.
 
+#include <rebel/runtime/api/rbln_retcode.h>
 #include <stdint.h>
-
-#include "rebel/runtime/api/rbln_retcode.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -62,7 +61,7 @@ typedef struct {
   RblnKinetoActivityKind kind;  // activity class (categories are display-only)
 } RblnKinetoSlice;
 
-// The full result of one profiling scope, delivered to the sink in one call.
+// The full result of one profiling session, delivered to the sink in one call.
 // Every pointer below (and every string it reaches) is valid ONLY for the
 // duration of the sink call; copy anything that must outlive it.
 typedef struct {
@@ -74,7 +73,7 @@ typedef struct {
   uint32_t slices_count;
 } RblnKinetoExport;
 
-// Callback invoked once per scope with the fully materialized export. Every
+// Callback invoked once per session with the fully materialized export. Every
 // pointer it receives is valid only until it returns.
 typedef void (*RblnKinetoExportSink)(const RblnKinetoExport* exp, void* user_data);
 
@@ -88,7 +87,7 @@ typedef void (*RblnKinetoExportSink)(const RblnKinetoExport* exp, void* user_dat
 RBLNRetCode rbln_kineto_is_active(int32_t* active_out);
 
 /**
- * @brief Begins one profiling scope.
+ * @brief Begins one profiling session.
  *
  * @details Discards any data captured before this call and starts a fresh
  * capture. Trace output is written under the directory named by the
@@ -96,15 +95,15 @@ RBLNRetCode rbln_kineto_is_active(int32_t* active_out);
  *
  * @return 0 on success, or an error code on failure.
  */
-RBLNRetCode rbln_kineto_begin_scope(void);
+RBLNRetCode rbln_kineto_begin_session(void);
 
 /**
- * @brief Ends one profiling scope and delivers its result.
+ * @brief Ends one profiling session and delivers its result.
  *
  * @details Invokes `sink` exactly once, synchronously, with the materialized
  * export before returning; all pointers passed to `sink` are valid only during
- * that call. If the scope captured nothing, `sink` is not called and
- * `*exported_out` is set to 0; otherwise it is set to 1. The scope is reset for
+ * that call. If the session captured nothing, `sink` is not called and
+ * `*exported_out` is set to 0; otherwise it is set to 1. The session is reset for
  * reuse afterward.
  *
  * @param sink [in] Callback that receives the export.
@@ -113,8 +112,8 @@ RBLNRetCode rbln_kineto_begin_scope(void);
  *
  * @return 0 on success, or an error code on failure.
  */
-RBLNRetCode rbln_kineto_end_scope_and_export(RblnKinetoExportSink sink, void* user_data,
-                                             int32_t* exported_out);
+RBLNRetCode rbln_kineto_end_session_and_export(RblnKinetoExportSink sink, void* user_data,
+                                               int32_t* exported_out);
 
 #ifdef __cplusplus
 }

--- a/third_party/rebel_compiler/include/rebel/runtime/api/rbln_retcode.h
+++ b/third_party/rebel_compiler/include/rebel/runtime/api/rbln_retcode.h
@@ -1,0 +1,18 @@
+#ifndef REBEL_RUNTIME_API_RBLN_RETCODE_H
+#define REBEL_RUNTIME_API_RBLN_RETCODE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+  RBLNRetCode_SUCCESS = 0,
+  RBLNRetCode_FAILURE,
+  RBLNRetCode_INVALID,
+} RBLNRetCode;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // REBEL_RUNTIME_API_RBLN_RETCODE_H

--- a/third_party/rebel_compiler/include/rebel/runtime/api/rbln_runtime_api.h
+++ b/third_party/rebel_compiler/include/rebel/runtime/api/rbln_runtime_api.h
@@ -7,7 +7,7 @@
 #include <tuple>
 #include <vector>
 
-#include "rebel/runtime/api/rbln_retcode.h"
+#include <rebel/runtime/api/rbln_retcode.h>
 
 #ifdef __cplusplus
 

--- a/third_party/rebel_compiler/include/rebel/runtime/api/rbln_runtime_api.h
+++ b/third_party/rebel_compiler/include/rebel/runtime/api/rbln_runtime_api.h
@@ -1,13 +1,12 @@
 #ifndef REBEL_RUNTIME_API_RBLN_RUNTIME_API_H
 #define REBEL_RUNTIME_API_RBLN_RUNTIME_API_H
 
+#include <rebel/runtime/api/rbln_retcode.h>
 #include <stdint.h>
 
 #include <string>
 #include <tuple>
 #include <vector>
-
-#include <rebel/runtime/api/rbln_retcode.h>
 
 #ifdef __cplusplus
 

--- a/third_party/rebel_compiler/include/rebel/runtime/api/rbln_runtime_api.h
+++ b/third_party/rebel_compiler/include/rebel/runtime/api/rbln_runtime_api.h
@@ -7,6 +7,8 @@
 #include <tuple>
 #include <vector>
 
+#include "rebel/runtime/api/rbln_retcode.h"
+
 #ifdef __cplusplus
 
 namespace rbln {
@@ -15,12 +17,6 @@ class MemoryStats;
 
 extern "C" {
 #endif
-
-typedef enum {
-  RBLNRetCode_SUCCESS = 0,
-  RBLNRetCode_FAILURE,
-  RBLNRetCode_INVALID,
-} RBLNRetCode;
 
 typedef enum {
   RBLNMemcpyType_H2D = 0,
@@ -278,15 +274,10 @@ constexpr uint32_t kMaxV2VMultiCopies = 1024;
 RBLNRetCode rbln_memcpy_v2v_multi(
     const std::vector<std::tuple<uint64_t, uint64_t, uint64_t>>& copies);
 
-// Async variants. *handle_out == 0 means a synchronous (fast-path-ineligible) completion;
-// else rbln_transfer_wait before reading dst. Sync copy APIs don't chain on the stream —
-// wait/synchronize before a sync copy on the same vaddr.
-//
-// Ordering contract: between an async dispatch and its rbln_transfer_wait, do NOT issue any
-// other copy that touches the SAME device area (not just the same vaddr — distinct vaddrs in
-// one vmem entry share its area, hence the same cached command buffer). The finalize step
-// reads the area's MRU command-buffer entry, which an intervening copy would rotate, so an
-// unaligned D2H bounce would land at the wrong host address.
+// Async variants. *handle_out == 0 means a synchronous (fast-path-ineligible) completion; else
+// rbln_transfer_wait (or rbln_device_synchronize) before reading dst — there is no auto-sync on
+// host read. The same vaddr/area may be re-copied while a transfer is in flight (finalize is
+// per-handle, not MRU-order). Sync copy APIs drain the device's in-flight transfers first.
 RBLNRetCode rbln_memcpy_v2h_async(uint64_t src_vaddr, uintptr_t dst_host_ptr, uint64_t size,
                                   uint64_t* handle_out);
 RBLNRetCode rbln_memcpy_h2v_async(uintptr_t src_host_ptr, uint64_t dst_vaddr, uint64_t size,

--- a/torch_rbln/csrc/rbln/CMakeLists.txt
+++ b/torch_rbln/csrc/rbln/CMakeLists.txt
@@ -2,7 +2,9 @@ set(target torch_rbln_csrc_rbln)
 
 find_package(Torch REQUIRED)
 
-pybind11_add_module(${target} Module.cpp DispatchShim.cpp WarmCache.cpp ../distributed/c10d/rbln/ProcessGroupRBLNModule.cpp)
+pybind11_add_module(${target} Module.cpp DispatchShim.cpp WarmCache.cpp ../distributed/c10d/rbln/ProcessGroupRBLNModule.cpp
+  profiler/kineto/rbln_kineto_emitter.cc
+  profiler/kineto/rbln_kineto_adapter.cc)
 
 
 find_library(TORCH_PYTHON_LIBRARY torch_python PATH "${TORCH_INSTALL_PREFIX}/lib")

--- a/torch_rbln/csrc/rbln/Module.cpp
+++ b/torch_rbln/csrc/rbln/Module.cpp
@@ -12,6 +12,7 @@
 #include <torch_rbln/csrc/distributed/c10d/rbln/ProcessGroupRBLNModule.hpp>
 #include <torch_rbln/csrc/rbln/DispatchShim.h>
 #include <torch_rbln/csrc/rbln/WarmCache.h>
+#include <torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_adapter.h>
 #include <exception>
 #include <vector>
 
@@ -359,6 +360,7 @@ extern "C" PyObject* initModule() {
   register_public_device_api(python_module);
   register_internal_api(python_module);
   register_supported_dtypes_api(python_module);
+  rbln::profiler::kineto::register_rbln_kineto_profiler();
 
   c10::rbln::register_rbln_device_mapping_initialized_callback([]() {
     py::gil_scoped_acquire gil;

--- a/torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_adapter.cc
+++ b/torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_adapter.cc
@@ -4,6 +4,8 @@
 
 #include <torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_adapter.h>
 
+#include <c10/rbln/RBLNLogging.h>
+
 #include <kineto/ActivityType.h>
 #include <kineto/Config.h>
 #include <kineto/GenericTraceActivity.h>
@@ -51,21 +53,41 @@ class RblnActivityProfilerSession : public ::libkineto::IActivityProfilerSession
   RblnActivityProfilerSession& operator=(const RblnActivityProfilerSession&) = delete;
 
   void start() override {
-    status_ = ::libkineto::TraceStatus::RECORDING;
     // (steady, system) anchor at session open; exported slices carry steady_clock ns,
     // so we add (system - steady) at projection time to convert them to system time.
     anchor_steady_ns_ = now_ns(std::chrono::steady_clock::now());
     anchor_system_ns_ = now_ns(std::chrono::system_clock::now());
     start_ts_ns_ = anchor_system_ns_;
-    rbln_kineto_begin_session();
+    const RBLNRetCode ret = rbln_kineto_begin_session();
+    if (ret != RBLNRetCode_SUCCESS) {
+      RBLN_LOG_WARN(
+          "rbln_kineto_begin_session failed with error code: {}; skipping rbln profiling for this session",
+          static_cast<int>(ret));
+      status_ = ::libkineto::TraceStatus::ERROR;
+      return;
+    }
+    session_started_ = true;
+    status_ = ::libkineto::TraceStatus::RECORDING;
   }
 
   void stop() override {
+    if (!session_started_) {
+      status_ = ::libkineto::TraceStatus::ERROR;
+      return;
+    }
+    session_started_ = false;
     status_ = ::libkineto::TraceStatus::PROCESSING;
     clock_offset_ns_ = anchor_system_ns_ - anchor_steady_ns_;
     projected_ = ProjectedKinetoTrace{};
     int32_t exported = 0;
-    rbln_kineto_end_session_and_export(&sink_thunk, this, &exported);
+    const RBLNRetCode ret = rbln_kineto_end_session_and_export(&sink_thunk, this, &exported);
+    if (ret != RBLNRetCode_SUCCESS) {
+      RBLN_LOG_WARN(
+          "rbln_kineto_end_session_and_export failed with error code: {}; dropping rbln trace for this session",
+          static_cast<int>(ret));
+      status_ = ::libkineto::TraceStatus::ERROR;
+      return;
+    }
     status_ = ::libkineto::TraceStatus::READY;
   }
 
@@ -118,6 +140,7 @@ class RblnActivityProfilerSession : public ::libkineto::IActivityProfilerSession
   int64_t anchor_system_ns_ = 0;
   int64_t clock_offset_ns_ = 0;
   int64_t start_ts_ns_ = 0; // metadata-event timestamp for device/resource rows
+  bool session_started_ = false; // begin_session succeeded; gates stop()'s end call
 };
 
 class RblnActivityProfiler : public ::libkineto::IActivityProfiler {
@@ -143,7 +166,12 @@ class RblnActivityProfiler : public ::libkineto::IActivityProfiler {
     // always includes PRIVATEUSE1_RUNTIME/DRIVER in its default set, so the request
     // can't tell us whether the user actually wants rbln profiling.
     int32_t active = 0;
-    rbln_kineto_is_active(&active);
+    const RBLNRetCode ret = rbln_kineto_is_active(&active);
+    if (ret != RBLNRetCode_SUCCESS) {
+      RBLN_LOG_WARN(
+          "rbln_kineto_is_active failed with error code: {}; not creating a profiling session", static_cast<int>(ret));
+      return nullptr;
+    }
     if (!active)
       return nullptr;
     return std::make_unique<RblnActivityProfilerSession>();

--- a/torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_adapter.cc
+++ b/torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_adapter.cc
@@ -1,0 +1,186 @@
+// libkineto plugin coupling a torch.profiler scope with one rbln profiling
+// scope, through the rbln_kineto_* C-ABI (rebel/runtime/api/rbln_kineto_api.h).
+// start()/stop() drive the exporter via the C API
+
+#include "torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_adapter.h"
+
+#include <kineto/ActivityType.h>
+#include <kineto/Config.h>
+#include <kineto/GenericTraceActivity.h>
+#include <kineto/IActivityProfiler.h>
+#include <kineto/TraceSpan.h>
+#include <kineto/libkineto.h>
+#include <kineto/output_base.h>
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "rebel/runtime/api/rbln_kineto_api.h"
+#include "torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_emitter.h"
+
+namespace rbln {
+namespace profiler {
+namespace kineto {
+
+namespace {
+
+// GenericTraceActivity keeps the span by pointer, and the activities live longer
+// than this session (they travel into torch's trace result), so the span must
+// live at least as long: static, not a session member/local (which would dangle).
+const ::libkineto::TraceSpan& default_trace_span() {
+  static ::libkineto::TraceSpan span(0, 0, "rbln_trace");
+  return span;
+}
+
+int64_t now_ns(std::chrono::steady_clock::time_point tp) {
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(tp.time_since_epoch()).count();
+}
+int64_t now_ns(std::chrono::system_clock::time_point tp) {
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(tp.time_since_epoch()).count();
+}
+
+} // namespace
+
+class RblnActivityProfilerSession : public ::libkineto::IActivityProfilerSession {
+ public:
+  RblnActivityProfilerSession() {
+    rbln_kineto_exporter_create(&exporter_);
+  }
+  ~RblnActivityProfilerSession() override {
+    if (exporter_)
+      rbln_kineto_exporter_destroy(exporter_);
+  }
+  RblnActivityProfilerSession(const RblnActivityProfilerSession&) = delete;
+  RblnActivityProfilerSession& operator=(const RblnActivityProfilerSession&) = delete;
+
+  void start() override {
+    status_ = ::libkineto::TraceStatus::RECORDING;
+    // (steady, system) anchor at scope open; exported slices carry steady_clock ns,
+    // so we add (system - steady) at projection time to convert them to system time.
+    anchor_steady_ns_ = now_ns(std::chrono::steady_clock::now());
+    anchor_system_ns_ = now_ns(std::chrono::system_clock::now());
+    start_ts_ns_ = anchor_system_ns_;
+    rbln_kineto_begin_scope(exporter_);
+  }
+
+  void stop() override {
+    status_ = ::libkineto::TraceStatus::PROCESSING;
+    clock_offset_ns_ = anchor_system_ns_ - anchor_steady_ns_;
+    projected_ = ProjectedKinetoTrace{};
+    int32_t exported = 0;
+    rbln_kineto_end_scope_and_export(exporter_, &sink_thunk, this, &exported);
+    status_ = ::libkineto::TraceStatus::READY;
+  }
+
+  void on_export(const RblnKinetoExport* exp) {
+    convert_export_to_kineto(exp, clock_offset_ns_, default_trace_span(), &projected_);
+  }
+
+  std::vector<std::string> errors() override {
+    return {};
+  }
+
+  void processTrace(::libkineto::ActivityLogger& logger) override {
+    // Register device/resource rows through the logger, not the getDeviceInfo()
+    // getter: that getter returns only one DeviceInfo, but a trace can have
+    // multiple device rows, so the single getter can't fit them.
+    for (const auto& dev : projected_.device_infos) {
+      logger.handleDeviceInfo(dev, start_ts_ns_);
+    }
+    for (const auto& res : projected_.resource_infos) {
+      logger.handleResourceInfo(res, start_ts_ns_);
+    }
+    for (const auto& act : projected_.activities) {
+      act.log(logger);
+    }
+  }
+
+  std::unique_ptr<::libkineto::DeviceInfo> getDeviceInfo() override {
+    return {};
+  }
+
+  std::vector<::libkineto::ResourceInfo> getResourceInfos() override {
+    return {};
+  }
+
+  std::unique_ptr<::libkineto::CpuTraceBuffer> getTraceBuffer() override {
+    auto buf = std::make_unique<::libkineto::CpuTraceBuffer>();
+    for (const auto& act : projected_.activities) {
+      buf->emplace_activity(act);
+    }
+    return buf;
+  }
+
+ private:
+  static void sink_thunk(const RblnKinetoExport* exp, void* user_data) {
+    static_cast<RblnActivityProfilerSession*>(user_data)->on_export(exp);
+  }
+
+  ::RblnKinetoExporter* exporter_ = nullptr;
+  ProjectedKinetoTrace projected_;
+  int64_t anchor_steady_ns_ = 0;
+  int64_t anchor_system_ns_ = 0;
+  int64_t clock_offset_ns_ = 0;
+  int64_t start_ts_ns_ = 0; // metadata-event timestamp for device/resource rows
+};
+
+class RblnActivityProfiler : public ::libkineto::IActivityProfiler {
+ public:
+  RblnActivityProfiler()
+      : supported_{::libkineto::ActivityType::PRIVATEUSE1_RUNTIME, ::libkineto::ActivityType::PRIVATEUSE1_DRIVER} {}
+  ~RblnActivityProfiler() override = default;
+
+  const std::string& name() const override {
+    static const std::string kName = "RblnProfiler";
+    return kName;
+  }
+
+  const std::set<::libkineto::ActivityType>& availableActivities() const override {
+    return supported_;
+  }
+
+  std::unique_ptr<::libkineto::IActivityProfilerSession> configure(
+      const std::set<::libkineto::ActivityType>& /*activity_types*/,
+      const ::libkineto::Config&) override {
+    // Create a session only when rbln profiling is actually running
+    // (rbln_kineto_is_active()), not based on the requested activity types: pytorch
+    // always includes PRIVATEUSE1_RUNTIME/DRIVER in its default set, so the request
+    // can't tell us whether the user actually wants rbln profiling.
+    int32_t active = 0;
+    rbln_kineto_is_active(&active);
+    if (!active)
+      return nullptr;
+    return std::make_unique<RblnActivityProfilerSession>();
+  }
+
+  std::unique_ptr<::libkineto::IActivityProfilerSession> configure(
+      int64_t /*ts_ms*/,
+      int64_t /*duration_ms*/,
+      const std::set<::libkineto::ActivityType>& activity_types,
+      const ::libkineto::Config& config) override {
+    return configure(activity_types, config);
+  }
+
+ private:
+  std::set<::libkineto::ActivityType> supported_;
+};
+
+namespace {
+
+std::unique_ptr<::libkineto::IActivityProfiler> create_rbln_profiler() {
+  return std::make_unique<RblnActivityProfiler>();
+}
+
+} // namespace
+
+void register_rbln_kineto_profiler() {
+  ::libkineto::api().registerProfilerFactory(&create_rbln_profiler);
+}
+
+} // namespace kineto
+} // namespace profiler
+} // namespace rbln

--- a/torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_adapter.cc
+++ b/torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_adapter.cc
@@ -123,11 +123,7 @@ class RblnActivityProfilerSession : public ::libkineto::IActivityProfilerSession
   }
 
   std::unique_ptr<::libkineto::CpuTraceBuffer> getTraceBuffer() override {
-    auto buf = std::make_unique<::libkineto::CpuTraceBuffer>();
-    for (const auto& act : projected_.activities) {
-      buf->emplace_activity(act);
-    }
-    return buf;
+    return nullptr;
   }
 
  private:

--- a/torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_adapter.cc
+++ b/torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_adapter.cc
@@ -1,8 +1,8 @@
-// libkineto plugin coupling a torch.profiler scope with one rbln profiling
-// scope, through the rbln_kineto_* C-ABI (rebel/runtime/api/rbln_kineto_api.h).
+// libkineto plugin coupling a torch.profiler session with one rbln profiling
+// session, through the rbln_kineto_* C-ABI (rebel/runtime/api/rbln_kineto_api.h).
 // start()/stop() drive the exporter via the C API
 
-#include "torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_adapter.h"
+#include <torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_adapter.h>
 
 #include <kineto/ActivityType.h>
 #include <kineto/Config.h>
@@ -19,12 +19,10 @@
 #include <string>
 #include <vector>
 
-#include "rebel/runtime/api/rbln_kineto_api.h"
-#include "torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_emitter.h"
+#include <rebel/runtime/api/rbln_kineto_api.h>
+#include <torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_emitter.h>
 
-namespace rbln {
-namespace profiler {
-namespace kineto {
+namespace rbln::profiler::kineto {
 
 namespace {
 
@@ -54,12 +52,12 @@ class RblnActivityProfilerSession : public ::libkineto::IActivityProfilerSession
 
   void start() override {
     status_ = ::libkineto::TraceStatus::RECORDING;
-    // (steady, system) anchor at scope open; exported slices carry steady_clock ns,
+    // (steady, system) anchor at session open; exported slices carry steady_clock ns,
     // so we add (system - steady) at projection time to convert them to system time.
     anchor_steady_ns_ = now_ns(std::chrono::steady_clock::now());
     anchor_system_ns_ = now_ns(std::chrono::system_clock::now());
     start_ts_ns_ = anchor_system_ns_;
-    rbln_kineto_begin_scope();
+    rbln_kineto_begin_session();
   }
 
   void stop() override {
@@ -67,7 +65,7 @@ class RblnActivityProfilerSession : public ::libkineto::IActivityProfilerSession
     clock_offset_ns_ = anchor_system_ns_ - anchor_steady_ns_;
     projected_ = ProjectedKinetoTrace{};
     int32_t exported = 0;
-    rbln_kineto_end_scope_and_export(&sink_thunk, this, &exported);
+    rbln_kineto_end_session_and_export(&sink_thunk, this, &exported);
     status_ = ::libkineto::TraceStatus::READY;
   }
 
@@ -175,6 +173,4 @@ void register_rbln_kineto_profiler() {
   ::libkineto::api().registerProfilerFactory(&create_rbln_profiler);
 }
 
-} // namespace kineto
-} // namespace profiler
-} // namespace rbln
+} // namespace rbln::profiler::kineto

--- a/torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_adapter.cc
+++ b/torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_adapter.cc
@@ -47,13 +47,8 @@ int64_t now_ns(std::chrono::system_clock::time_point tp) {
 
 class RblnActivityProfilerSession : public ::libkineto::IActivityProfilerSession {
  public:
-  RblnActivityProfilerSession() {
-    rbln_kineto_exporter_create(&exporter_);
-  }
-  ~RblnActivityProfilerSession() override {
-    if (exporter_)
-      rbln_kineto_exporter_destroy(exporter_);
-  }
+  RblnActivityProfilerSession() = default;
+  ~RblnActivityProfilerSession() override = default;
   RblnActivityProfilerSession(const RblnActivityProfilerSession&) = delete;
   RblnActivityProfilerSession& operator=(const RblnActivityProfilerSession&) = delete;
 
@@ -64,7 +59,7 @@ class RblnActivityProfilerSession : public ::libkineto::IActivityProfilerSession
     anchor_steady_ns_ = now_ns(std::chrono::steady_clock::now());
     anchor_system_ns_ = now_ns(std::chrono::system_clock::now());
     start_ts_ns_ = anchor_system_ns_;
-    rbln_kineto_begin_scope(exporter_);
+    rbln_kineto_begin_scope();
   }
 
   void stop() override {
@@ -72,7 +67,7 @@ class RblnActivityProfilerSession : public ::libkineto::IActivityProfilerSession
     clock_offset_ns_ = anchor_system_ns_ - anchor_steady_ns_;
     projected_ = ProjectedKinetoTrace{};
     int32_t exported = 0;
-    rbln_kineto_end_scope_and_export(exporter_, &sink_thunk, this, &exported);
+    rbln_kineto_end_scope_and_export(&sink_thunk, this, &exported);
     status_ = ::libkineto::TraceStatus::READY;
   }
 
@@ -120,7 +115,6 @@ class RblnActivityProfilerSession : public ::libkineto::IActivityProfilerSession
     static_cast<RblnActivityProfilerSession*>(user_data)->on_export(exp);
   }
 
-  ::RblnKinetoExporter* exporter_ = nullptr;
   ProjectedKinetoTrace projected_;
   int64_t anchor_steady_ns_ = 0;
   int64_t anchor_system_ns_ = 0;

--- a/torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_adapter.cc
+++ b/torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_adapter.cc
@@ -58,6 +58,7 @@ class RblnActivityProfilerSession : public ::libkineto::IActivityProfilerSession
     anchor_steady_ns_ = now_ns(std::chrono::steady_clock::now());
     anchor_system_ns_ = now_ns(std::chrono::system_clock::now());
     start_ts_ns_ = anchor_system_ns_;
+    clock_offset_ns_ = anchor_system_ns_ - anchor_steady_ns_;
     const RBLNRetCode ret = rbln_kineto_begin_session();
     if (ret != RBLNRetCode_SUCCESS) {
       RBLN_LOG_WARN(
@@ -77,7 +78,6 @@ class RblnActivityProfilerSession : public ::libkineto::IActivityProfilerSession
     }
     session_started_ = false;
     status_ = ::libkineto::TraceStatus::PROCESSING;
-    clock_offset_ns_ = anchor_system_ns_ - anchor_steady_ns_;
     projected_ = ProjectedKinetoTrace{};
     int32_t exported = 0;
     const RBLNRetCode ret = rbln_kineto_end_session_and_export(&sink_thunk, this, &exported);

--- a/torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_adapter.h
+++ b/torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_adapter.h
@@ -1,17 +1,13 @@
 #ifndef TORCH_RBLN_PROFILER_KINETO_RBLN_KINETO_ADAPTER_H
 #define TORCH_RBLN_PROFILER_KINETO_RBLN_KINETO_ADAPTER_H
 
-namespace rbln {
-namespace profiler {
-namespace kineto {
+namespace rbln::profiler::kineto {
 
 // Registers the rbln IActivityProfiler factory with libkineto; call once at _C
 // module init. Explicit (not static-init) -- static-init in a pybind module can
 // be dead-stripped.
 void register_rbln_kineto_profiler();
 
-} // namespace kineto
-} // namespace profiler
-} // namespace rbln
+} // namespace rbln::profiler::kineto
 
 #endif // TORCH_RBLN_PROFILER_KINETO_RBLN_KINETO_ADAPTER_H

--- a/torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_adapter.h
+++ b/torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_adapter.h
@@ -1,0 +1,17 @@
+#ifndef TORCH_RBLN_PROFILER_KINETO_RBLN_KINETO_ADAPTER_H
+#define TORCH_RBLN_PROFILER_KINETO_RBLN_KINETO_ADAPTER_H
+
+namespace rbln {
+namespace profiler {
+namespace kineto {
+
+// Registers the rbln IActivityProfiler factory with libkineto; call once at _C
+// module init. Explicit (not static-init) -- static-init in a pybind module can
+// be dead-stripped.
+void register_rbln_kineto_profiler();
+
+} // namespace kineto
+} // namespace profiler
+} // namespace rbln
+
+#endif // TORCH_RBLN_PROFILER_KINETO_RBLN_KINETO_ADAPTER_H

--- a/torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_emitter.cc
+++ b/torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_emitter.cc
@@ -1,0 +1,100 @@
+// C-ABI -> libkineto assembly
+
+#include "torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_emitter.h"
+
+#include <cstdint>
+#include <string>
+
+namespace rbln {
+namespace profiler {
+namespace kineto {
+
+namespace {
+
+// Map the producer-set activity kind to a libkineto ActivityType.
+::libkineto::ActivityType kind_to_activity_type(RblnKinetoActivityKind kind) {
+  using ::libkineto::ActivityType;
+  switch (kind) {
+    case RBLN_KINETO_KIND_COMPUTE:
+      return ActivityType::CONCURRENT_KERNEL;
+    case RBLN_KINETO_KIND_DMA:
+      return ActivityType::GPU_MEMCPY;
+    case RBLN_KINETO_KIND_SYNC:
+      return ActivityType::PRIVATEUSE1_DRIVER;
+    case RBLN_KINETO_KIND_RUNTIME:
+    default:
+      return ActivityType::PRIVATEUSE1_RUNTIME;
+  }
+}
+
+} // namespace
+
+void convert_export_to_kineto(
+    const RblnKinetoExport* exp,
+    int64_t clock_offset_ns,
+    const ::libkineto::TraceSpan& span,
+    ProjectedKinetoTrace* out) {
+  if (!out)
+    return;
+  out->device_infos.clear();
+  out->resource_infos.clear();
+  out->activities.clear();
+  if (!exp)
+    return;
+
+  out->device_infos.reserve(exp->devices_count);
+  for (uint32_t i = 0; i < exp->devices_count; ++i) {
+    const RblnKinetoDevice& dev = exp->devices[i];
+    out->device_infos.emplace_back(/*id=*/dev.pid,
+                                   /*sortIndex=*/kRblnDeviceSortIndex + dev.pid,
+                                   /*name=*/std::string(dev.name ? dev.name : ""),
+                                   /*label=*/std::string());
+  }
+
+  out->resource_infos.reserve(exp->lanes_count);
+  for (uint32_t i = 0; i < exp->lanes_count; ++i) {
+    const RblnKinetoLane& lane = exp->lanes[i];
+    out->resource_infos.emplace_back(/*deviceId=*/lane.device_pid,
+                                     /*id=*/lane.resource_tid,
+                                     /*sortIndex=*/lane.resource_tid,
+                                     /*name=*/std::string(lane.name ? lane.name : ""));
+  }
+
+  out->activities.reserve(exp->slices_count);
+  for (uint32_t i = 0; i < exp->slices_count; ++i) {
+    const RblnKinetoSlice& s = exp->slices[i];
+    const ::libkineto::ActivityType act_type = kind_to_activity_type(s.kind);
+    ::libkineto::GenericTraceActivity act(span, act_type, std::string(s.name ? s.name : ""));
+    act.startTime = s.start_steady_ns + clock_offset_ns;
+    act.endTime = s.end_steady_ns + clock_offset_ns;
+    act.device = s.device_pid;
+    act.resource = s.resource_tid;
+    act.id = static_cast<int32_t>(s.corr_id);
+
+    std::string joined;
+    for (uint32_t c = 0; c < s.categories_count; ++c) {
+      if (!s.categories[c])
+        continue;
+      if (!joined.empty())
+        joined += ", ";
+      joined += s.categories[c];
+    }
+    if (!joined.empty())
+      act.addMetadataQuoted("categories", joined);
+    for (uint32_t a = 0; a < s.annotations_count; ++a) {
+      const RblnKinetoAnnotation& ann = s.annotations[a];
+      const std::string ann_name = ann.name ? ann.name : "";
+      const std::string ann_val = ann.value ? ann.value : "";
+      if (ann.value_is_quoted) {
+        act.addMetadataQuoted(ann_name, ann_val);
+      } else {
+        act.addMetadata(ann_name, ann_val);
+      }
+    }
+    out->activities.push_back(std::move(act));
+  }
+}
+
+} // namespace kineto
+} // namespace profiler
+} // namespace rbln

--- a/torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_emitter.cc
+++ b/torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_emitter.cc
@@ -1,13 +1,11 @@
 // C-ABI -> libkineto assembly
 
-#include "torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_emitter.h"
+#include <torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_emitter.h>
 
 #include <cstdint>
 #include <string>
 
-namespace rbln {
-namespace profiler {
-namespace kineto {
+namespace rbln::profiler::kineto {
 
 namespace {
 
@@ -45,19 +43,21 @@ void convert_export_to_kineto(
   out->device_infos.reserve(exp->devices_count);
   for (uint32_t i = 0; i < exp->devices_count; ++i) {
     const RblnKinetoDevice& dev = exp->devices[i];
-    out->device_infos.emplace_back(/*id=*/dev.pid,
-                                   /*sortIndex=*/kRblnDeviceSortIndex + dev.pid,
-                                   /*name=*/std::string(dev.name ? dev.name : ""),
-                                   /*label=*/std::string());
+    out->device_infos.emplace_back(
+        /*id=*/dev.pid,
+        /*sortIndex=*/kRblnDeviceSortIndex + dev.pid,
+        /*name=*/std::string(dev.name ? dev.name : ""),
+        /*label=*/std::string());
   }
 
   out->resource_infos.reserve(exp->lanes_count);
   for (uint32_t i = 0; i < exp->lanes_count; ++i) {
     const RblnKinetoLane& lane = exp->lanes[i];
-    out->resource_infos.emplace_back(/*deviceId=*/lane.device_pid,
-                                     /*id=*/lane.resource_tid,
-                                     /*sortIndex=*/lane.resource_tid,
-                                     /*name=*/std::string(lane.name ? lane.name : ""));
+    out->resource_infos.emplace_back(
+        /*deviceId=*/lane.device_pid,
+        /*id=*/lane.resource_tid,
+        /*sortIndex=*/lane.resource_tid,
+        /*name=*/std::string(lane.name ? lane.name : ""));
   }
 
   out->activities.reserve(exp->slices_count);
@@ -95,6 +95,4 @@ void convert_export_to_kineto(
   }
 }
 
-} // namespace kineto
-} // namespace profiler
-} // namespace rbln
+} // namespace rbln::profiler::kineto

--- a/torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_emitter.cc
+++ b/torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_emitter.cc
@@ -69,7 +69,6 @@ void convert_export_to_kineto(
     act.endTime = s.end_steady_ns + clock_offset_ns;
     act.device = s.device_pid;
     act.resource = s.resource_tid;
-    act.id = static_cast<int32_t>(s.corr_id);
 
     std::string joined;
     for (uint32_t c = 0; c < s.categories_count; ++c) {

--- a/torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_emitter.h
+++ b/torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_emitter.h
@@ -1,0 +1,44 @@
+#ifndef TORCH_RBLN_PROFILER_KINETO_RBLN_KINETO_EMITTER_H
+#define TORCH_RBLN_PROFILER_KINETO_RBLN_KINETO_EMITTER_H
+
+// C-ABI -> libkineto assembly
+
+#include <kineto/ActivityType.h>
+#include <kineto/GenericTraceActivity.h>
+#include <kineto/IActivityProfiler.h>
+#include <kineto/TraceSpan.h>
+
+#include <cstdint>
+#include <vector>
+
+#include "rebel/runtime/api/rbln_kineto_api.h"
+
+namespace rbln {
+namespace profiler {
+namespace kineto {
+
+// Sort-priority base for rbln device rows: keeps them below host CPU rows in the
+// Perfetto UI; each sorts at base + pid so multi-node rows keep node order.
+constexpr int64_t kRblnDeviceSortIndex = 5000000;
+
+// One projection's output, emitted through the logger in processTrace.
+struct ProjectedKinetoTrace {
+  std::vector<::libkineto::DeviceInfo> device_infos;
+  std::vector<::libkineto::ResourceInfo> resource_infos;
+  std::vector<::libkineto::GenericTraceActivity> activities;
+};
+
+// Assembles 'out' (cleared first) from the C export, converting each slice's
+// steady_clock time to system time by adding clock_offset_ns. All strings are
+// copied, so 'exp' can be discarded once this returns.
+void convert_export_to_kineto(
+    const RblnKinetoExport* exp,
+    int64_t clock_offset_ns,
+    const ::libkineto::TraceSpan& span,
+    ProjectedKinetoTrace* out);
+
+} // namespace kineto
+} // namespace profiler
+} // namespace rbln
+
+#endif // TORCH_RBLN_PROFILER_KINETO_RBLN_KINETO_EMITTER_H

--- a/torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_emitter.h
+++ b/torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_emitter.h
@@ -11,11 +11,9 @@
 #include <cstdint>
 #include <vector>
 
-#include "rebel/runtime/api/rbln_kineto_api.h"
+#include <rebel/runtime/api/rbln_kineto_api.h>
 
-namespace rbln {
-namespace profiler {
-namespace kineto {
+namespace rbln::profiler::kineto {
 
 // Sort-priority base for rbln device rows: keeps them below host CPU rows in the
 // Perfetto UI; each sorts at base + pid so multi-node rows keep node order.
@@ -37,8 +35,6 @@ void convert_export_to_kineto(
     const ::libkineto::TraceSpan& span,
     ProjectedKinetoTrace* out);
 
-} // namespace kineto
-} // namespace profiler
-} // namespace rbln
+} // namespace rbln::profiler::kineto
 
 #endif // TORCH_RBLN_PROFILER_KINETO_RBLN_KINETO_EMITTER_H


### PR DESCRIPTION
## Summary of Changes

This PR adds **`torch.profiler` support for the RBLN NPU backend** by implementing the
consumer side of the rbln ↔ libkineto bridge.

**What this PR does.** It registers an RBLN `IActivityProfiler` with libkineto. When a
`torch.profiler` session runs, the plugin drives rebel_compiler's `rbln_kineto_*` C-ABI to
pull the materialized rbln trace and converts it into libkineto activities, so the RBLN
device/host timeline appears in the **same chrome trace** as the Python/CPU events.

**Added:**

- **libkineto plugin (adapter)** — `torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_adapter.{cc,h}`
  An `IActivityProfiler` / `IActivityProfilerSession` whose `start()`/`stop()` drive the C-ABI
  (`rbln_kineto_begin_session` / `rbln_kineto_end_session_and_export`), gated on
  `rbln_kineto_is_active()` so a session is created only when rbln profiling is actually on.
- **trace projection (emitter)** — `torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_emitter.{cc,h}`
  Converts the exported rbln POD (`RblnKinetoExport`: devices / lanes / slices) into libkineto
  `DeviceInfo` / `ResourceInfo` / `GenericTraceActivity`, applying the steady→system clock offset.
- **registration** — registers the profiler factory with libkineto at `_C` init.
- **vendored C-ABI headers** — `third_party/rebel_compiler/include/rebel/runtime/api/rbln_kineto_api.h`
  (+ `rbln_retcode.h`), the contract shared with rebel_compiler.

**Expected behavior**

| Setup | Result |
|---|---|
| `RBLN_PROFILER=1` **and** `torch.profiler` | Python profiling data within the scope **and** RBLN runtime profiling are merged into one chrome trace. The Query Profiler still writes its `.pb` for the events inside the scope. |
| `RBLN_PROFILER=1` only (or torch-rbln without this kineto plugin) | Unchanged — standalone `.pb` from the Query Profiler, independent of torch. |
| `torch.profiler` only (no `RBLN_PROFILER`) | Unchanged — default chrome trace, with no RBLN profiler data. |

---

---
## Related Issues / Tickets

<!--
All pull requests must have a corresponding issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
see: docs/CONTRIBUTING.md#pull-request-guidelines
-->

* https://github.com/rebellions-sw/rebel_compiler/pull/11658

---

## Type of Change

<!--
Select the type that best describes your PR. This should match the issue label.
see: docs/CONTRIBUTING.md#development-related-issue
-->

- [x] `feature` — New capability or functionality
- [ ] `core` — Changes to RBLN backend, device layer, C++ extension, op registration, or `torch.compile` integration
- [ ] `fix` — Bug fix
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code improvement without behavior change
- [ ] `docs` — Documentation only
- [ ] `other` — Other (describe below)

---

## Affected Modules

<!--
Check all modules affected by this change.
-->

- [ ] Backend
- [ ] Device
- [ ] Ops/Kernels
- [ ] `torch.compile`
- [x] C++ extension (`torch_rbln/csrc`)
- [ ] Memory
- [x] Build/Tools
- [ ] Docs

---

## How to Test

> Requires torch-rbln built against a rebel_compiler that exports the `rbln_kineto_*`
> (session) C-ABI — see Notes.

1. Profile an RBLN model under both flags:

   ```python
   import torch   # registers the libkineto profiler
   from torch.profiler import profile
   # ... load / compile a model on the RBLN backend ...
   with profile(with_stack=True) as prof:
       model(inputs)            # runs on the RBLN NPU
   prof.export_chrome_trace("trace.json")
   ```

   ```bash
   RBLN_PROFILER=1 RBLN_PROFILER_DIR=./rbln_prof python run_profile.py
   ```

2. Open `trace.json` (chrome://tracing or ui.perfetto.dev) and verify RBLN device rows
   (compute / DMA / sync slices) appear **alongside** the Python/CPU events.
3. Verify `./rbln_prof/session_<N>/rbln_*.pb` is still produced (Query Profiler intact).
4. Negative checks:
   - `RBLN_PROFILER=1` alone (no `torch.profiler`) → only the `.pb`; no behavior change.
   - `torch.profiler` alone (no `RBLN_PROFILER`) → default chrome trace; no RBLN rows.

Expected result: device/compute/DMA slices from the rbln trace render under their own rows
in the merged chrome trace, with timestamps aligned to the Python timeline.

---

## Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

## Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
* [ ] This PR is linked to a corresponding issue — see [Contributing to torch-rbln](docs/CONTRIBUTING.md)
* [x] Linting passes — see [Linting](docs/LINTING.md)
* [x] All CI tests pass — see [CI/CD Workflows](docs/WORKFLOWS.md)
* [ ] The test method is described, and the expected result is clearly stated (if applicable)
* [ ] Relevant documentation has been updated (if applicable)

---

## Notes

<!-- Anything reviewers should pay extra attention to? -->

---
