### PR TITLE
refactor(rbln): use num_devices compile option in place of tensor_parallel_size

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -176,7 +176,7 @@ The following environment variables control tensor parallel behavior for `torch.
 
 ### TORCH_RBLN_USE_TP_FAILOVER
 
-Enables automatic tensor parallel failover. When a RuntimeError occurs during execution with `tensor_parallel_size > 1`, the system automatically retries with `tp_size=1` on the root NPU of the device group.
+Enables automatic tensor parallel failover. When a RuntimeError occurs during execution with `num_devices > 1`, the system automatically retries with `num_devices=1` on the root NPU of the device group.
 
 This is useful for models that don't support tensor parallelism, allowing them to run on a single NPU within an aggregated device group without manual intervention.
 
@@ -186,32 +186,32 @@ export TORCH_RBLN_USE_TP_FAILOVER=OFF  # disable (default: OFF)
 ```
 
 **Behavior:**
-- When set to ON and a RuntimeError occurs with `tp > 1`:
+- When set to ON and a RuntimeError occurs with `num_devices > 1`:
   1. The system logs a warning message indicating the failover attempt
-  2. The model is recompiled with `tensor_parallel_size=1`
+  2. The model is recompiled with `num_devices=1`
   3. Execution continues on the root NPU of the device group
 - When set to OFF or unset (default), RuntimeErrors are propagated as-is
 
 **Example scenario:**
 With `RBLN_NPUS_PER_DEVICE=4` (4 NPUs per logical device):
-- Initial compilation attempts `tp=4`
+- Initial compilation attempts `num_devices=4`
 - If the model doesn't support TP, a RuntimeError occurs
-- With failover enabled, the system retries with `tp=1` on NPU 0
+- With failover enabled, the system retries with `num_devices=1` on NPU 0
 
 ### TORCH_RBLN_USE_DEVICE_TP
 
-Controls whether eager mode operations use the device group's tensor parallel size instead of `tp_size=1`.
+Controls whether eager mode operations use the device group's `num_devices` instead of `num_devices=1`.
 
-By default, eager mode ops (operations outside of `torch.compile`) use `tp_size=1`. When this environment variable is set to ON, eager mode ops will follow the logical device size defined by `RBLN_NPUS_PER_DEVICE` or `RBLN_DEVICE_MAP`, matching the behavior of `torch.compile` operations.
+By default, eager mode ops (operations outside of `torch.compile`) use `num_devices=1`. When this environment variable is set to ON, eager mode ops will follow the logical device size defined by `RBLN_NPUS_PER_DEVICE` or `RBLN_DEVICE_MAP`, matching the behavior of `torch.compile` operations.
 
 ```bash
-export TORCH_RBLN_USE_DEVICE_TP=ON   # use device group tp size
-export TORCH_RBLN_USE_DEVICE_TP=OFF  # use tp_size=1 for eager ops (default: OFF)
+export TORCH_RBLN_USE_DEVICE_TP=ON   # use device group num_devices
+export TORCH_RBLN_USE_DEVICE_TP=OFF  # use num_devices=1 for eager ops (default: OFF)
 ```
 
 **Behavior:**
-- When set to ON: Eager mode ops use the device group's tensor parallel size (e.g., `tp=4` with `RBLN_NPUS_PER_DEVICE=4`)
-- When set to OFF or unset (default): Eager mode ops use `tp_size=1`
+- When set to ON: Eager mode ops use the device group's `num_devices` (e.g., `num_devices=4` with `RBLN_NPUS_PER_DEVICE=4`)
+- When set to OFF or unset (default): Eager mode ops use `num_devices=1`
 
 **Use case:**
 This is useful when you want consistent tensor parallel behavior across both eager and compiled operations, particularly in mixed execution scenarios.

--- a/test/rbln/test_torch_compile_patch.py
+++ b/test/rbln/test_torch_compile_patch.py
@@ -20,13 +20,13 @@ from torch_rbln._internal.ops_utils import extract_device_id_from_inputs
 from torch_rbln._internal.torch_compile_patch_helpers import (
     _convert_result_to_device,
     attempt_cpu_fallback,
-    auto_determine_tp_if_needed,
+    auto_determine_num_devices_if_needed,
     CompiledFunctionWrapper,
     extract_device_from_inputs,
-    get_tensor_parallel_size_from_options,
+    get_num_devices_from_options,
     handle_tp_failover,
     is_rbln_backend,
-    recompile_with_tp_size,
+    recompile_with_num_devices,
     should_attempt_failover,
 )
 
@@ -103,29 +103,41 @@ class TestTorchCompilePatchHelpers(TestCase):
         device_id = extract_device_id_from_inputs(t, 42, "hello")
         self.assertIsNone(device_id)
 
-    def test_get_tensor_parallel_size_from_options_with_tp_size(self):
-        """Test extracting tensor_parallel_size from compile_kwargs."""
+    def test_get_num_devices_from_options_with_num_devices(self):
+        """Test extracting num_devices from compile_kwargs."""
+        compile_kwargs = {"options": {"num_devices": 4}}
+        num_devices = get_num_devices_from_options(compile_kwargs)
+        self.assertEqual(num_devices, 4)
+
+    def test_get_num_devices_from_options_legacy_alias(self):
+        """The deprecated `tensor_parallel_size` alias is still accepted as a fallback."""
         compile_kwargs = {"options": {"tensor_parallel_size": 4}}
-        tp_size = get_tensor_parallel_size_from_options(compile_kwargs)
-        self.assertEqual(tp_size, 4)
+        num_devices = get_num_devices_from_options(compile_kwargs)
+        self.assertEqual(num_devices, 4)
 
