### PR TITLE
ci: standardize workflows

### DIFF
--- a/.github/workflows/_dispatch-event.yaml
+++ b/.github/workflows/_dispatch-event.yaml
@@ -23,24 +23,6 @@ on:
       GIT_PAT:
         description: Personal access token for cross-repository dispatch
         required: true
-  workflow_dispatch:
-    inputs:
-      event_name:
-        description: GitHub event name that triggered the workflow
-        type: string
-        required: true
-      event_type:
-        description: Event type for repository dispatch
-        type: string
-        required: true
-      torch_rbln_ref:
-        description: Git reference for torch-rbln (branch, tag, or SHA)
-        type: string
-        required: true
-      torch_rbln_sha:
-        description: Git commit SHA to include in the dispatch payload
-        type: string
-        required: true
 
 permissions:
   contents: read
@@ -50,6 +32,12 @@ jobs:
     name: Dispatch event for ${{ inputs.event_type }}
     if: ${{ github.repository_owner == vars.TORCH_RBLN_REPO_OWNER }}
     runs-on: ${{ vars.TORCH_RBLN_RUNNER_EXTERNAL }}
+    timeout-minutes: 60
+    container:
+      image: ${{ vars.TORCH_RBLN_IMAGE_NAME }}:${{ vars.TORCH_RBLN_IMAGE_TAG }}-py3.12
+      credentials:
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GIT_PAT }}
     steps:
       - name: Dispatch ${{ inputs.event_type }} event
         uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea  # v3.8.0
@@ -67,4 +55,3 @@ jobs:
                 "torch_rbln_ref": "${{ inputs.torch_rbln_ref }}",
                 "torch_rbln_sha": "${{ inputs.torch_rbln_sha }}"
               }
-    timeout-minutes: 60

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -3,32 +3,22 @@ name: CD
 on:
   push:
     tags: [v*]
-  workflow_dispatch:
-    inputs:
-      torch_rbln_ref:
-        description: Git reference for torch-rbln (branch, tag, or SHA)
-        type: string
-        required: true
-      torch_rbln_sha:
-        description: Git commit SHA to include in the dispatch payload
-        type: string
-        required: true
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ (github.event_name == 'workflow_dispatch' && github.run_id) || github.sha }}
+  group: ${{ github.workflow }}-${{ github.sha }}
   cancel-in-progress: false
 
 jobs:
   dispatch_torch_rbln_cd:
     if: ${{ github.repository_owner == vars.TORCH_RBLN_REPO_OWNER }}
-    uses: ./.github/workflows/dispatch_event.yaml
+    uses: ./.github/workflows/_dispatch-event.yaml
     with:
       event_name: ${{ github.event_name }}
       event_type: torch-rbln-cd
-      torch_rbln_ref: ${{ (github.event_name == 'workflow_dispatch' && inputs.torch_rbln_ref) || github.ref }}
-      torch_rbln_sha: ${{ (github.event_name == 'workflow_dispatch' && inputs.torch_rbln_sha) || github.sha }}
+      torch_rbln_ref: ${{ github.ref }}
+      torch_rbln_sha: ${{ github.sha }}
     secrets:
       GIT_PAT: ${{ secrets.GIT_PAT }}

--- a/.github/workflows/check-pr-title.yaml
+++ b/.github/workflows/check-pr-title.yaml
@@ -16,6 +16,12 @@ jobs:
     name: Check PR title
     if: ${{ github.repository_owner == vars.TORCH_RBLN_REPO_OWNER }}
     runs-on: ${{ vars.TORCH_RBLN_RUNNER_EXTERNAL }}
+    timeout-minutes: 10
+    container:
+      image: ${{ vars.TORCH_RBLN_IMAGE_NAME }}:${{ vars.TORCH_RBLN_IMAGE_TAG }}-py3.12
+      credentials:
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GIT_PAT }}
     steps:
       - name: Check Conventional Commits format
         id: pr_title_lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,32 +6,22 @@ on:
     branches-ignore: [main]
   push:
     branches: [dev]
-  workflow_dispatch:
-    inputs:
-      torch_rbln_ref:
-        description: Git reference for torch-rbln (branch, tag, or SHA)
-        type: string
-        required: true
-      torch_rbln_sha:
-        description: Git commit SHA to include in the dispatch payload
-        type: string
-        required: true
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.pull_request.number) || (github.event_name == 'workflow_dispatch' && github.run_id) || github.sha }}
-  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   dispatch_torch_rbln_ci:
     if: ${{ github.repository_owner == vars.TORCH_RBLN_REPO_OWNER }}
