### PR TITLE
ci: add workflow linting

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,19 +1,21 @@
-name: "CD"
+name: CD
 
 on:
   push:
-    tags:
-      - "v*"
+    tags: [v*]
   workflow_dispatch:
     inputs:
       torch_rbln_ref:
-        description: "Git reference for torch-rbln (branch, tag, or SHA)"
+        description: Git reference for torch-rbln (branch, tag, or SHA)
         type: string
         required: true
       torch_rbln_sha:
-        description: "Git commit SHA to include in the dispatch payload"
+        description: Git commit SHA to include in the dispatch payload
         type: string
         required: true
+
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ (github.event_name == 'workflow_dispatch' && github.run_id) || github.sha }}
@@ -25,7 +27,8 @@ jobs:
     uses: ./.github/workflows/dispatch_event.yaml
     with:
       event_name: ${{ github.event_name }}
-      event_type: "torch-rbln-cd"
+      event_type: torch-rbln-cd
       torch_rbln_ref: ${{ (github.event_name == 'workflow_dispatch' && inputs.torch_rbln_ref) || github.ref }}
       torch_rbln_sha: ${{ (github.event_name == 'workflow_dispatch' && inputs.torch_rbln_sha) || github.sha }}
-    secrets: inherit
+    secrets:
+      GIT_PAT: ${{ secrets.GIT_PAT }}

--- a/.github/workflows/check_pr_title.yaml
+++ b/.github/workflows/check_pr_title.yaml
@@ -1,4 +1,4 @@
-name: "Check PR title"
+name: Check PR title
 
 on:
   pull_request:
@@ -13,17 +13,17 @@ concurrency:
 
 jobs:
   check_pr_title:
-    name: "Check PR title"
+    name: Check PR title
     if: ${{ github.repository_owner == vars.TORCH_RBLN_REPO_OWNER }}
     runs-on: ${{ vars.TORCH_RBLN_RUNNER_EXTERNAL }}
     steps:
-      - name: "Check Conventional Commits format"
+      - name: Check Conventional Commits format
         id: pr_title_lint
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: Wandalen/wretry.action@v3
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea  # v3.8.0
         with:
-          action: amannn/action-semantic-pull-request@v5
+          action: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017  # v5.5.3
           attempt_limit: 5
           attempt_delay: 5000
           with: |
@@ -42,11 +42,11 @@ jobs:
             subjectPatternError: |
               The subject "{subject}" found in the pull request title "{title}" must start with a lowercase letter and not end with a period.
 
-      - name: "Post comment on invalid PR title"
+      - name: Post comment on invalid PR title
         if: ${{ always() && steps.pr_title_lint.outcome == 'failure' }}
-        uses: Wandalen/wretry.action@v3
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea  # v3.8.0
         with:
-          action: marocchino/sticky-pull-request-comment@v2
+          action: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405  # v2.9.4
           attempt_limit: 5
           attempt_delay: 5000
           with: |