-    def test_get_tensor_parallel_size_from_options_without_tp_size(self):
-        """Test that None is returned when tp_size is not set."""
+    def test_get_num_devices_from_options_num_devices_wins_over_alias(self):
+        """`num_devices` takes precedence when both keys are present."""
+        compile_kwargs = {"options": {"num_devices": 4, "tensor_parallel_size": 8}}
+        num_devices = get_num_devices_from_options(compile_kwargs)
+        self.assertEqual(num_devices, 4)
+
+    def test_get_num_devices_from_options_without_num_devices(self):
+        """Test that None is returned when num_devices is not set."""
         compile_kwargs = {"options": {}}
-        tp_size = get_tensor_parallel_size_from_options(compile_kwargs)
-        self.assertIsNone(tp_size)
+        num_devices = get_num_devices_from_options(compile_kwargs)
+        self.assertIsNone(num_devices)
 
-    def test_get_tensor_parallel_size_from_options_no_options(self):
+    def test_get_num_devices_from_options_no_options(self):
         """Test that None is returned when options key is missing."""
         compile_kwargs = {}
-        tp_size = get_tensor_parallel_size_from_options(compile_kwargs)
-        self.assertIsNone(tp_size)
+        num_devices = get_num_devices_from_options(compile_kwargs)
+        self.assertIsNone(num_devices)
 
-    def test_get_tensor_parallel_size_from_options_non_dict_options(self):
+    def test_get_num_devices_from_options_non_dict_options(self):
         """Test that None is returned when options is not a dict."""
         compile_kwargs = {"options": "not_a_dict"}
-        tp_size = get_tensor_parallel_size_from_options(compile_kwargs)
-        self.assertIsNone(tp_size)
+        num_devices = get_num_devices_from_options(compile_kwargs)
+        self.assertIsNone(num_devices)
 
     def test_convert_result_to_device_single_tensor(self):
         """Test converting single tensor result to target device."""
@@ -255,56 +267,58 @@ class TestTorchCompilePatchHelpers(TestCase):
 class TestTensorParallelFunctions(TestCase):
     """Tests for tensor parallel related functions."""
 
-    def test_recompile_with_tp_size(self):
-        """Test recompile_with_tp_size updates compile_kwargs correctly."""
+    def test_recompile_with_num_devices(self):
+        """Test recompile_with_num_devices updates compile_kwargs correctly."""
         mock_compile_fn = Mock(return_value="recompiled_fn")
         mock_model = Mock()
         compile_kwargs = {"backend": "rbln", "options": {"some_option": "value"}}
 
-        result = recompile_with_tp_size(mock_model, compile_kwargs, tp_size=4, original_compile_fn=mock_compile_fn)
+        result = recompile_with_num_devices(
+            mock_model, compile_kwargs, num_devices=4, original_compile_fn=mock_compile_fn
+        )
 
         # Verify compile function was called with updated options
         mock_compile_fn.assert_called_once()
         call_args = mock_compile_fn.call_args
         self.assertEqual(call_args[0][0], mock_model)
         self.assertEqual(call_args[1]["backend"], "rbln")
-        self.assertEqual(call_args[1]["options"]["tensor_parallel_size"], 4)
+        self.assertEqual(call_args[1]["options"]["num_devices"], 4)
         self.assertEqual(call_args[1]["options"]["some_option"], "value")
         self.assertEqual(result, "recompiled_fn")
 
-    def test_recompile_with_tp_size_no_existing_options(self):
-        """Test recompile_with_tp_size with no existing options."""
+    def test_recompile_with_num_devices_no_existing_options(self):
+        """Test recompile_with_num_devices with no existing options."""
         mock_compile_fn = Mock(return_value="recompiled_fn")
         mock_model = Mock()
         compile_kwargs = {"backend": "rbln"}
 
-        recompile_with_tp_size(mock_model, compile_kwargs, tp_size=2, original_compile_fn=mock_compile_fn)
+        recompile_with_num_devices(mock_model, compile_kwargs, num_devices=2, original_compile_fn=mock_compile_fn)
 
         call_args = mock_compile_fn.call_args
-        self.assertEqual(call_args[1]["options"]["tensor_parallel_size"], 2)
+        self.assertEqual(call_args[1]["options"]["num_devices"], 2)
 
-    @patch("torch_rbln._internal.torch_compile_patch_helpers.auto_determine_tensor_parallel_size")
-    def test_auto_determine_tp_if_needed_when_not_set(self, mock_auto_tp):
-        """Test auto_determine_tp_if_needed when tp_size is not set."""
+    @patch("torch_rbln._internal.torch_compile_patch_helpers.auto_determine_num_devices")
+    def test_auto_determine_num_devices_if_needed_when_not_set(self, mock_auto_tp):
+        """Test auto_determine_num_devices_if_needed when num_devices is not set."""
         mock_auto_tp.return_value = 4
         mock_compile_fn = Mock(return_value="recompiled_fn")
         mock_model = Mock()
         compile_kwargs = {"backend": "rbln"}
 