-    uses: ./.github/workflows/dispatch_event.yaml
+    uses: ./.github/workflows/_dispatch-event.yaml
     with:
       event_name: ${{ github.event_name }}
       event_type: torch-rbln-ci
-      torch_rbln_ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.ref) || (github.event_name == 'workflow_dispatch' && inputs.torch_rbln_ref) || github.ref }}
-      torch_rbln_sha: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || (github.event_name == 'workflow_dispatch' && inputs.torch_rbln_sha) || github.sha }}
+      torch_rbln_ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref }}
+      torch_rbln_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
     secrets:
       GIT_PAT: ${{ secrets.GIT_PAT }}

--- a/.github/workflows/lint-workflows.yaml
+++ b/.github/workflows/lint-workflows.yaml
@@ -22,15 +22,16 @@ jobs:
     name: Lint workflows
     if: ${{ github.repository_owner == vars.TORCH_RBLN_REPO_OWNER }}
     runs-on: ${{ vars.TORCH_RBLN_RUNNER_EXTERNAL }}
+    env:
+      GIT_CONFIG_COUNT: '1'
+      GIT_CONFIG_KEY_0: safe.directory
+      GIT_CONFIG_VALUE_0: ${{ github.workspace }}
+    timeout-minutes: 15
     container:
       image: ${{ vars.TORCH_RBLN_IMAGE_NAME }}:${{ vars.TORCH_RBLN_IMAGE_TAG }}-py3.12
       credentials:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GIT_PAT }}
-    env:
-      GIT_CONFIG_COUNT: '1'
-      GIT_CONFIG_KEY_0: safe.directory
-      GIT_CONFIG_VALUE_0: ${{ github.workspace }}
     steps:
       - name: Check out repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
@@ -65,4 +66,3 @@ jobs:
           set -euo pipefail
 
           zizmor --offline .github/
-    timeout-minutes: 15

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,32 +6,22 @@ on:
     branches: [main]
   push:
     branches: [main]
-  workflow_dispatch:
-    inputs:
-      torch_rbln_ref:
-        description: Git reference for torch-rbln (branch, tag, or SHA)
-        type: string
-        required: true
-      torch_rbln_sha:
-        description: Git commit SHA to include in the dispatch payload
-        type: string
-        required: true
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.pull_request.number) || (github.event_name == 'workflow_dispatch' && github.run_id) || github.sha }}
-  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   dispatch_torch_rbln_release:
     if: ${{ github.repository_owner == vars.TORCH_RBLN_REPO_OWNER }}
-    uses: ./.github/workflows/dispatch_event.yaml
+    uses: ./.github/workflows/_dispatch-event.yaml
     with:
       event_name: ${{ github.event_name }}
       event_type: torch-rbln-release
-      torch_rbln_ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.ref) || (github.event_name == 'workflow_dispatch' && inputs.torch_rbln_ref) || github.ref }}
-      torch_rbln_sha: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || (github.event_name == 'workflow_dispatch' && inputs.torch_rbln_sha) || github.sha }}
+      torch_rbln_ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref }}
+      torch_rbln_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
     secrets:
       GIT_PAT: ${{ secrets.GIT_PAT }}

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -9,8 +9,8 @@ This document describes the GitHub Actions workflows that power the automated te
 | CI (`ci.yaml`)                         | PRs and pushes to `dev`       | Fast feedback on every change       | Linting + `test_set_ci`-marked tests                               |
 | Release (`release.yaml`)               | PRs and pushes to `main`      | Pre-release validation              | Linting + all tests except `test_set_experimental`/`test_set_perf` |
 | CD (`cd.yaml`)                         | Version tags (`v*`)           | Build and publish release artifacts | Deployment pipeline                                                |
