### PR TITLE
fix: sort development builds by recency

### DIFF
--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -82,15 +82,18 @@ The merge method depends on the branch pair:
 
 torch-rbln releases align with the [RBLN SDK](https://docs.rbln.ai/) — each release version matches the corresponding SDK version.
 
-Versions are derived from git tags using [setuptools-scm](https://setuptools-scm.readthedocs.io/). Tags use the format `v<major>.<minor>.<patch>[rc<N>]`, where the optional `rc<N>` suffix marks a release candidate build.
+Versions are derived from git tags using [setuptools-scm](https://setuptools-scm.readthedocs.io/). Tags use the format `v<major>.<minor>.<patch>` with an optional `rc<N>` (release candidate) or `.post<N>` (post-release) suffix.
 
-| Source                 | Example Tag      | Resulting Version      |
-|------------------------|------------------|------------------------|
-| On a release tag       | `v0.10.0`        | `0.10.0`               |
-| On a release candidate | `v0.10.0rc0`     | `0.10.0rc0`            |
-| 5 commits past a tag   | `v0.10.0rc0` + 5 | `0.10.1.dev5+g1a2b3c4` |
+| Source                     | Example Tag         | Resulting Version            |
+|----------------------------|---------------------|------------------------------|
+| On a release candidate     | `v0.10.0rc0`        | `0.10.0rc0`                  |
+| On a release tag           | `v0.10.0`           | `0.10.0`                     |
+| On a post-release          | `v0.10.0.post0`     | `0.10.0.post0`               |
+| 5 commits past a candidate | `v0.10.0rc0` + 5    | `0.10.0rc1.dev5+g1a2b3c4`    |
+| 5 commits past a release   | `v0.10.0` + 5       | `0.10.1.dev5+g1a2b3c4`       |
+| 5 commits past a post      | `v0.10.0.post0` + 5 | `0.10.0.post1.dev5+g1a2b3c4` |
 
-Development builds between tags carry a `.devN+g<commit>` suffix so they sort below the next release.
+Development builds between tags anticipate the next release and carry a `.devN+g<sha>` suffix, so they sort below it.
 
 ## Release Lifecycle
 

--- a/mypy-strict.ini
+++ b/mypy-strict.ini
@@ -6,7 +6,7 @@
 # files.
 
 [mypy]
-python_version = 3.8
+# Do not set python_version: mypy then targets the Python version it runs under.
 
 cache_dir = .mypy_cache/strict
 allow_redefinition = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,13 +47,8 @@ build-backend = "hatchling.build"
 # ==============================================================================
 
 [tool.hatch.version]
-# Version is computed by tools/get_version.py, which calls setuptools-scm
-# with custom version_scheme and local_scheme callables:
-# - On a tag (distance=0): preserve the tag version as-is, including pre-release
-#   e.g. v0.10.0a0 → 0.10.0a0,  v0.10.0 → 0.10.0
-# - Off a tag (distance>0): strip pre-release, bump patch, append .devN+gCOMMIT
-#   e.g. v0.10.0a0, dist=5 → 0.10.1.dev5+g1234abc
-#        v0.10.0,   dist=5 → 0.10.1.dev5+g1234abc
+# Version is derived from git tags by setuptools-scm.
+# See `docs/RELEASE_PROCESS.md` for the tag-to-version mapping.
 source = "code"
 path = "tools/get_version.py"
 expression = "compute_version()"

--- a/tools/get_version.py
+++ b/tools/get_version.py
@@ -1,57 +1,37 @@
-"""Compute the project version using setuptools-scm with custom schemes.
+"""Compute the project version from git tags using setuptools-scm.
 
-Called by hatchling's 'code' version source plugin during builds.
-Passes custom version_scheme and local_scheme callables directly to
-setuptools-scm, eliminating the need for a separate entry-point package.
+Invoked by hatchling's ``code`` version source at build time. setuptools-scm's
+defaults apply except for a custom local scheme (``_local_scheme``).
 """
 
 from __future__ import annotations
 
-import re
+import os
 from typing import TYPE_CHECKING
 
-from setuptools_scm import get_version as _scm_get_version
+from setuptools_scm import get_version
 
 
 if TYPE_CHECKING:
     from setuptools_scm.version import ScmVersion
 
-TAG_REGEX = r"^v(?P<version>\d+\.\d+\.\d+(?:(?:a|b|rc)\d*)?)"
-
-
-def _version_scheme(version: ScmVersion) -> str:
-    """Like guess-next-dev, but strip pre-release suffixes before bumping.
-
-    - distance == 0 (on tag): return tag version as-is, preserving pre-release.
-      Use distance, not exact, so dirty working tree still gets tag version.
-      e.g. v0.10.0a0  → 0.10.0a0
-    - distance > 0 (off tag): strip pre-release, bump patch, add .devN
-      e.g. v0.10.0a0, distance=5 → 0.10.1.dev5
-           v0.10.0,   distance=5 → 0.10.1.dev5
-    """
-    if version.distance == 0:
-        return version.format_with("{tag}")
-
-    tag_str = str(version.tag)
-    match = re.match(r"^(\d+)\.(\d+)\.(\d+)", tag_str)
-    if not match:
-        raise ValueError(f"Cannot parse base version from tag: {tag_str}")
-
-    major, minor, patch = match.group(1), match.group(2), match.group(3)
-    return f"{major}.{minor}.{int(patch) + 1}.dev{version.distance}"
-
 
 def _local_scheme(version: ScmVersion) -> str:
-    """Return +{node} only (no date component). Omit when on tag (distance=0)."""
+    """PEP 440 local segment: ``+g<sha>`` off a tag, empty on a tag, with a
+    ``.debug`` / ``+debug`` marker for ``TORCH_RBLN_BUILD_TYPE=Debug`` builds.
+
+    Omits the date that setuptools-scm's default ``node-and-date`` would add, so
+    a dirty tree yields the same segment as a clean one.
+    """
     if version.distance == 0 or version.node is None:
-        return ""
-    return version.format_choice("+{node}", "+{node}")
+        local = ""
+    else:
+        local = version.format_with("+{node}")
+    if os.environ.get("TORCH_RBLN_BUILD_TYPE") == "Debug":
+        local = f"{local}.debug" if local else "+debug"
+    return local
 
 
 def compute_version() -> str:
-    """Compute version from git tags using setuptools-scm."""
-    return _scm_get_version(
-        version_scheme=_version_scheme,
-        local_scheme=_local_scheme,
-        tag_regex=TAG_REGEX,
-    )
+    """Return the project version."""
+    return get_version(local_scheme=_local_scheme)


### PR DESCRIPTION
## Summary of Changes

Adopts the default `guess-next-dev` version scheme from `setuptools-scm`, so a newer build always sorts above an older one.

The custom scheme it replaces sets a build's `.devN` to its commit distance from the nearest tag, but collapses different tags of one release onto a single base version. Because that distance resets at each tag, a newer build can receive a lower number and sort below an older one.

A custom local scheme is kept for two reasons: it omits the date the default appends to dirty builds, keeping their version reproducible, and it adds the `.debug` or `+debug` marker for debug wheels.

---

## Type of Change

- [x] `fix` — Bug fix

---

## Affected Modules

- [x] Build/Tools
- [x] Docs

---

## Checklist

* [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
* [x] Linting passes — see [Linting](docs/LINTING.md)
* [x] All CI tests pass — see [CI/CD Workflows](docs/WORKFLOWS.md)
* [x] Relevant documentation has been updated (if applicable)

---