-        result = auto_determine_tp_if_needed(
+        result = auto_determine_num_devices_if_needed(
             mock_model, compile_kwargs, device_id=0, original_compile_fn=mock_compile_fn
         )
 
         mock_auto_tp.assert_called_once_with(0)
         self.assertEqual(result, "recompiled_fn")
 
-    def test_auto_determine_tp_if_needed_when_already_set(self):
-        """Test auto_determine_tp_if_needed when tp_size is already set."""
+    def test_auto_determine_num_devices_if_needed_when_already_set(self):
+        """Test auto_determine_num_devices_if_needed when num_devices is already set."""
         mock_compile_fn = Mock()
         mock_model = Mock()
-        compile_kwargs = {"options": {"tensor_parallel_size": 2}}
+        compile_kwargs = {"options": {"num_devices": 2}}
 
-        result = auto_determine_tp_if_needed(
+        result = auto_determine_num_devices_if_needed(
             mock_model, compile_kwargs, device_id=0, original_compile_fn=mock_compile_fn
         )
 
@@ -312,15 +326,15 @@ class TestTensorParallelFunctions(TestCase):
         mock_compile_fn.assert_not_called()
         self.assertIsNone(result)
 
-    @patch("torch_rbln._internal.torch_compile_patch_helpers.auto_determine_tensor_parallel_size")
-    def test_auto_determine_tp_if_needed_when_auto_tp_fails(self, mock_auto_tp):
-        """Test auto_determine_tp_if_needed when auto-determination fails."""
+    @patch("torch_rbln._internal.torch_compile_patch_helpers.auto_determine_num_devices")
+    def test_auto_determine_num_devices_if_needed_when_auto_tp_fails(self, mock_auto_tp):
+        """Test auto_determine_num_devices_if_needed when auto-determination fails."""
         mock_auto_tp.return_value = None
         mock_compile_fn = Mock()
         mock_model = Mock()
         compile_kwargs = {}
 
-        result = auto_determine_tp_if_needed(
+        result = auto_determine_num_devices_if_needed(
             mock_model, compile_kwargs, device_id=0, original_compile_fn=mock_compile_fn
         )
 
@@ -333,7 +347,7 @@ class TestTensorParallelFunctions(TestCase):
         mock_enable_failover.return_value = True
         compile_kwargs = {}
 
-        result = should_attempt_failover(device_id=0, compile_kwargs=compile_kwargs, current_tp=4)
+        result = should_attempt_failover(device_id=0, compile_kwargs=compile_kwargs, current_num_devices=4)
 
         self.assertTrue(result)
 
@@ -343,42 +357,42 @@ class TestTensorParallelFunctions(TestCase):
         mock_enable_failover.return_value = False
         compile_kwargs = {}
 
-        result = should_attempt_failover(device_id=0, compile_kwargs=compile_kwargs, current_tp=4)
+        result = should_attempt_failover(device_id=0, compile_kwargs=compile_kwargs, current_num_devices=4)
 
         self.assertFalse(result)
 
     @patch("torch_rbln._internal.torch_compile_patch_helpers.use_tp_failover")
     def test_should_attempt_failover_tp_is_one(self, mock_enable_failover):
-        """Test should_attempt_failover when current_tp is 1."""
+        """Test should_attempt_failover when current_num_devices is 1."""
         mock_enable_failover.return_value = True
         compile_kwargs = {}
 
-        result = should_attempt_failover(device_id=0, compile_kwargs=compile_kwargs, current_tp=1)
+        result = should_attempt_failover(device_id=0, compile_kwargs=compile_kwargs, current_num_devices=1)
 
         self.assertFalse(result)
 
     @patch("torch_rbln._internal.torch_compile_patch_helpers.use_tp_failover")
     def test_should_attempt_failover_explicit_tp_one(self, mock_enable_failover):
-        """Test should_attempt_failover when tp_size=1 is explicitly set."""
+        """Test should_attempt_failover when num_devices=1 is explicitly set."""
         mock_enable_failover.return_value = True
-        compile_kwargs = {"options": {"tensor_parallel_size": 1}}
+        compile_kwargs = {"options": {"num_devices": 1}}
 
-        result = should_attempt_failover(device_id=0, compile_kwargs=compile_kwargs, current_tp=4)
+        result = should_attempt_failover(device_id=0, compile_kwargs=compile_kwargs, current_num_devices=4)
 
         self.assertFalse(result)
 
     @patch("torch_rbln._internal.torch_compile_patch_helpers.use_tp_failover")
     def test_should_attempt_failover_explicit_tp_gt_one(self, mock_enable_failover):
-        """Test should_attempt_failover when tp_size>1 is explicitly set."""
+        """Test should_attempt_failover when num_devices>1 is explicitly set."""
         mock_enable_failover.return_value = True
-        compile_kwargs = {"options": {"tensor_parallel_size": 2}}
+        compile_kwargs = {"options": {"num_devices": 2}}
 
-        result = should_attempt_failover(device_id=0, compile_kwargs=compile_kwargs, current_tp=2)
+        result = should_attempt_failover(device_id=0, compile_kwargs=compile_kwargs, current_num_devices=2)
 
         self.assertFalse(result)
 
     @patch("torch_rbln._internal.torch_compile_patch_helpers.get_physical_device_ids")
-    @patch("torch_rbln._internal.torch_compile_patch_helpers.auto_determine_tensor_parallel_size")
+    @patch("torch_rbln._internal.torch_compile_patch_helpers.auto_determine_num_devices")
     @patch("torch_rbln._internal.torch_compile_patch_helpers.use_tp_failover")
     def test_handle_tp_failover_success(self, mock_enable_failover, mock_auto_tp, mock_get_devices):
         """Test handle_tp_failover successfully recompiles with tp=1."""
@@ -409,12 +423,12 @@ class TestTensorParallelFunctions(TestCase):
         self.assertIsNone(result)
 
     @patch("torch_rbln._internal.torch_compile_patch_helpers.use_tp_failover")
-    def test_handle_tp_failover_respects_explicit_tp_size(self, mock_enable_failover):
+    def test_handle_tp_failover_respects_explicit_num_devices(self, mock_enable_failover):
         """Test handle_tp_failover does not override explicit caller TP settings."""
         mock_enable_failover.return_value = True
         mock_compile_fn = Mock()
         mock_model = Mock()
-        compile_kwargs = {"options": {"tensor_parallel_size": 4}}
+        compile_kwargs = {"options": {"num_devices": 4}}
 
         result = handle_tp_failover(mock_model, compile_kwargs, device_id=0, original_compile_fn=mock_compile_fn)
 
@@ -426,7 +440,7 @@ class TestTensorParallelFunctions(TestCase):
 class TestCompiledFunctionWrapper(TestCase):
     """Tests for CompiledFunctionWrapper class."""
 
-    @patch("torch_rbln._internal.torch_compile_patch_helpers.auto_determine_tp_if_needed")
+    @patch("torch_rbln._internal.torch_compile_patch_helpers.auto_determine_num_devices_if_needed")
     def test_wrapper_successful_execution(self, mock_auto_determine):
         """Test that wrapper correctly executes compiled function on success."""
         mock_auto_determine.return_value = None  # No recompilation needed
@@ -443,7 +457,7 @@ class TestCompiledFunctionWrapper(TestCase):
         result = wrapper(t)
         self.assertEqual(result.item(), 10)
 
-    @patch("torch_rbln._internal.torch_compile_patch_helpers.auto_determine_tp_if_needed")
+    @patch("torch_rbln._internal.torch_compile_patch_helpers.auto_determine_num_devices_if_needed")
     @patch("torch_rbln._internal.torch_compile_patch_helpers.use_tp_failover")
     def test_wrapper_cpu_fallback_on_error(self, mock_enable_failover, mock_auto_determine):
         """Test that wrapper falls back to CPU on error."""
@@ -466,7 +480,7 @@ class TestCompiledFunctionWrapper(TestCase):
             self.assertEqual(result.device.type, "rbln")
             self.assertEqual(result.tolist(), [2.0, 3.0])
 
-    @patch("torch_rbln._internal.torch_compile_patch_helpers.auto_determine_tp_if_needed")
+    @patch("torch_rbln._internal.torch_compile_patch_helpers.auto_determine_num_devices_if_needed")
     @patch("torch_rbln._internal.torch_compile_patch_helpers.use_tp_failover")
     def test_wrapper_cpu_fallback_handles_cpu_first_inputs_and_nested_outputs(
         self,
@@ -500,7 +514,7 @@ class TestCompiledFunctionWrapper(TestCase):
         self.assertEqual(result["result"][1][0].device.type, "rbln")
         self.assertEqual(result["result"][0].cpu().tolist(), [4.0, 6.0])
 
-    @patch("torch_rbln._internal.torch_compile_patch_helpers.auto_determine_tp_if_needed")
+    @patch("torch_rbln._internal.torch_compile_patch_helpers.auto_determine_num_devices_if_needed")
     @patch("torch_rbln._internal.torch_compile_patch_helpers.use_tp_failover")
     def test_wrapper_cpu_fallback_raises_without_rbln_inputs(
         self,
@@ -526,7 +540,7 @@ class TestCompiledFunctionWrapper(TestCase):
 
         self.assertIn("requires at least one RBLN tensor input", str(ctx.exception))
 
-    @patch("torch_rbln._internal.torch_compile_patch_helpers.auto_determine_tp_if_needed")
+    @patch("torch_rbln._internal.torch_compile_patch_helpers.auto_determine_num_devices_if_needed")
     @patch("torch_rbln._internal.torch_compile_patch_helpers.use_tp_failover")
     def test_wrapper_raises_when_compile_error_fallback_disabled(self, mock_enable_failover, mock_auto_determine):
         """Test that wrapper raises exception when 'compile_error' fallback is disabled."""
@@ -548,7 +562,7 @@ class TestCompiledFunctionWrapper(TestCase):
                 wrapper(t)
             self.assertIn("Compilation error", str(ctx.exception))
 
-    @patch("torch_rbln._internal.torch_compile_patch_helpers.auto_determine_tp_if_needed")
+    @patch("torch_rbln._internal.torch_compile_patch_helpers.auto_determine_num_devices_if_needed")
     def test_wrapper_recompile_retry_success(self, mock_auto_determine):
         """Test that wrapper retries on recompile limit and succeeds."""
         try:
@@ -578,7 +592,7 @@ class TestCompiledFunctionWrapper(TestCase):
             mock_reset.assert_called_once()
             self.assertEqual(call_count[0], 2)
 
-    @patch("torch_rbln._internal.torch_compile_patch_helpers.auto_determine_tp_if_needed")
+    @patch("torch_rbln._internal.torch_compile_patch_helpers.auto_determine_num_devices_if_needed")
     def test_wrapper_recompile_retry_then_fallback(self, mock_auto_determine):
         """Test that wrapper falls back to CPU after max retries."""
         try:
@@ -606,7 +620,7 @@ class TestCompiledFunctionWrapper(TestCase):
                 # Should fall back to CPU
                 self.assertEqual(result.item(), 15.0)
 
-    @patch("torch_rbln._internal.torch_compile_patch_helpers.auto_determine_tp_if_needed")
+    @patch("torch_rbln._internal.torch_compile_patch_helpers.auto_determine_num_devices_if_needed")
     def test_wrapper_auto_determine_tp_on_first_call(self, mock_auto_determine):
         """Test that TP auto-determination happens only once on first call."""
 
@@ -633,7 +647,7 @@ class TestCompiledFunctionWrapper(TestCase):
         wrapper(t)
         mock_auto_determine.assert_called_once()  # Still only once
 
-    @patch("torch_rbln._internal.torch_compile_patch_helpers.auto_determine_tp_if_needed")
+    @patch("torch_rbln._internal.torch_compile_patch_helpers.auto_determine_num_devices_if_needed")
     def test_wrapper_tp_failover_on_runtime_error(self, mock_auto_determine):
         """Test that TP failover is triggered on RuntimeError."""
         mock_auto_determine.return_value = None
@@ -891,13 +905,13 @@ class TestTorchCompileMonkeyPatch(TestCase):
             first = compile_rbln_cached(
                 model,
                 dynamic=False,
-                options={"disable_logger": True, "tensor_parallel_size": 1},
+                options={"disable_logger": True, "num_devices": 1},
                 device_cache_key=0,
             )
             second = compile_rbln_cached(
                 model,
                 dynamic=False,
-                options={"disable_logger": True, "tensor_parallel_size": 1},
+                options={"disable_logger": True, "num_devices": 1},
                 device_cache_key=0,
             )
 
@@ -1003,7 +1017,7 @@ class TestTorchCompileMonkeyPatch(TestCase):
 
         self.assertEqual(mock_compile.call_count, 2)
 
-    @patch("torch_rbln._internal.torch_compile_patch_helpers.auto_determine_tp_if_needed")
+    @patch("torch_rbln._internal.torch_compile_patch_helpers.auto_determine_num_devices_if_needed")
     def test_patch_torch_compile_wrapper_integration(self, mock_auto_determine):
         """Test CompiledFunctionWrapper integration with torch.compile."""
         mock_auto_determine.return_value = None

--- a/torch_rbln/_internal/env_utils.py
+++ b/torch_rbln/_internal/env_utils.py
@@ -54,15 +54,15 @@ def is_rbln_deploy() -> bool:
     return os.getenv("TORCH_RBLN_DEPLOY") == "ON"
 
 
-def use_device_group_tensor_parallel_size() -> bool:
+def use_device_group_num_devices() -> bool:
     """
-    Check if eager mode ops should use device group tensor parallel size instead of tp_size=1.
+    Check if eager mode ops should use the device group's num_devices instead of num_devices=1.
 
-    By default, eager mode ops use tp_size=1. When this returns True, eager mode ops will
+    By default, eager mode ops use num_devices=1. When this returns True, eager mode ops will
     follow the logical device size (RBLN_NPUS_PER_DEVICE) like torch.compile operations do.
 
     Returns:
-        bool: True if eager mode ops should use logical device tensor parallel size
+        bool: True if eager mode ops should use the logical device's num_devices
               (environment variable TORCH_RBLN_USE_DEVICE_TP is "ON"), False otherwise.
     """
     return os.getenv("TORCH_RBLN_USE_DEVICE_TP") == "ON"
@@ -72,8 +72,8 @@ def use_tp_failover() -> bool:
     """
     Check if tensor parallel failover is enabled.
 
-    When enabled, if a RuntimeError occurs during execution with tensor parallel size > 1,
-    the system will automatically retry with tp_size=1.
+    When enabled, if a RuntimeError occurs during execution with num_devices > 1,
+    the system will automatically retry with num_devices=1.
 
     Returns:
         bool: True if failover is enabled (environment variable TORCH_RBLN_USE_TP_FAILOVER is "ON"),

--- a/torch_rbln/_internal/kernels/custom_transpose.py
+++ b/torch_rbln/_internal/kernels/custom_transpose.py
@@ -23,7 +23,7 @@ def custom_transpose_rbln(self, dim0: int, dim1: int, out=None):
         compiled = compile_rbln_cached(
             _transpose_op_module,
             dynamic=False,
-            options={"disable_logger": True, "tensor_parallel_size": 1},
+            options={"disable_logger": True, "num_devices": 1},
             device_cache_key=self.device.index,
         )
         external_result = compiled(self, dim0=dim0, dim1=dim1)

--- a/torch_rbln/_internal/monkey_patches.py
+++ b/torch_rbln/_internal/monkey_patches.py
@@ -91,7 +91,7 @@ def _register_rbln_backend() -> bool:
 def patch_torch_compile() -> None:
     """
     Monkey patch torch.compile() to automatically register the RBLN backend on first use
-    and add automatic tensor parallel size determination and failover support.
+    and add automatic num_devices determination and tensor-parallel failover support.
 
     This patch wraps torch.compile() to ensure the RBLN backend is registered before
     the first compilation. The registration is lazy (happens on first call) to avoid

--- a/torch_rbln/_internal/ops_utils.py
+++ b/torch_rbln/_internal/ops_utils.py
@@ -1689,7 +1689,7 @@ def compile_and_run_view_aware(op_callable, op_name, args, kwargs_filtered, out_
     (``ops_utils`` is imported broadly).
     """
     from torch_rbln._internal.compile_cache import compile_rbln_cached
-    from torch_rbln._internal.env_utils import use_device_group_tensor_parallel_size
+    from torch_rbln._internal.env_utils import use_device_group_num_devices
     from torch_rbln._internal.warm_cache import (
         consume_force_recompile as _consume_warm_cache_force_recompile,
         install_pending as _install_warm_cache_pending,
@@ -1756,8 +1756,8 @@ def compile_and_run_view_aware(op_callable, op_name, args, kwargs_filtered, out_
     has_views = any(r is not None for r in view_recipes)
 
     compile_options = {"disable_logger": True}
-    if not use_device_group_tensor_parallel_size():
-        compile_options["tensor_parallel_size"] = 1
+    if not use_device_group_num_devices():
+        compile_options["num_devices"] = 1
     _runtime_holder = []
     compile_options["_runtime_holder"] = _runtime_holder
 

--- a/torch_rbln/_internal/register_custom_ops.py
+++ b/torch_rbln/_internal/register_custom_ops.py
@@ -133,7 +133,7 @@ def paged_attn_prefill_rbln(*args, **kwargs):
         compiled = compile_rbln_cached(
             op_module,
             dynamic=False,
-            options={"disable_logger": True, "tensor_parallel_size": 1},
+            options={"disable_logger": True, "num_devices": 1},
             device_cache_key=(extract_device_id_from_inputs(*view_args, **view_kwargs), view_recipes),
         )
         external_result = compiled(*view_args, **view_kwargs)
@@ -189,7 +189,7 @@ def paged_attn_decode_rbln(*args, **kwargs):
         compiled = compile_rbln_cached(
             op_module,
             dynamic=False,
-            options={"disable_logger": True, "tensor_parallel_size": 1},
+            options={"disable_logger": True, "num_devices": 1},
             device_cache_key=(extract_device_id_from_inputs(*view_args, **view_kwargs), view_recipes),
         )
         external_result = compiled(*view_args, **view_kwargs)
@@ -259,7 +259,7 @@ def paged_causal_attn_prefill_rbln(*args, **kwargs):
         compiled = compile_rbln_cached(
             op_module,
             dynamic=False,
-            options={"disable_logger": True, "tensor_parallel_size": 1},
+            options={"disable_logger": True, "num_devices": 1},
             device_cache_key=(extract_device_id_from_inputs(*view_args, **view_kwargs), view_recipes),
         )
         external_result = compiled(*view_args, **view_kwargs)
@@ -322,7 +322,7 @@ def paged_causal_attn_decode_rbln(*args, **kwargs):
         compiled = compile_rbln_cached(
             op_module,
             dynamic=False,
-            options={"disable_logger": True, "tensor_parallel_size": 1},
+            options={"disable_logger": True, "num_devices": 1},
             device_cache_key=(extract_device_id_from_inputs(*view_args, **view_kwargs), view_recipes),
         )
         external_result = compiled(*view_args, **view_kwargs)
@@ -381,7 +381,7 @@ def flash_attention_naive_prefill_rbln(*args, **kwargs):
         op_module,
         backend="rbln",
         dynamic=False,
-        options={"disable_logger": True, "tensor_parallel_size": 1},
+        options={"disable_logger": True, "num_devices": 1},
     )
     external_result = compiled(*view_args, **view_kwargs)
     if result_tensor is None:
@@ -434,7 +434,7 @@ def flash_attention_naive_decode_rbln(*args, **kwargs):
         op_module,
         backend="rbln",
         dynamic=False,
-        options={"disable_logger": True, "tensor_parallel_size": 1},
+        options={"disable_logger": True, "num_devices": 1},
     )
     external_result = compiled(*view_args, **view_kwargs)
     if result_tensor is None:

--- a/torch_rbln/_internal/rsd_utils.py
+++ b/torch_rbln/_internal/rsd_utils.py
@@ -42,9 +42,9 @@ def get_physical_device_ids(device_id: int) -> Optional[list[int]]:
     return entry.physical_device_ids
 
 
-def auto_determine_tensor_parallel_size(device_id: Optional[int]) -> Optional[int]:
+def auto_determine_num_devices(device_id: Optional[int]) -> Optional[int]:
     """
-    Automatically determine tensor_parallel_size based on RSD environment variables.
+    Automatically determine num_devices based on RSD environment variables.
 
     This function reads RBLN_NPUS_PER_DEVICE or RBLN_DEVICE_MAP environment variables
     to determine the number of physical NPUs mapped to the given logical device.
@@ -65,7 +65,7 @@ def auto_determine_tensor_parallel_size(device_id: Optional[int]) -> Optional[in
 
     Note:
         This function is used by torch.compile backend to automatically set
-        tensor_parallel_size when not explicitly provided.
+        num_devices when not explicitly provided.
     """
     # Use device_id=0 as default if not provided
     target_device_id = device_id if device_id is not None else 0

--- a/torch_rbln/_internal/torch_compile_patch_helpers.py
+++ b/torch_rbln/_internal/torch_compile_patch_helpers.py
@@ -1,8 +1,8 @@
 """
 Helper functions and classes for torch.compile patching.
 
-This module contains utilities for wrapping compiled functions with tensor parallel
-auto-determination, failover support, and CPU fallback functionality.
+This module contains utilities for wrapping compiled functions with num_devices
+auto-determination, tensor-parallel failover support, and CPU fallback functionality.
 """
 
 import threading
@@ -18,7 +18,7 @@ except Exception:  # pragma: no cover - torch internals may move
 from torch_rbln._internal.env_utils import is_fallback_disabled, use_tp_failover
 from torch_rbln._internal.log_utils import rbln_log_error, rbln_log_warn
 from torch_rbln._internal.ops_utils import extract_device_id_from_inputs, to_cpu
-from torch_rbln._internal.rsd_utils import auto_determine_tensor_parallel_size, get_physical_device_ids
+from torch_rbln._internal.rsd_utils import auto_determine_num_devices, get_physical_device_ids
 
 
 # Thread-local reentrancy guard: when we're already inside an RBLN op that uses torch.compile,
@@ -131,45 +131,53 @@ def attempt_cpu_fallback(original_fn, args, kwargs, original_device):
     return result
 
 
-def recompile_with_tp_size(model, compile_kwargs, tp_size, original_compile_fn):
-    """Recompile model with specified tensor_parallel_size."""
+def recompile_with_num_devices(model, compile_kwargs, num_devices, original_compile_fn):
+    """Recompile model with the specified ``num_devices``."""
     recompile_kwargs = compile_kwargs.copy()
     recompile_options = recompile_kwargs.get("options", {})
     if isinstance(recompile_options, dict):
         recompile_options = recompile_options.copy()
     else:
         recompile_options = {}
-    recompile_options["tensor_parallel_size"] = tp_size
+    recompile_options["num_devices"] = num_devices
     recompile_kwargs["options"] = recompile_options
     return original_compile_fn(model, **recompile_kwargs)
 
 
-def get_tensor_parallel_size_from_options(compile_kwargs):
-    """Extract tensor_parallel_size from compile options."""
+def get_num_devices_from_options(compile_kwargs):
+    """Extract ``num_devices`` from compile options.
+
+    ``num_devices`` takes precedence; ``tensor_parallel_size`` is accepted as a
+    deprecated alias.
+    """
     compile_options = compile_kwargs.get("options", {})
     if not isinstance(compile_options, dict):
         return None
-    return compile_options.get("tensor_parallel_size")
+    num_devices = compile_options.get("num_devices")
+    if num_devices is None:
+        num_devices = compile_options.get("tensor_parallel_size")
+    return num_devices
 
 
-def _resolve_current_tensor_parallel_size(device_id, compile_kwargs):
-    """Resolve the TP size currently in use for this compiled function.
+def _resolve_current_num_devices(device_id, compile_kwargs):
+    """Resolve the ``num_devices`` currently in use for this compiled function.
 
-    An explicit ``options.tensor_parallel_size`` always wins. Otherwise we fall
-    back to the topology-derived auto-determined TP size.
+    An explicit ``options.num_devices`` (or the legacy ``tensor_parallel_size``)
+    always wins. Otherwise we fall back to the topology-derived auto-determined
+    device count.
     """
-    explicit_tp_size = get_tensor_parallel_size_from_options(compile_kwargs)
-    if explicit_tp_size is not None:
-        return explicit_tp_size
-    return auto_determine_tensor_parallel_size(device_id)
+    explicit_num_devices = get_num_devices_from_options(compile_kwargs)
+    if explicit_num_devices is not None:
+        return explicit_num_devices
+    return auto_determine_num_devices(device_id)
 
 
-def auto_determine_tp_if_needed(model, compile_kwargs, device_id, original_compile_fn):
-    """Auto-determine tensor_parallel_size if it's None in compile_kwargs.
+def auto_determine_num_devices_if_needed(model, compile_kwargs, device_id, original_compile_fn):
+    """Auto-determine ``num_devices`` if it's None in compile_kwargs.
 
-    This function checks if tensor_parallel_size is explicitly set in compile_kwargs.
-    If not, it automatically determines the TP size based on the RSD device topology
-    (RBLN_NPUS_PER_DEVICE or RBLN_DEVICE_MAP environment variables).
+    This function checks if ``num_devices`` is explicitly set in compile_kwargs.
+    If not, it automatically determines the device count based on the RSD device
+    topology (RBLN_NPUS_PER_DEVICE or RBLN_DEVICE_MAP environment variables).
 
     Args:
         model: The model to compile.
@@ -178,37 +186,37 @@ def auto_determine_tp_if_needed(model, compile_kwargs, device_id, original_compi
         original_compile_fn: The original torch.compile function.
 
     Returns:
-        Compiled function with auto-determined TP size, or None if:
-        - TP size is already explicitly set
+        Compiled function with auto-determined ``num_devices``, or None if:
+        - ``num_devices`` is already explicitly set
         - Auto-determination fails
     """
-    tp_size = get_tensor_parallel_size_from_options(compile_kwargs)
-    if tp_size is not None:
+    num_devices = get_num_devices_from_options(compile_kwargs)
+    if num_devices is not None:
         return None  # Already set, no need to auto-determine
 
-    auto_tp = auto_determine_tensor_parallel_size(device_id)
-    if auto_tp is None:
+    auto_num_devices = auto_determine_num_devices(device_id)
+    if auto_num_devices is None:
         return None  # Cannot determine
 
     try:
-        return recompile_with_tp_size(model, compile_kwargs, auto_tp, original_compile_fn)
+        return recompile_with_num_devices(model, compile_kwargs, auto_num_devices, original_compile_fn)
     except Exception:
         # If recompilation fails, return None to use original compiled_fn
         return None
 
 
-def should_attempt_failover(device_id, compile_kwargs, current_tp):
+def should_attempt_failover(device_id, compile_kwargs, current_num_devices):
     """Check if failover should be attempted.
 
     Failover is attempted when:
     - TORCH_RBLN_USE_TP_FAILOVER=ON
-    - tensor_parallel_size was not explicitly set by the caller
-    - current_tp > 1
+    - ``num_devices`` was not explicitly set by the caller
+    - current_num_devices > 1
 
     Args:
         device_id: The RBLN logical device ID.
         compile_kwargs: Keyword arguments passed to torch.compile.
-        current_tp: Current tensor parallel size.
+        current_num_devices: Current number of devices the model is distributed across.
 
     Returns:
         True if failover should be attempted, False otherwise.
@@ -216,22 +224,22 @@ def should_attempt_failover(device_id, compile_kwargs, current_tp):
     if not use_tp_failover():
         return False
 
-    # Respect an explicitly requested TP size. Silent failover is only allowed
-    # for topology-driven auto TP, not for caller-selected configurations.
-    if get_tensor_parallel_size_from_options(compile_kwargs) is not None:
+    # Respect an explicitly requested num_devices. Silent failover is only allowed
+    # for topology-driven auto device counts, not for caller-selected configurations.
+    if get_num_devices_from_options(compile_kwargs) is not None:
         return False
 
-    if current_tp is None or current_tp <= 1:
+    if current_num_devices is None or current_num_devices <= 1:
         return False  # No need to failover
 
     return True
 
 
 def handle_tp_failover(model, compile_kwargs, device_id, original_compile_fn):
-    """Handle tensor parallel failover by retrying with tp=1.
+    """Handle tensor parallel failover by retrying with num_devices=1.
 
-    When a RuntimeError occurs during execution with tensor parallel size > 1,
-    this function attempts to recompile the model with tp_size=1 as a fallback.
+    When a RuntimeError occurs during execution with num_devices > 1,
+    this function attempts to recompile the model with num_devices=1 as a fallback.
 
     This is useful for models that don't support tensor parallelism, allowing
     them to run on a single NPU within the device group.
@@ -243,13 +251,13 @@ def handle_tp_failover(model, compile_kwargs, device_id, original_compile_fn):
         original_compile_fn: The original torch.compile function.
 
     Returns:
-        Compiled function with tp=1 (failover), or None if failover is not applicable
+        Compiled function with num_devices=1 (failover), or None if failover is not applicable
         or recompilation fails (caller will then try CPU fallback or re-raise).
     """
-    # Determine the TP size that the current compiled_fn is actually using.
-    current_tp = _resolve_current_tensor_parallel_size(device_id, compile_kwargs)
+    # Determine the num_devices that the current compiled_fn is actually using.
+    current_num_devices = _resolve_current_num_devices(device_id, compile_kwargs)
 
-    if not should_attempt_failover(device_id, compile_kwargs, current_tp):
+    if not should_attempt_failover(device_id, compile_kwargs, current_num_devices):
         return None
 
     # Log the failover attempt
@@ -257,13 +265,13 @@ def handle_tp_failover(model, compile_kwargs, device_id, original_compile_fn):
     if physical_device_ids:
         model_name = getattr(model, "__name__", str(model))
         rbln_log_warn(
-            f"Model '{model_name}' unsupported with tp={current_tp}. "
-            f"Retrying with tp=1 on root device (NPU {physical_device_ids[0]})."
+            f"Model '{model_name}' unsupported with num_devices={current_num_devices}. "
+            f"Retrying with num_devices=1 on root device (NPU {physical_device_ids[0]})."
         )
 
-    # Recompile with tp=1
+    # Recompile with num_devices=1
     try:
-        return recompile_with_tp_size(model, compile_kwargs, 1, original_compile_fn)
+        return recompile_with_num_devices(model, compile_kwargs, 1, original_compile_fn)
     except Exception:
         # If recompilation fails, return None to re-raise original error
         return None
@@ -274,11 +282,11 @@ class CompiledFunctionWrapper:
 
     This wrapper provides the following features:
 
-    1. **TP Auto-Determination**: Automatically determines tensor_parallel_size based on
+    1. **TP Auto-Determination**: Automatically determines num_devices based on
        RSD device topology (RBLN_NPUS_PER_DEVICE or RBLN_DEVICE_MAP) if not explicitly set.
 
     2. **TP Failover**: When TORCH_RBLN_USE_TP_FAILOVER=ON and a RuntimeError occurs
-       with tp > 1, automatically retries with tp=1 on the root NPU.
+       with num_devices > 1, automatically retries with num_devices=1 on the root NPU.
 
     3. **CPU Fallback**: Falls back to CPU execution when compilation fails (in non-debug mode).
 
@@ -299,7 +307,7 @@ class CompiledFunctionWrapper:
         self._original_compile_fn = original_compile_fn
         self._compile_kwargs = compile_kwargs or {}
         self._max_retries = 1
-        self._auto_tp_determined = False
+        self._auto_num_devices_determined = False
         self._failover_attempted = False
 
     def _try_tp_failover(self, device_id):
@@ -372,14 +380,14 @@ class CompiledFunctionWrapper:
         # Extract device_id for TP operations
         device_id = extract_device_id_from_inputs(*args, **kwargs)
 
-        # Auto-determine tensor_parallel_size if needed (only once)
-        if not self._auto_tp_determined:
-            compiled_fn_with_auto_tp = auto_determine_tp_if_needed(
+        # Auto-determine num_devices if needed (only once)
+        if not self._auto_num_devices_determined:
+            compiled_fn_with_auto_num_devices = auto_determine_num_devices_if_needed(
                 self._original_fn, self._compile_kwargs, device_id, self._original_compile_fn
             )
-            if compiled_fn_with_auto_tp is not None:
-                self._compiled_fn = compiled_fn_with_auto_tp
-            self._auto_tp_determined = True
+            if compiled_fn_with_auto_num_devices is not None:
+                self._compiled_fn = compiled_fn_with_auto_num_devices
+            self._auto_num_devices_determined = True
 
         for attempt in range(self._max_retries + 1):
             try:

--- a/torch_rbln/_internal/torch_compile_patch_helpers.py
+++ b/torch_rbln/_internal/torch_compile_patch_helpers.py
@@ -145,10 +145,13 @@ def recompile_with_num_devices(model, compile_kwargs, num_devices, original_comp
 
 
 def get_num_devices_from_options(compile_kwargs):
-    """Extract ``num_devices`` from compile options.
+    """Read the caller-pinned device count from compile options.
 
-    ``num_devices`` takes precedence; ``tensor_parallel_size`` is accepted as a
-    deprecated alias.
+    Used only to detect whether the caller explicitly set a device count, so
+    auto-determination and failover do not override an explicit choice. Both
+    ``num_devices`` and the legacy ``tensor_parallel_size`` are recognized
+    (``num_devices`` wins); canonicalizing the option for the backend is the
+    backend's responsibility, not this function's.
     """
     compile_options = compile_kwargs.get("options", {})
     if not isinstance(compile_options, dict):


### PR DESCRIPTION
## Summary of Changes

The compiler renamed its `tensor_parallel_size` compile option to `num_devices`. This adopts the new name everywhere torch-rbln sets the option (eager ops, custom kernels, `torch.compile` auto-determination and failover), and makes the option reader accept both keys — `num_devices` takes precedence and `tensor_parallel_size` is kept as a deprecated alias. Internal helpers, docstrings, and configuration docs are aligned to `num_devices`.

---

## Related Issues / Tickets

* Related to #

---

## Type of Change

- [x] `refactor` — Code improvement without behavior change

---

## Affected Modules

- [x] Ops/Kernels
- [x] `torch.compile`
- [x] Docs

---

## How to Test

1. Run `pytest test/rbln/test_torch_compile_patch.py`
2. Verify the option reader/writer tests pass, including the `num_devices` / `tensor_parallel_size` alias and precedence cases.

---

## Checklist

* [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
* [ ] This PR is linked to a corresponding issue
* [x] Linting passes
* [ ] All CI tests pass
* [x] The test method is described, and the expected result is clearly stated
* [x] Relevant documentation has been updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