-| Check PR Title (`check_pr_title.yaml`) | PR opened, edited, or updated | Enforce Conventional Commits format | —                                                                  |
-| Lint workflows (`lint_workflows.yaml`) | PRs; pushes to `main`/`dev`   | Lint the workflow files             | —                                                                  |
+| Check PR Title (`check-pr-title.yaml`) | PR opened, edited, or updated | Enforce Conventional Commits format | —                                                                  |
+| Lint workflows (`lint-workflows.yaml`) | PRs; pushes to `main`/`dev`   | Lint the workflow files             | —                                                                  |
 
 CI, Release, and CD workflows delegate to a shared [Event Dispatch](#event-dispatch-mechanism) mechanism that sends events to infrastructure with physical RBLN NPU devices.
 
@@ -18,15 +18,15 @@ CI, Release, and CD workflows delegate to a shared [Event Dispatch](#event-dispa
 
 ## Triggers and Concurrency
 
-| Workflow       | `pull_request`                  | `push`             | `workflow_dispatch`  | Cancel in-progress?              |
-|----------------|---------------------------------|--------------------|----------------------|----------------------------------|
-| CI             | To any branch **except** `main` | To `dev`           | Yes (by ref and SHA) | Yes (except `workflow_dispatch`) |
-| Release        | To `main`                       | To `main`          | Yes (by ref and SHA) | Yes (except `workflow_dispatch`) |
-| CD             | —                               | Tags matching `v*` | Yes (by ref and SHA) | **No**                           |
-| Check PR Title | On open, edit, sync, reopen     | —                  | —                    | Yes                              |
-| Lint workflows | All PRs                         | To `main`/`dev`    | —                    | Yes                              |
+| Workflow       | `pull_request`                  | `push`             | Cancel in-progress? |
+|----------------|---------------------------------|--------------------|---------------------|
+| CI             | To any branch **except** `main` | To `dev`           | Yes                 |
+| Release        | To `main`                       | To `main`          | Yes                 |
+| CD             | —                               | Tags matching `v*` | **No**              |
+| Check PR Title | On open, edit, sync, reopen     | —                  | Yes                 |
+| Lint workflows | All PRs                         | To `main`/`dev`    | Yes                 |
 
-CI and Release runs are grouped by PR number (or SHA for pushes); a new push cancels the in-progress run. Manually triggered runs (`workflow_dispatch`) are never cancelled. CD runs are also never cancelled — once a deployment starts, it runs to completion. Check PR Title runs are grouped by PR number and always cancel the in-progress run.
+CI and Release runs are grouped by PR number (or SHA for pushes); a new push cancels the in-progress run. CD runs are never cancelled — once a deployment starts, it runs to completion. Check PR Title runs are grouped by PR number and always cancel the in-progress run.
 
 ---
 
@@ -79,7 +79,7 @@ The CD workflow builds and publishes release artifacts after code has passed bot
 
 ## Check PR Title Workflow
 
-**File:** [`.github/workflows/check_pr_title.yaml`](../.github/workflows/check_pr_title.yaml)
+**File:** [`.github/workflows/check-pr-title.yaml`](../.github/workflows/check-pr-title.yaml)
 
 The Check PR Title workflow enforces the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format on all pull request titles. It triggers whenever a PR is opened, edited, synchronized, or reopened.
 
@@ -97,7 +97,7 @@ If the title is invalid, the workflow uses [`marocchino/sticky-pull-request-comm
 
 ## Lint Workflows
 
-**File:** [`.github/workflows/lint_workflows.yaml`](../.github/workflows/lint_workflows.yaml)
+**File:** [`.github/workflows/lint-workflows.yaml`](../.github/workflows/lint-workflows.yaml)
 
 This workflow runs `actionlint`, `yamllint`, and `zizmor` on the workflow files (see [Linting](LINTING.md)).
 
@@ -105,7 +105,7 @@ This workflow runs `actionlint`, `yamllint`, and `zizmor` on the workflow files 
 
 ## Event Dispatch Mechanism
 
-**File:** [`.github/workflows/dispatch_event.yaml`](../.github/workflows/dispatch_event.yaml)
+**File:** [`.github/workflows/_dispatch-event.yaml`](../.github/workflows/_dispatch-event.yaml)
 
 CI, Release, and CD workflows delegate to an internal hardware-backed automation flow via GitHub [repository dispatch](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#repository_dispatch).
 This is necessary because testing `torch-rbln` requires access to physical RBLN NPU hardware hosted on dedicated infrastructure.


### PR DESCRIPTION
## Summary of Changes

Standardizes the workflow files: filenames move to kebab-case, the reusable workflow is marked with a `_` prefix, jobs run in the shared container image, and the unused `workflow_dispatch` triggers are removed.

---

## Type of Change

- [x] `other` — Other (describe below)

CI infrastructure change only.

---

## Affected Modules

- [x] Build/Tools
- [x] Docs

---

## Checklist

* [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
* [x] Linting passes — see [Linting](docs/LINTING.md)
* [x] All CI tests pass — see [CI/CD Workflows](docs/WORKFLOWS.md)
* [x] Relevant documentation has been updated (if applicable)

---