@@ -62,11 +62,11 @@ jobs:
               ${{ fromJSON(steps.pr_title_lint.outputs.outputs || '{}').error_message }}
               ```
 
-      - name: "Delete comment on valid PR title"
+      - name: Delete comment on valid PR title
         if: ${{ always() && steps.pr_title_lint.outcome == 'success' }}
-        uses: Wandalen/wretry.action@v3
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea  # v3.8.0
         with:
-          action: marocchino/sticky-pull-request-comment@v2
+          action: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405  # v2.9.4
           attempt_limit: 5
           attempt_delay: 5000
           with: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,23 +1,24 @@
-name: "CI"
+name: CI
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    branches-ignore:
-      - "main"
+    branches-ignore: [main]
   push:
-    branches:
-      - "dev"
+    branches: [dev]
   workflow_dispatch:
     inputs:
       torch_rbln_ref:
-        description: "Git reference for torch-rbln (branch, tag, or SHA)"
+        description: Git reference for torch-rbln (branch, tag, or SHA)
         type: string
         required: true
       torch_rbln_sha:
-        description: "Git commit SHA to include in the dispatch payload"
+        description: Git commit SHA to include in the dispatch payload
         type: string
         required: true
+
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.pull_request.number) || (github.event_name == 'workflow_dispatch' && github.run_id) || github.sha }}
@@ -29,7 +30,8 @@ jobs:
     uses: ./.github/workflows/dispatch_event.yaml
     with:
       event_name: ${{ github.event_name }}
-      event_type: "torch-rbln-ci"
+      event_type: torch-rbln-ci
       torch_rbln_ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.ref) || (github.event_name == 'workflow_dispatch' && inputs.torch_rbln_ref) || github.ref }}
       torch_rbln_sha: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || (github.event_name == 'workflow_dispatch' && inputs.torch_rbln_sha) || github.sha }}
-    secrets: inherit
+    secrets:
+      GIT_PAT: ${{ secrets.GIT_PAT }}

--- a/.github/workflows/dispatch_event.yaml
+++ b/.github/workflows/dispatch_event.yaml
@@ -1,53 +1,60 @@
-name: "Dispatch event"
+name: Dispatch event
 
 on:
   workflow_call:
     inputs:
       event_name:
-        description: "GitHub event name that triggered the workflow"
+        description: GitHub event name that triggered the workflow
         type: string
         required: true
       event_type:
-        description: "Event type for repository dispatch"
+        description: Event type for repository dispatch
         type: string
         required: true
       torch_rbln_ref:
-        description: "Git reference for torch-rbln (branch, tag, or SHA)"
+        description: Git reference for torch-rbln (branch, tag, or SHA)
         type: string
         required: true
       torch_rbln_sha:
-        description: "Git commit SHA to include in the dispatch payload"
+        description: Git commit SHA to include in the dispatch payload
         type: string
+        required: true
+    secrets:
+      GIT_PAT:
+        description: Personal access token for cross-repository dispatch
         required: true
   workflow_dispatch:
     inputs:
       event_name:
-        description: "GitHub event name that triggered the workflow"
+        description: GitHub event name that triggered the workflow
         type: string
         required: true
       event_type:
-        description: "Event type for repository dispatch"
+        description: Event type for repository dispatch
         type: string
         required: true
       torch_rbln_ref:
-        description: "Git reference for torch-rbln (branch, tag, or SHA)"
+        description: Git reference for torch-rbln (branch, tag, or SHA)
         type: string
         required: true
       torch_rbln_sha:
-        description: "Git commit SHA to include in the dispatch payload"
+        description: Git commit SHA to include in the dispatch payload
         type: string
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   dispatch_event:
-    name: "Dispatch event for ${{ inputs.event_type }}"
+    name: Dispatch event for ${{ inputs.event_type }}
     if: ${{ github.repository_owner == vars.TORCH_RBLN_REPO_OWNER }}
     runs-on: ${{ vars.TORCH_RBLN_RUNNER_EXTERNAL }}
     steps:
-      - name: "Dispatch ${{ inputs.event_type }} event"
-        uses: Wandalen/wretry.action@v3
+      - name: Dispatch ${{ inputs.event_type }} event
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea  # v3.8.0
         with:
-          action: peter-evans/repository-dispatch@v4
+          action: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697  # v4.0.1
           attempt_limit: 5
           attempt_delay: 5000
           with: |

--- a/.github/workflows/lint_workflows.yaml
+++ b/.github/workflows/lint_workflows.yaml
@@ -1,0 +1,68 @@
+name: Lint workflows
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main, dev]
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint_workflows:
+    name: Lint workflows
+    if: ${{ github.repository_owner == vars.TORCH_RBLN_REPO_OWNER }}
+    runs-on: ${{ vars.TORCH_RBLN_RUNNER_EXTERNAL }}
+    container:
+      image: ${{ vars.TORCH_RBLN_IMAGE_NAME }}:${{ vars.TORCH_RBLN_IMAGE_TAG }}-py3.12
+      credentials:
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GIT_PAT }}
+    env:
+      GIT_CONFIG_COUNT: '1'
+      GIT_CONFIG_KEY_0: safe.directory
+      GIT_CONFIG_VALUE_0: ${{ github.workspace }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
+
+      - name: Install workflow lint tools
+        run: |
+          set -euo pipefail
+
+          uv venv .venv-lint
+          uv pip install --group lint --python .venv-lint/bin/python
+          echo "${PWD}/.venv-lint/bin" >> "${GITHUB_PATH}"
+
+      - name: Run actionlint
+        run: |
+          set -euo pipefail
+
+          actionlint
+
+      - name: Run yamllint
+        run: |
+          set -euo pipefail
+
+          yamllint --strict .github/
+
+      - name: Run zizmor
+        run: |
+          set -euo pipefail
+
+          zizmor --offline .github/
+    timeout-minutes: 15

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,23 +1,24 @@
-name: "Release"
+name: Release
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    branches:
-      - "main"
+    branches: [main]
   push:
-    branches:
-      - "main"
+    branches: [main]
   workflow_dispatch:
     inputs:
       torch_rbln_ref:
-        description: "Git reference for torch-rbln (branch, tag, or SHA)"
+        description: Git reference for torch-rbln (branch, tag, or SHA)
         type: string
         required: true
       torch_rbln_sha:
-        description: "Git commit SHA to include in the dispatch payload"
+        description: Git commit SHA to include in the dispatch payload
         type: string
         required: true
+
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.pull_request.number) || (github.event_name == 'workflow_dispatch' && github.run_id) || github.sha }}
@@ -29,7 +30,8 @@ jobs:
     uses: ./.github/workflows/dispatch_event.yaml
     with:
       event_name: ${{ github.event_name }}
-      event_type: "torch-rbln-release"
+      event_type: torch-rbln-release
       torch_rbln_ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.ref) || (github.event_name == 'workflow_dispatch' && inputs.torch_rbln_ref) || github.ref }}
       torch_rbln_sha: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || (github.event_name == 'workflow_dispatch' && inputs.torch_rbln_sha) || github.sha }}
-    secrets: inherit
+    secrets:
+      GIT_PAT: ${{ secrets.GIT_PAT }}

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,21 @@
+extends: default
+
+rules:
+  document-start: disable
+  empty-values:
+    forbid-in-block-mappings: true
+    forbid-in-flow-mappings: true
+    forbid-in-block-sequences: true
+  float-values:
+    forbid-inf: true
+    forbid-nan: true
+    forbid-scientific-notation: true
+    require-numeral-before-decimal: true
+  line-length: disable
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: true
+  quoted-strings:
+    required: only-when-needed
+  truthy:
+    check-keys: false

--- a/docs/LINTING.md
+++ b/docs/LINTING.md
@@ -12,3 +12,15 @@ After initialization, linting runs on every `git commit`. To manually lint and a
 ```bash
 lintrunner -m main -a
 ```
+
+## Workflow linting
+
+[Workflow linting](WORKFLOWS.md#lint-workflows) runs [`actionlint`](https://github.com/rhysd/actionlint), [`yamllint`](https://github.com/adrienverge/yamllint), and [`zizmor`](https://github.com/zizmorcore/zizmor) on the workflow files. To run them locally:
+
+```bash
+uv pip install --group lint
+
+actionlint
+yamllint --strict .github/
+zizmor --offline .github/
+```

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -10,6 +10,7 @@ This document describes the GitHub Actions workflows that power the automated te
 | Release (`release.yaml`)               | PRs and pushes to `main`      | Pre-release validation              | Linting + all tests except `test_set_experimental`/`test_set_perf` |
 | CD (`cd.yaml`)                         | Version tags (`v*`)           | Build and publish release artifacts | Deployment pipeline                                                |
 | Check PR Title (`check_pr_title.yaml`) | PR opened, edited, or updated | Enforce Conventional Commits format | —                                                                  |
+| Lint workflows (`lint_workflows.yaml`) | PRs; pushes to `main`/`dev`   | Lint the workflow files             | —                                                                  |
 
 CI, Release, and CD workflows delegate to a shared [Event Dispatch](#event-dispatch-mechanism) mechanism that sends events to infrastructure with physical RBLN NPU devices.
 
@@ -23,6 +24,7 @@ CI, Release, and CD workflows delegate to a shared [Event Dispatch](#event-dispa
 | Release        | To `main`                       | To `main`          | Yes (by ref and SHA) | Yes (except `workflow_dispatch`) |
 | CD             | —                               | Tags matching `v*` | Yes (by ref and SHA) | **No**                           |
 | Check PR Title | On open, edit, sync, reopen     | —                  | —                    | Yes                              |
+| Lint workflows | All PRs                         | To `main`/`dev`    | —                    | Yes                              |
 
 CI and Release runs are grouped by PR number (or SHA for pushes); a new push cancels the in-progress run. Manually triggered runs (`workflow_dispatch`) are never cancelled. CD runs are also never cancelled — once a deployment starts, it runs to completion. Check PR Title runs are grouped by PR number and always cancel the in-progress run.
 
@@ -90,6 +92,14 @@ The workflow uses [`amannn/action-semantic-pull-request`](https://github.com/ama
 **Allowed types:** `feat`, `fix`, `refactor`, `perf`, `docs`, `test`, `build`, `ci`, `chore`
 
 If the title is invalid, the workflow uses [`marocchino/sticky-pull-request-comment`](https://github.com/marocchino/sticky-pull-request-comment) to post a sticky comment on the PR explaining the required format. The comment is automatically deleted once the title is corrected.
+
+---
+
+## Lint Workflows
+
+**File:** [`.github/workflows/lint_workflows.yaml`](../.github/workflows/lint_workflows.yaml)
+
+This workflow runs `actionlint`, `yamllint`, and `zizmor` on the workflow files (see [Linting](LINTING.md)).
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,6 +162,7 @@ build = [
   "pip>=24.3.1,<24.4"
 ]
 lint = [
+  "actionlint-py>=1.7.12.24,<1.8.0",
   "black>=24.2.0,<25.0.0",
   "click>=8.1.8,<8.2.0",
   "cmakelint>=1.4.1,<1.5",
@@ -204,7 +205,9 @@ lint = [
   "types-setuptools>=75.8.0.20250110,<75.8.1.0",
   "types-tabulate>=0.8.8,<0.9.0",
   "types-urllib3>=1.26.25.14,<1.26.26.0",
-  "usort>=1.0.8.post1,<1.1.0"
+  "usort>=1.0.8.post1,<1.1.0",
+  "yamllint>=1.38.0,<1.39.0",
+  "zizmor>=1.26.1,<1.27.0"
 ]
 dev = [
   { include-group = "build" },


### PR DESCRIPTION
## Summary of Changes

Adds `lint_workflows.yaml`, which runs `actionlint`, `yamllint`, and `zizmor` over the workflow files.

To pass the gate, the existing workflows are updated: third-party actions are pinned to full-length commit SHAs, each is scoped to least-privilege `permissions`, and callers pass `GIT_PAT` explicitly instead of `secrets: inherit` (all enforced by `zizmor`); redundant quotes are removed (enforced by `yamllint`).

---

## Type of Change

- [x] `other` — Other (describe below)

CI infrastructure change only.

---

## Affected Modules

- [x] Build/Tools
- [x] Docs

---

## Checklist

* [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
* [x] Linting passes — see [Linting](docs/LINTING.md)
* [x] All CI tests pass — see [CI/CD Workflows](docs/WORKFLOWS.md)
* [x] Relevant documentation has been updated (if applicable)

---
