### PR TITLE
fix(device): gate runtime ops on runtime_available() so RBLN degrades like CUDA

### DIFF
--- a/c10/rbln/DeviceMappingManager.cpp
+++ b/c10/rbln/DeviceMappingManager.cpp
@@ -408,7 +408,7 @@ void DeviceMappingManager::initialize() {
     // would SEGFAULT. Checked before the dummy branch too: degrade to 0 devices.
     if (!rbln_runtime_available()) {
       RBLN_LOG_INFO(
-          "RBLN runtime (librbln-thunk.so) not loaded; initializing with 0 logical device(s). "
+          "RBLN runtime not loaded; initializing with 0 logical device(s). "
           "Device access will fail at the point of use.");
       device_count_ = 0;
       buildDeviceTopology();

--- a/c10/rbln/DeviceMappingManager.cpp
+++ b/c10/rbln/DeviceMappingManager.cpp
@@ -410,13 +410,25 @@ void DeviceMappingManager::initialize() {
       return;
     }
 
+    // Querying the count needs librbln-thunk.so; if it is not loadable (compile /
+    // CPU-only / CI hosts with no SDK) a raw rbln_* call would SEGFAULT. Route into
+    // the same 0-device path as a host with no NPU, so get_device_count() degrades
+    // to a clean 0 (torch.cuda parity) and use fails at the point of use.
+    if (!c10::rbln::thunk_loadable()) {
+      RBLN_LOG_INFO(
+          "RBLN runtime (librbln-thunk.so) not loadable; initializing with 0 logical device(s). "
+          "Device access will fail at the point of use.");
+      device_count_ = 0;
+      buildDeviceTopology();
+      return;
+    }
+
     int device_count = 0;
-    // A failed query (SDK/driver not loadable) stays fatal; "query succeeded,
-    // found 0 NPUs" is handled below.
+    // The thunk is loadable but the query failed (kernel driver not loaded / device
+    // unavailable): fatal. "Query succeeded, found 0 NPUs" is handled below.
     RBLN_CHECK(
         !rbln_get_device_count(&device_count),
-        "rbln_get_device_count failed; the RBLN SDK/driver may not be loadable — ensure the SDK is installed "
-        "and the kernel driver is loaded");
+        "rbln_get_device_count failed; the RBLN kernel driver may not be loaded or the device is unavailable");
     const int physical_device_count = device_count;
     RBLN_LOG_DEBUG("Found {} physical NPU(s)", physical_device_count);
 

--- a/c10/rbln/DeviceMappingManager.cpp
+++ b/c10/rbln/DeviceMappingManager.cpp
@@ -403,23 +403,24 @@ void DeviceMappingManager::initialize() {
   c10::call_once(init_flag_, [this]() {
     RBLN_LOG_DEBUG("Initializing RBLN device mapping");
 
-    // Explicit opt-in, checked before any runtime query so a host with no
-    // SDK/driver can still construct device tensors and compile.
-    if (dummyDeviceEnabled()) {
-      initializeDummyDevices();
-      return;
-    }
-
-    // Querying the count needs librbln-thunk.so; if it is not loadable (compile /
-    // CPU-only / CI hosts with no SDK) a raw rbln_* call would SEGFAULT. Route into
-    // the same 0-device path as a host with no NPU, so get_device_count() degrades
-    // to a clean 0 (torch.cuda parity) and use fails at the point of use.
+    // Enumeration touches the runtime in BOTH modes -- the real path calls
+    // rbln_get_device_count(), and dummy host-backs via rbln_register_device_id() --
+    // so if librbln-thunk.so is not loadable (compile / CPU-only / CI hosts) a raw
+    // rbln_* call would SEGFAULT. Checked before the dummy branch too: degrade to 0
+    // logical devices (torch.cuda parity), so use fails cleanly at the point of use.
     if (!c10::rbln::thunk_loadable()) {
       RBLN_LOG_INFO(
           "RBLN runtime (librbln-thunk.so) not loadable; initializing with 0 logical device(s). "
           "Device access will fail at the point of use.");
       device_count_ = 0;
       buildDeviceTopology();
+      return;
+    }
+
+    // Explicit opt-in for host-backed dummy devices: no NPU needed, but the runtime
+    // (checked above) is -- dummy materializes tensors through it.
+    if (dummyDeviceEnabled()) {
+      initializeDummyDevices();
       return;
     }
 

--- a/c10/rbln/DeviceMappingManager.cpp
+++ b/c10/rbln/DeviceMappingManager.cpp
@@ -408,7 +408,7 @@ void DeviceMappingManager::initialize() {
     // so if librbln-thunk.so is not loadable (compile / CPU-only / CI hosts) a raw
     // rbln_* call would SEGFAULT. Checked before the dummy branch too: degrade to 0
     // logical devices (torch.cuda parity), so use fails cleanly at the point of use.
-    if (!c10::rbln::thunk_loadable()) {
+    if (!c10::rbln::runtime_loaded()) {
       RBLN_LOG_INFO(
           "RBLN runtime (librbln-thunk.so) not loadable; initializing with 0 logical device(s). "
           "Device access will fail at the point of use.");
@@ -425,7 +425,7 @@ void DeviceMappingManager::initialize() {
     }
 
     int device_count = 0;
-    // The thunk is loadable but the query failed (kernel driver not loaded / device
+    // The runtime is loaded but the query failed (kernel driver not loaded / device
     // unavailable): fatal. "Query succeeded, found 0 NPUs" is handled below.
     RBLN_CHECK(
         !rbln_get_device_count(&device_count),

--- a/c10/rbln/DeviceMappingManager.cpp
+++ b/c10/rbln/DeviceMappingManager.cpp
@@ -403,22 +403,19 @@ void DeviceMappingManager::initialize() {
   c10::call_once(init_flag_, [this]() {
     RBLN_LOG_DEBUG("Initializing RBLN device mapping");
 
-    // Enumeration touches the runtime in BOTH modes -- the real path calls
-    // rbln_get_device_count(), and dummy host-backs via rbln_register_device_id() --
-    // so if librbln-thunk.so is not loadable (compile / CPU-only / CI hosts) a raw
-    // rbln_* call would SEGFAULT. Checked before the dummy branch too: degrade to 0
-    // logical devices (torch.cuda parity), so use fails cleanly at the point of use.
-    if (!c10::rbln::runtime_loaded()) {
+    // Enumeration hits the runtime in both modes (real: rbln_get_device_count();
+    // dummy: rbln_register_device_id()), so without the runtime a raw rbln_* call
+    // would SEGFAULT. Checked before the dummy branch too: degrade to 0 devices.
+    if (!rbln_runtime_available()) {
       RBLN_LOG_INFO(
-          "RBLN runtime (librbln-thunk.so) not loadable; initializing with 0 logical device(s). "
+          "RBLN runtime (librbln-thunk.so) not loaded; initializing with 0 logical device(s). "
           "Device access will fail at the point of use.");
       device_count_ = 0;
       buildDeviceTopology();
       return;
     }
 
-    // Explicit opt-in for host-backed dummy devices: no NPU needed, but the runtime
-    // (checked above) is -- dummy materializes tensors through it.
+    // Dummy: host-backed, no NPU, but still needs the runtime (checked above).
     if (dummyDeviceEnabled()) {
       initializeDummyDevices();
       return;

--- a/c10/rbln/RBLNAllocator.cpp
+++ b/c10/rbln/RBLNAllocator.cpp
@@ -68,9 +68,11 @@ struct RBLNAllocator final : public c10::DeviceAllocator {
   }
 
   bool initialized() override {
-    // RBLN runtime initializes lazily on first allocation; device availability
-    // is a sufficient proxy for readiness.
-    const bool is_initialized = (c10::rbln::get_device_count() > 0);
+    // Gates torch.accelerator.empty_cache()/memory_stats(). thunk_loadable() first
+    // so a missing runtime (incl. dummy) is false, not a segfault; throwing
+    // get_device_count() keeps a malformed config loud (config parse is thunk-free).
+    const bool is_initialized =
+        c10::rbln::thunk_loadable() && (c10::rbln::is_dummy_device() || c10::rbln::get_device_count() > 0);
     RBLN_LOG_DEBUG("is_initialized={}", is_initialized);
     return is_initialized;
   }

--- a/c10/rbln/RBLNAllocator.cpp
+++ b/c10/rbln/RBLNAllocator.cpp
@@ -68,11 +68,11 @@ struct RBLNAllocator final : public c10::DeviceAllocator {
   }
 
   bool initialized() override {
-    // Gates torch.accelerator.empty_cache()/memory_stats(). runtime_loaded() first
-    // so a missing runtime (incl. dummy) is false, not a segfault; throwing
-    // get_device_count() keeps a malformed config loud when the runtime is present.
+    // Gates torch.accelerator.empty_cache()/memory_stats(). Runtime check first so a
+    // missing runtime is false (not a segfault); throwing get_device_count() keeps a
+    // malformed config loud when the runtime is present.
     const bool is_initialized =
-        c10::rbln::runtime_loaded() && (c10::rbln::is_dummy_device() || c10::rbln::get_device_count() > 0);
+        rbln_runtime_available() && (c10::rbln::is_dummy_device() || c10::rbln::get_device_count() > 0);
     RBLN_LOG_DEBUG("is_initialized={}", is_initialized);
     return is_initialized;
   }

--- a/c10/rbln/RBLNAllocator.cpp
+++ b/c10/rbln/RBLNAllocator.cpp
@@ -70,7 +70,7 @@ struct RBLNAllocator final : public c10::DeviceAllocator {
   bool initialized() override {
     // Gates torch.accelerator.empty_cache()/memory_stats(). thunk_loadable() first
     // so a missing runtime (incl. dummy) is false, not a segfault; throwing
-    // get_device_count() keeps a malformed config loud (config parse is thunk-free).
+    // get_device_count() keeps a malformed config loud when the thunk is present.
     const bool is_initialized =
         c10::rbln::thunk_loadable() && (c10::rbln::is_dummy_device() || c10::rbln::get_device_count() > 0);
     RBLN_LOG_DEBUG("is_initialized={}", is_initialized);

--- a/c10/rbln/RBLNAllocator.cpp
+++ b/c10/rbln/RBLNAllocator.cpp
@@ -68,11 +68,11 @@ struct RBLNAllocator final : public c10::DeviceAllocator {
   }
 
   bool initialized() override {
-    // Gates torch.accelerator.empty_cache()/memory_stats(). thunk_loadable() first
+    // Gates torch.accelerator.empty_cache()/memory_stats(). runtime_loaded() first
     // so a missing runtime (incl. dummy) is false, not a segfault; throwing
-    // get_device_count() keeps a malformed config loud when the thunk is present.
+    // get_device_count() keeps a malformed config loud when the runtime is present.
     const bool is_initialized =
-        c10::rbln::thunk_loadable() && (c10::rbln::is_dummy_device() || c10::rbln::get_device_count() > 0);
+        c10::rbln::runtime_loaded() && (c10::rbln::is_dummy_device() || c10::rbln::get_device_count() > 0);
     RBLN_LOG_DEBUG("is_initialized={}", is_initialized);
     return is_initialized;
   }

--- a/c10/rbln/RBLNFunctions.cpp
+++ b/c10/rbln/RBLNFunctions.cpp
@@ -274,13 +274,13 @@ bool is_dummy_device() {
 // mandatory ops throw via require_runtime(), and nothing segfaults.
 
 // Is the RBLN device runtime (librbln-thunk.so) loaded and usable? Delegates to
-// librbln's own rbln_runtime_available(), which reports the actual thunk-load state
+// librbln's own rbln_runtime_available(), which reports the actual runtime-load state
 // (symbols resolved at librbln static-init) -- authoritative and safe to call when
-// the thunk is absent. Public so initialized()/hasPrimaryContext() can gate the
+// the runtime is absent. Public so initialized()/hasPrimaryContext() can gate the
 // throwing get_device_count() on it: with the runtime present a malformed
 // RBLN_DEVICE_MAP still throws (config parse runs); with it absent, enumeration
 // degrades to 0 before parse, so a missing runtime yields false without segfaulting.
-bool thunk_loadable() noexcept {
+bool runtime_loaded() noexcept {
   return rbln_runtime_available();
 }
 
@@ -288,11 +288,11 @@ namespace {
 
 std::atomic<bool> runtime_shutting_down_{false}; // set at teardown via a Python atexit hook
 
-// True when the runtime cannot be touched at all -- absent thunk or teardown -- as
+// True when the runtime cannot be touched at all -- absent runtime or teardown -- as
 // distinct from "no device present", which to_device_id() reports loudly. Lets a
 // teardown-safe op no-op without masking a genuine no-device error.
 bool runtime_torn_down() noexcept {
-  return runtime_shutting_down_.load(std::memory_order_relaxed) || !thunk_loadable();
+  return runtime_shutting_down_.load(std::memory_order_relaxed) || !runtime_loaded();
 }
 
 // Mandatory-op guard: a clean throw instead of a SEGFAULT (no-device is reported
@@ -301,7 +301,7 @@ void require_runtime(const char* op) {
   RBLN_CHECK(
       !runtime_shutting_down_.load(std::memory_order_relaxed), "Cannot {}: the RBLN runtime is shutting down.", op);
   RBLN_CHECK(
-      thunk_loadable(),
+      runtime_loaded(),
       "Cannot {}: the RBLN device runtime (librbln-thunk.so) is not loadable; install the RBLN SDK/runtime "
       "(required even in RBLN_DUMMY_DEVICE mode).",
       op);
@@ -327,10 +327,10 @@ void set_runtime_shutting_down(bool value) noexcept {
 }
 
 bool runtime_available() noexcept {
-  // Will an rbln_* call be serviced safely now? Needs the thunk loadable and not
+  // Will an rbln_* call be serviced safely now? Needs the runtime loaded and not
   // shutting down -- true in dummy mode too (dummy host-backs via the runtime, so it
   // needs librbln-thunk.so); a real device additionally needs a device present.
-  return !runtime_shutting_down_.load(std::memory_order_relaxed) && thunk_loadable() &&
+  return !runtime_shutting_down_.load(std::memory_order_relaxed) && runtime_loaded() &&
       (is_dummy_device() || get_device_count_nothrow() > 0);
 }
 
@@ -410,7 +410,7 @@ void free_nothrow(void* data) noexcept {
   // leak instead. Dummy host-backs frees via the runtime too, so it is gated the
   // same way. Uses the cheap primitives, NOT runtime_available(), so this noexcept
   // deleter avoids get_device_count()'s GIL/Python side effects at teardown.
-  if (runtime_shutting_down_.load(std::memory_order_relaxed) || !thunk_loadable()) {
+  if (runtime_shutting_down_.load(std::memory_order_relaxed) || !runtime_loaded()) {
     RBLN_WARN_NOTHROW(
         "rbln_free skipped for {}: RBLN runtime unavailable; leaking rather than crashing", fmt::ptr(data));
     return;
@@ -596,7 +596,7 @@ void memcpy_v2v_async(void* rbln_dst_data, const void* rbln_src_data, size_t nby
 
 void synchronize(c10::DeviceIndex device_index) {
   RBLN_LOG_DEBUG("Synchronizing device {}", static_cast<int>(device_index));
-  // Nothing to drain if the runtime is torn down (shutdown / absent thunk): no-op
+  // Nothing to drain if the runtime is torn down (shutdown / absent runtime): no-op
   // rather than segfault. A genuine no-device host still throws via to_device_id()
   // below (torch.cuda.synchronize() parity; see RBLNNoDeviceTest).
   if (runtime_torn_down()) {

--- a/c10/rbln/RBLNFunctions.cpp
+++ b/c10/rbln/RBLNFunctions.cpp
@@ -267,42 +267,27 @@ bool is_dummy_device() {
 }
 
 // --- Device-runtime liveness ------------------------------------------------
-// librbln.so loads librbln-thunk.so (the device driver); it is absent on
-// compile/CPU-only/CI hosts and unmapped at shutdown, when a raw rbln_* call
-// null-derefs -> uncatchable SEGFAULT (CUDA merely returns an error code). Every
-// runtime-touching leaf gates on runtime_available(): best-effort ops no-op,
-// mandatory ops throw via require_runtime(), and nothing segfaults.
-
-// Is the RBLN device runtime (librbln-thunk.so) loaded and usable? Delegates to
-// librbln's own rbln_runtime_available(), which reports the actual runtime-load state
-// (symbols resolved at librbln static-init) -- authoritative and safe to call when
-// the runtime is absent. Public so initialized()/hasPrimaryContext() can gate the
-// throwing get_device_count() on it: with the runtime present a malformed
-// RBLN_DEVICE_MAP still throws (config parse runs); with it absent, enumeration
-// degrades to 0 before parse, so a missing runtime yields false without segfaulting.
-bool runtime_loaded() noexcept {
-  return rbln_runtime_available();
-}
+// librbln.so loads librbln-thunk.so (the driver); absent (compile/CPU-only/CI) or
+// unmapped at shutdown, a raw rbln_* call SEGFAULTs. Runtime-touching leaves gate on
+// runtime_available(), built on librbln's own rbln_runtime_available().
 
 namespace {
 
 std::atomic<bool> runtime_shutting_down_{false}; // set at teardown via a Python atexit hook
 
-// True when the runtime cannot be touched at all -- absent runtime or teardown -- as
-// distinct from "no device present", which to_device_id() reports loudly. Lets a
-// teardown-safe op no-op without masking a genuine no-device error.
+// Torn down (shutting down or driver absent) vs "no device present" (reported by
+// to_device_id()): teardown-safe ops no-op only on the former.
 bool runtime_torn_down() noexcept {
-  return runtime_shutting_down_.load(std::memory_order_relaxed) || !runtime_loaded();
+  return runtime_shutting_down_.load(std::memory_order_relaxed) || !rbln_runtime_available();
 }
 
-// Mandatory-op guard: a clean throw instead of a SEGFAULT (no-device is reported
-// separately by to_device_id()). librbln-thunk.so is required even in dummy mode.
+// Mandatory-op guard: clean throw, never a SEGFAULT. Required even in dummy mode.
 void require_runtime(const char* op) {
   RBLN_CHECK(
       !runtime_shutting_down_.load(std::memory_order_relaxed), "Cannot {}: the RBLN runtime is shutting down.", op);
   RBLN_CHECK(
-      runtime_loaded(),
-      "Cannot {}: the RBLN device runtime (librbln-thunk.so) is not loadable; install the RBLN SDK/runtime "
+      rbln_runtime_available(),
+      "Cannot {}: the RBLN device runtime (librbln-thunk.so) is not loaded; install the RBLN SDK/runtime "
       "(required even in RBLN_DUMMY_DEVICE mode).",
       op);
 }
@@ -327,10 +312,9 @@ void set_runtime_shutting_down(bool value) noexcept {
 }
 
 bool runtime_available() noexcept {
-  // Will an rbln_* call be serviced safely now? Needs the runtime loaded and not
-  // shutting down -- true in dummy mode too (dummy host-backs via the runtime, so it
-  // needs librbln-thunk.so); a real device additionally needs a device present.
-  return !runtime_shutting_down_.load(std::memory_order_relaxed) && runtime_loaded() &&
+  // Driver loaded, not shutting down, a device present (dummy needs the driver too,
+  // but no NPU). Single source of truth; never throws. CUDA parity.
+  return !runtime_shutting_down_.load(std::memory_order_relaxed) && rbln_runtime_available() &&
       (is_dummy_device() || get_device_count_nothrow() > 0);
 }
 
@@ -339,11 +323,9 @@ void* malloc(c10::DeviceIndex device_index, size_t nbytes) {
   RBLN_CHECK(nbytes > 0, "nbytes must be positive, but got {}", nbytes);
   check_device_index(device_index);
 
-  // Mandatory op -> clean throw (not SEGFAULT) when the real runtime is unavailable
-  // (no-op in dummy). malloc is the gateway, so this stops a workload up front.
+  // Allocation is the gateway: clean throw (not SEGFAULT) if the runtime is gone;
+  // to_device_id() then throws on a host with no device.
   require_runtime("allocate device memory");
-  // to_device_id() enforces that a device is actually available (device_count >
-  // 0), so allocation fails cleanly here on a host with no NPU.
   const auto torch_device_id = static_cast<uint32_t>(to_device_id(device_index));
   const auto size = static_cast<uint64_t>(nbytes);
   uint64_t vaddr = 0;
@@ -401,16 +383,14 @@ void free(void* data) {
 }
 
 void free_nothrow(void* data) noexcept {
-  // Non-throwing free for the noexcept DataPtr deleter: rbln_free is extern "C"
-  // and RBLN_WARN_NOTHROW is itself nothrow, so no try/catch is needed.
+  // Noexcept deleter: rbln_free and RBLN_WARN_NOTHROW are both nothrow.
   if (data == nullptr) {
     return;
   }
-  // Absent/torn-down runtime: rbln_free would deref a dead runtime -> SEGFAULT;
-  // leak instead. Dummy host-backs frees via the runtime too, so it is gated the
-  // same way. Uses the cheap primitives, NOT runtime_available(), so this noexcept
-  // deleter avoids get_device_count()'s GIL/Python side effects at teardown.
-  if (runtime_shutting_down_.load(std::memory_order_relaxed) || !runtime_loaded()) {
+  // Torn-down runtime: rbln_free would deref a dead runtime -> SEGFAULT; leak instead.
+  // Uses runtime_torn_down() (cheap), not runtime_available(), to avoid
+  // get_device_count()'s GIL/Python side effects in the deleter at teardown.
+  if (runtime_torn_down()) {
     RBLN_WARN_NOTHROW(
         "rbln_free skipped for {}: RBLN runtime unavailable; leaking rather than crashing", fmt::ptr(data));
     return;
@@ -596,10 +576,10 @@ void memcpy_v2v_async(void* rbln_dst_data, const void* rbln_src_data, size_t nby
 
 void synchronize(c10::DeviceIndex device_index) {
   RBLN_LOG_DEBUG("Synchronizing device {}", static_cast<int>(device_index));
-  // Nothing to drain if the runtime is torn down (shutdown / absent runtime): no-op
-  // rather than segfault. A genuine no-device host still throws via to_device_id()
-  // below (torch.cuda.synchronize() parity; see RBLNNoDeviceTest).
-  if (runtime_torn_down()) {
+  // No-op only during teardown (runtime may be unmapped); otherwise a missing device
+  // -- no driver or no NPU -- throws via to_device_id() (torch.cuda.synchronize()
+  // parity; see RBLNNoDeviceTest). No raw call is reached before that throw.
+  if (runtime_shutting_down_.load(std::memory_order_relaxed)) {
     return;
   }
   check_device_index(device_index);
@@ -821,8 +801,8 @@ void reset_accumulated_memory_stats(const c10::Device& device) {
 
 void reset_peak_memory_stats(const c10::Device& device) {
   RBLN_LOG_DEBUG("logical device={}", c10::str(device));
-  // Best-effort: nothing to reset when the runtime is unavailable. (The generic
-  // torch.accelerator.reset_*() have no Python init-guard, so this gate matters.)
+  // Best-effort no-op when unavailable (torch.accelerator.reset_peak has no Python
+  // init-guard, so the leaf gate is the only protection).
   if (!runtime_available()) {
     return;
   }
@@ -838,9 +818,8 @@ void reset_peak_memory_stats(const c10::Device& device) {
 
 void set_file_offloading_enabled(bool enabled) {
   RBLN_LOG_DEBUG("Calling rbln_set_file_offloading_enabled: enabled={}", enabled);
-  // Global toggle reachable without any allocation (torch.rbln.offload()), so it is
-  // gated directly: best-effort no-op when the runtime is unavailable (offloading is
-  // meaningless with no device) rather than segfaulting on a compile/CPU-only host.
+  // Reachable without an allocation (torch.rbln.offload()), so gated directly:
+  // best-effort no-op when the runtime is unavailable.
   if (!runtime_available()) {
     return;
   }

--- a/c10/rbln/RBLNFunctions.cpp
+++ b/c10/rbln/RBLNFunctions.cpp
@@ -5,8 +5,6 @@
 #include <c10/util/CallOnce.h>
 #include <rebel/runtime/memory_stats.h>
 
-#include <dlfcn.h> // dlopen() probe for librbln-thunk.so (runtime-liveness gate)
-
 #include <atomic>
 #include <cstdint>
 #include <cstdlib>
@@ -269,23 +267,21 @@ bool is_dummy_device() {
 }
 
 // --- Device-runtime liveness ------------------------------------------------
-// torch-rbln lazily dlopen()s librbln-thunk.so on the first device op; if it is
-// absent (compile/CPU-only/CI hosts) or unmapped at shutdown, a raw rbln_* call
+// librbln.so loads librbln-thunk.so (the device driver); it is absent on
+// compile/CPU-only/CI hosts and unmapped at shutdown, when a raw rbln_* call
 // null-derefs -> uncatchable SEGFAULT (CUDA merely returns an error code). Every
 // runtime-touching leaf gates on runtime_available(): best-effort ops no-op,
 // mandatory ops throw via require_runtime(), and nothing segfaults.
 
-// Cached nothrow probe: is librbln-thunk.so loadable? Same unversioned name
-// librbln.so uses (no ".so.N" version coupling); RTLD_LOCAL so a probe does not
-// promote thunk symbols globally. Public so initialized()/hasPrimaryContext() can
-// gate the throwing get_device_count() on it: with the thunk loadable a malformed
+// Is the RBLN device runtime (librbln-thunk.so) loaded and usable? Delegates to
+// librbln's own rbln_runtime_available(), which reports the actual thunk-load state
+// (symbols resolved at librbln static-init) -- authoritative and safe to call when
+// the thunk is absent. Public so initialized()/hasPrimaryContext() can gate the
+// throwing get_device_count() on it: with the runtime present a malformed
 // RBLN_DEVICE_MAP still throws (config parse runs); with it absent, enumeration
 // degrades to 0 before parse, so a missing runtime yields false without segfaulting.
 bool thunk_loadable() noexcept {
-  static const bool loadable = []() noexcept {
-    return ::dlopen("librbln-thunk.so", RTLD_LAZY | RTLD_LOCAL) != nullptr;
-  }();
-  return loadable;
+  return rbln_runtime_available();
 }
 
 namespace {

--- a/c10/rbln/RBLNFunctions.cpp
+++ b/c10/rbln/RBLNFunctions.cpp
@@ -267,9 +267,9 @@ bool is_dummy_device() {
 }
 
 // --- Device-runtime liveness ------------------------------------------------
-// librbln.so loads librbln-thunk.so (the driver); absent (compile/CPU-only/CI) or
-// unmapped at shutdown, a raw rbln_* call SEGFAULTs. Runtime-touching leaves gate on
-// runtime_available(), built on librbln's own rbln_runtime_available().
+// The device runtime (driver) is loaded lazily and is absent on compile/CPU-only/CI
+// hosts or unmapped at shutdown, when a raw rbln_* call SEGFAULTs. Runtime-touching
+// leaves gate on runtime_available(), built on librbln's own rbln_runtime_available().
 
 namespace {
 
@@ -287,7 +287,7 @@ void require_runtime(const char* op) {
       !runtime_shutting_down_.load(std::memory_order_relaxed), "Cannot {}: the RBLN runtime is shutting down.", op);
   RBLN_CHECK(
       rbln_runtime_available(),
-      "Cannot {}: the RBLN device runtime (librbln-thunk.so) is not loaded; install the RBLN SDK/runtime "
+      "Cannot {}: the RBLN device runtime is not loaded; install the RBLN SDK/runtime "
       "(required even in RBLN_DUMMY_DEVICE mode).",
       op);
 }

--- a/c10/rbln/RBLNFunctions.cpp
+++ b/c10/rbln/RBLNFunctions.cpp
@@ -278,8 +278,9 @@ bool is_dummy_device() {
 // Cached nothrow probe: is librbln-thunk.so loadable? Same unversioned name
 // librbln.so uses (no ".so.N" version coupling); RTLD_LOCAL so a probe does not
 // promote thunk symbols globally. Public so initialized()/hasPrimaryContext() can
-// gate the throwing get_device_count() on it (config parsing is thunk-free, so a
-// malformed RBLN_DEVICE_MAP still throws while a missing runtime yields false).
+// gate the throwing get_device_count() on it: with the thunk loadable a malformed
+// RBLN_DEVICE_MAP still throws (config parse runs); with it absent, enumeration
+// degrades to 0 before parse, so a missing runtime yields false without segfaulting.
 bool thunk_loadable() noexcept {
   static const bool loadable = []() noexcept {
     return ::dlopen("librbln-thunk.so", RTLD_LAZY | RTLD_LOCAL) != nullptr;

--- a/c10/rbln/RBLNFunctions.cpp
+++ b/c10/rbln/RBLNFunctions.cpp
@@ -5,6 +5,8 @@
 #include <c10/util/CallOnce.h>
 #include <rebel/runtime/memory_stats.h>
 
+#include <dlfcn.h> // dlopen() probe for librbln-thunk.so (runtime-liveness gate)
+
 #include <atomic>
 #include <cstdint>
 #include <cstdlib>
@@ -266,11 +268,76 @@ bool is_dummy_device() {
   return dummy;
 }
 
+// --- Device-runtime liveness ------------------------------------------------
+// torch-rbln lazily dlopen()s librbln-thunk.so on the first device op; if it is
+// absent (compile/CPU-only/CI hosts) or unmapped at shutdown, a raw rbln_* call
+// null-derefs -> uncatchable SEGFAULT (CUDA merely returns an error code). Every
+// runtime-touching leaf gates on runtime_available(): best-effort ops no-op,
+// mandatory ops throw via require_runtime(), and nothing segfaults.
+
+// Cached nothrow probe: is librbln-thunk.so loadable? Same unversioned name
+// librbln.so uses (no ".so.N" version coupling); RTLD_LOCAL so a probe does not
+// promote thunk symbols globally. Public so initialized()/hasPrimaryContext() can
+// gate the throwing get_device_count() on it (config parsing is thunk-free, so a
+// malformed RBLN_DEVICE_MAP still throws while a missing runtime yields false).
+bool thunk_loadable() noexcept {
+  static const bool loadable = []() noexcept {
+    return ::dlopen("librbln-thunk.so", RTLD_LAZY | RTLD_LOCAL) != nullptr;
+  }();
+  return loadable;
+}
+
+namespace {
+
+std::atomic<bool> runtime_shutting_down_{false}; // set at teardown via a Python atexit hook
+
+// Mandatory-op guard: a clean throw instead of a SEGFAULT (no-device is reported
+// separately by to_device_id()). librbln-thunk.so is required even in dummy mode.
+void require_runtime(const char* op) {
+  RBLN_CHECK(
+      !runtime_shutting_down_.load(std::memory_order_relaxed), "Cannot {}: the RBLN runtime is shutting down.", op);
+  RBLN_CHECK(
+      thunk_loadable(),
+      "Cannot {}: the RBLN device runtime (librbln-thunk.so) is not loadable; install the RBLN SDK/runtime "
+      "(required even in RBLN_DUMMY_DEVICE mode).",
+      op);
+}
+
+} // namespace
+
+c10::DeviceIndex get_device_count_nothrow() noexcept {
+  // Nothrow view of get_device_count() for the liveness gate; failures map to 0.
+  try {
+    return get_device_count();
+  } catch (const std::exception& e) {
+    RBLN_WARN_NOTHROW("get_device_count failed, treating as 0 device(s): {}", e.what());
+    return 0;
+  } catch (...) {
+    RBLN_WARN_NOTHROW("get_device_count failed, treating as 0 device(s): unknown exception");
+    return 0;
+  }
+}
+
+void set_runtime_shutting_down(bool value) noexcept {
+  runtime_shutting_down_.store(value, std::memory_order_relaxed);
+}
+
+bool runtime_available() noexcept {
+  // Will an rbln_* call be serviced safely now? Needs the thunk loadable and not
+  // shutting down -- true in dummy mode too (dummy host-backs via the runtime, so it
+  // needs librbln-thunk.so); a real device additionally needs a device present.
+  return !runtime_shutting_down_.load(std::memory_order_relaxed) && thunk_loadable() &&
+      (is_dummy_device() || get_device_count_nothrow() > 0);
+}
+
 void* malloc(c10::DeviceIndex device_index, size_t nbytes) {
   RBLN_LOG_DEBUG("logical device=rbln:{}, nbytes={}", static_cast<int>(device_index), nbytes);
   RBLN_CHECK(nbytes > 0, "nbytes must be positive, but got {}", nbytes);
   check_device_index(device_index);
 
+  // Mandatory op -> clean throw (not SEGFAULT) when the real runtime is unavailable
+  // (no-op in dummy). malloc is the gateway, so this stops a workload up front.
+  require_runtime("allocate device memory");
   // to_device_id() enforces that a device is actually available (device_count >
   // 0), so allocation fails cleanly here on a host with no NPU.
   const auto torch_device_id = static_cast<uint32_t>(to_device_id(device_index));
@@ -320,6 +387,7 @@ void free(void* data) {
   RBLN_LOG_DEBUG("data={}", fmt::ptr(data));
   RBLN_CHECK(data != nullptr, "data cannot be nullptr");
 
+  require_runtime("free device memory");
   const auto vaddr = reinterpret_cast<uint64_t>(data);
   RBLN_LOG_DEBUG("Calling rbln_free: vaddr={:#x}", vaddr);
   RBLN_CHECK(
@@ -332,6 +400,15 @@ void free_nothrow(void* data) noexcept {
   // Non-throwing free for the noexcept DataPtr deleter: rbln_free is extern "C"
   // and RBLN_WARN_NOTHROW is itself nothrow, so no try/catch is needed.
   if (data == nullptr) {
+    return;
+  }
+  // Real host with an absent/torn-down runtime: rbln_free would deref a dead
+  // runtime -> SEGFAULT; leak instead. Uses the cheap primitives, NOT
+  // runtime_available(), so this noexcept deleter avoids get_device_count()'s
+  // GIL/Python side effects at teardown (dummy host-backs the free, so proceed).
+  if (!is_dummy_device() && (runtime_shutting_down_.load(std::memory_order_relaxed) || !thunk_loadable())) {
+    RBLN_WARN_NOTHROW(
+        "rbln_free skipped for {}: RBLN runtime unavailable; leaking rather than crashing", fmt::ptr(data));
     return;
   }
   const auto vaddr = reinterpret_cast<uint64_t>(data);
@@ -515,6 +592,10 @@ void memcpy_v2v_async(void* rbln_dst_data, const void* rbln_src_data, size_t nby
 
 void synchronize(c10::DeviceIndex device_index) {
   RBLN_LOG_DEBUG("Synchronizing device {}", static_cast<int>(device_index));
+  // Best-effort: nothing to drain when the runtime is unavailable.
+  if (!runtime_available()) {
+    return;
+  }
   check_device_index(device_index);
   const auto torch_device_id = static_cast<uint32_t>(to_device_id(device_index));
   RBLN_CHECK(
@@ -628,9 +709,12 @@ void return_borrowed(uint64_t borrow_id, bool updated) {
 
 c10::CachingDeviceAllocator::DeviceStats get_device_stats(const c10::Device& device) {
   RBLN_LOG_DEBUG("logical device={}", c10::str(device));
+  // Best-effort query: empty stats when the runtime is unavailable.
+  if (!runtime_available()) {
+    return c10::CachingDeviceAllocator::DeviceStats{};
+  }
   const auto device_index = device.index();
   check_device_index(device_index);
-
   const auto device_id = to_device_id(device_index);
   RBLN_LOG_DEBUG("Calling rbln_get_memory_stats: device_id={}", device_id);
   const auto memory_stats = rbln_get_memory_stats(device_id);
@@ -682,9 +766,12 @@ c10::CachingDeviceAllocator::DeviceStats get_device_stats(const c10::Device& dev
 
 void empty_cache(const c10::Device& device) {
   RBLN_LOG_DEBUG("logical device={}", c10::str(device));
+  // Best-effort: nothing to flush when the runtime is unavailable.
+  if (!runtime_available()) {
+    return;
+  }
   const auto device_index = device.index();
   check_device_index(device_index);
-
   const auto device_id = to_device_id(device_index);
   RBLN_LOG_DEBUG("Calling rbln_empty_cache: device_id={}", device_id);
   RBLN_CHECK(
@@ -695,9 +782,12 @@ void empty_cache(const c10::Device& device) {
 
 std::map<std::string, uint64_t> memory_stats(const c10::Device& device) {
   RBLN_LOG_DEBUG("logical device={}", c10::str(device));
+  // Best-effort query: empty when the runtime is unavailable.
+  if (!runtime_available()) {
+    return {};
+  }
   const auto device_index = device.index();
   check_device_index(device_index);
-
   const auto device_id = to_device_id(device_index);
   RBLN_LOG_DEBUG("Calling rbln_get_memory_stats: rbln:{}, device_id={}", static_cast<int>(device_index), device_id);
   const auto stats = rbln_get_memory_stats(device_id);
@@ -709,9 +799,12 @@ std::map<std::string, uint64_t> memory_stats(const c10::Device& device) {
 
 void reset_accumulated_memory_stats(const c10::Device& device) {
   RBLN_LOG_DEBUG("logical device={}", c10::str(device));
+  // Best-effort: nothing to reset when the runtime is unavailable.
+  if (!runtime_available()) {
+    return;
+  }
   const auto device_index = device.index();
   check_device_index(device_index);
-
   const auto device_id = to_device_id(device_index);
   RBLN_LOG_DEBUG("Calling rbln_reset_accumulated_memory_stats: device_id={}", device_id);
   RBLN_CHECK(
@@ -722,9 +815,13 @@ void reset_accumulated_memory_stats(const c10::Device& device) {
 
 void reset_peak_memory_stats(const c10::Device& device) {
   RBLN_LOG_DEBUG("logical device={}", c10::str(device));
+  // Best-effort: nothing to reset when the runtime is unavailable. (The generic
+  // torch.accelerator.reset_*() have no Python init-guard, so this gate matters.)
+  if (!runtime_available()) {
+    return;
+  }
   const auto device_index = device.index();
   check_device_index(device_index);
-
   const auto device_id = to_device_id(device_index);
   RBLN_LOG_DEBUG("Calling rbln_reset_peak_memory_stats: device_id={}", device_id);
   RBLN_CHECK(

--- a/c10/rbln/RBLNFunctions.cpp
+++ b/c10/rbln/RBLNFunctions.cpp
@@ -291,6 +291,13 @@ namespace {
 
 std::atomic<bool> runtime_shutting_down_{false}; // set at teardown via a Python atexit hook
 
+// True when the runtime cannot be touched at all -- absent thunk or teardown -- as
+// distinct from "no device present", which to_device_id() reports loudly. Lets a
+// teardown-safe op no-op without masking a genuine no-device error.
+bool runtime_torn_down() noexcept {
+  return runtime_shutting_down_.load(std::memory_order_relaxed) || !thunk_loadable();
+}
+
 // Mandatory-op guard: a clean throw instead of a SEGFAULT (no-device is reported
 // separately by to_device_id()). librbln-thunk.so is required even in dummy mode.
 void require_runtime(const char* op) {
@@ -402,11 +409,11 @@ void free_nothrow(void* data) noexcept {
   if (data == nullptr) {
     return;
   }
-  // Real host with an absent/torn-down runtime: rbln_free would deref a dead
-  // runtime -> SEGFAULT; leak instead. Uses the cheap primitives, NOT
-  // runtime_available(), so this noexcept deleter avoids get_device_count()'s
-  // GIL/Python side effects at teardown (dummy host-backs the free, so proceed).
-  if (!is_dummy_device() && (runtime_shutting_down_.load(std::memory_order_relaxed) || !thunk_loadable())) {
+  // Absent/torn-down runtime: rbln_free would deref a dead runtime -> SEGFAULT;
+  // leak instead. Dummy host-backs frees via the runtime too, so it is gated the
+  // same way. Uses the cheap primitives, NOT runtime_available(), so this noexcept
+  // deleter avoids get_device_count()'s GIL/Python side effects at teardown.
+  if (runtime_shutting_down_.load(std::memory_order_relaxed) || !thunk_loadable()) {
     RBLN_WARN_NOTHROW(
         "rbln_free skipped for {}: RBLN runtime unavailable; leaking rather than crashing", fmt::ptr(data));
     return;
@@ -592,8 +599,10 @@ void memcpy_v2v_async(void* rbln_dst_data, const void* rbln_src_data, size_t nby
 
 void synchronize(c10::DeviceIndex device_index) {
   RBLN_LOG_DEBUG("Synchronizing device {}", static_cast<int>(device_index));
-  // Best-effort: nothing to drain when the runtime is unavailable.
-  if (!runtime_available()) {
+  // Nothing to drain if the runtime is torn down (shutdown / absent thunk): no-op
+  // rather than segfault. A genuine no-device host still throws via to_device_id()
+  // below (torch.cuda.synchronize() parity; see RBLNNoDeviceTest).
+  if (runtime_torn_down()) {
     return;
   }
   check_device_index(device_index);
@@ -832,6 +841,12 @@ void reset_peak_memory_stats(const c10::Device& device) {
 
 void set_file_offloading_enabled(bool enabled) {
   RBLN_LOG_DEBUG("Calling rbln_set_file_offloading_enabled: enabled={}", enabled);
+  // Global toggle reachable without any allocation (torch.rbln.offload()), so it is
+  // gated directly: best-effort no-op when the runtime is unavailable (offloading is
+  // meaningless with no device) rather than segfaulting on a compile/CPU-only host.
+  if (!runtime_available()) {
+    return;
+  }
   RBLN_CHECK(
       !::rbln::rbln_set_file_offloading_enabled(enabled),
       "rbln_set_file_offloading_enabled failed (enabled={})",

--- a/c10/rbln/RBLNFunctions.h
+++ b/c10/rbln/RBLNFunctions.h
@@ -150,7 +150,7 @@ C10_RBLN_API c10::DeviceIndex get_device_count_nothrow() noexcept;
 /**
  * @brief Cached nothrow probe: is librbln-thunk.so loadable? Availability signals
  * gate the throwing get_device_count() on this, so a missing runtime degrades to
- * false without a segfault while a malformed config still throws loudly.
+ * false without a segfault; a malformed config still throws when the thunk is present.
  */
 C10_RBLN_API bool thunk_loadable() noexcept;
 

--- a/c10/rbln/RBLNFunctions.h
+++ b/c10/rbln/RBLNFunctions.h
@@ -148,25 +148,15 @@ C10_RBLN_API bool is_dummy_device();
 C10_RBLN_API c10::DeviceIndex get_device_count_nothrow() noexcept;
 
 /**
- * @brief Is the RBLN device runtime (librbln-thunk.so) loaded and usable? Nothrow
- * wrapper over librbln's rbln_runtime_available(). Availability signals gate the
- * throwing get_device_count() on this, so a missing runtime degrades to false
- * without a segfault; a malformed config still throws when the runtime is present.
- */
-C10_RBLN_API bool runtime_loaded() noexcept;
-
-/**
- * @brief Single source of truth: will an rbln_* call be serviced safely now? Needs
- * librbln-thunk.so loadable and not shutting down (dummy mode too -- it host-backs
- * via the runtime); a real device also needs a device present. False when the
- * runtime is absent/torn down. Never throws. CUDA parity.
+ * @brief Single source of truth: can an rbln_* call be serviced safely now?
+ * Runtime loaded (librbln's rbln_runtime_available()), not shutting down, and a
+ * device present -- dummy included (it host-backs via the runtime). Never throws.
  */
 C10_RBLN_API bool runtime_available() noexcept;
 
 /**
  * @brief Mark the runtime as shutting down so late frees / best-effort ops stop
- * dispatching into a possibly-unmapped librbln-thunk.so. Wired to a Python atexit
- * hook; safe to call repeatedly.
+ * dispatching into a possibly-unmapped runtime. Wired to a Python atexit hook.
  */
 C10_RBLN_API void set_runtime_shutting_down(bool value) noexcept;
 

--- a/c10/rbln/RBLNFunctions.h
+++ b/c10/rbln/RBLNFunctions.h
@@ -142,6 +142,34 @@ C10_RBLN_API void set_device_layout_like(void* target_data, const void* ref_data
 C10_RBLN_API bool is_dummy_device();
 
 /**
+ * @brief Nothrow view of get_device_count() (returns 0 on any failure), for the
+ * liveness predicates that must never throw.
+ */
+C10_RBLN_API c10::DeviceIndex get_device_count_nothrow() noexcept;
+
+/**
+ * @brief Cached nothrow probe: is librbln-thunk.so loadable? Availability signals
+ * gate the throwing get_device_count() on this, so a missing runtime degrades to
+ * false without a segfault while a malformed config still throws loudly.
+ */
+C10_RBLN_API bool thunk_loadable() noexcept;
+
+/**
+ * @brief Single source of truth: will an rbln_* call be serviced safely now? Needs
+ * librbln-thunk.so loadable and not shutting down (dummy mode too -- it host-backs
+ * via the runtime); a real device also needs a device present. False when the
+ * runtime is absent/torn down. Never throws. CUDA parity.
+ */
+C10_RBLN_API bool runtime_available() noexcept;
+
+/**
+ * @brief Mark the runtime as shutting down so late frees / best-effort ops stop
+ * dispatching into a possibly-unmapped librbln-thunk.so. Wired to a Python atexit
+ * hook; safe to call repeatedly.
+ */
+C10_RBLN_API void set_runtime_shutting_down(bool value) noexcept;
+
+/**
  * @brief Allocates memory on the specified RBLN device.
  *
  * This function allocates a contiguous block of memory on the given RBLN

--- a/c10/rbln/RBLNFunctions.h
+++ b/c10/rbln/RBLNFunctions.h
@@ -148,9 +148,10 @@ C10_RBLN_API bool is_dummy_device();
 C10_RBLN_API c10::DeviceIndex get_device_count_nothrow() noexcept;
 
 /**
- * @brief Cached nothrow probe: is librbln-thunk.so loadable? Availability signals
- * gate the throwing get_device_count() on this, so a missing runtime degrades to
- * false without a segfault; a malformed config still throws when the thunk is present.
+ * @brief Is the RBLN device runtime (librbln-thunk.so) loaded and usable? Nothrow
+ * wrapper over librbln's rbln_runtime_available(). Availability signals gate the
+ * throwing get_device_count() on this, so a missing runtime degrades to false
+ * without a segfault; a malformed config still throws when the thunk is present.
  */
 C10_RBLN_API bool thunk_loadable() noexcept;
 

--- a/c10/rbln/RBLNFunctions.h
+++ b/c10/rbln/RBLNFunctions.h
@@ -151,9 +151,9 @@ C10_RBLN_API c10::DeviceIndex get_device_count_nothrow() noexcept;
  * @brief Is the RBLN device runtime (librbln-thunk.so) loaded and usable? Nothrow
  * wrapper over librbln's rbln_runtime_available(). Availability signals gate the
  * throwing get_device_count() on this, so a missing runtime degrades to false
- * without a segfault; a malformed config still throws when the thunk is present.
+ * without a segfault; a malformed config still throws when the runtime is present.
  */
-C10_RBLN_API bool thunk_loadable() noexcept;
+C10_RBLN_API bool runtime_loaded() noexcept;
 
 /**
  * @brief Single source of truth: will an rbln_* call be serviced safely now? Needs

--- a/c10/rbln/RBLNHooksInterface.cpp
+++ b/c10/rbln/RBLNHooksInterface.cpp
@@ -32,8 +32,7 @@ bool RBLNHooksInterface::isAvailable() const {
 }
 
 bool RBLNHooksInterface::hasRBLN() const {
-  // isAvailable() must never throw (accelerator-hooks contract); runtime_available()
-  // is nothrow and already true in dummy mode.
+  // Nothrow (accelerator-hooks contract must not throw); true in dummy mode too.
   const bool has_rbln = c10::rbln::runtime_available();
   RBLN_LOG_DEBUG("has_rbln={}", has_rbln);
   return has_rbln;
@@ -50,10 +49,10 @@ c10::Device RBLNHooksInterface::getDeviceFromPtr(void* data) const {
 bool RBLNHooksInterface::hasPrimaryContext(c10::DeviceIndex device_index) const {
   RBLN_LOG_DEBUG("device_index={}", static_cast<int>(device_index));
 
-  // runtime_loaded() first so a missing runtime (incl. dummy) is a clean false (no
-  // segfault); throwing get_device_count() keeps a malformed config loud when present.
+  // Runtime check first so a missing runtime is a clean false (no segfault); throwing
+  // get_device_count() keeps a malformed config loud when the runtime is present.
   const bool has_context =
-      device_index >= 0 && c10::rbln::runtime_loaded() && device_index < c10::rbln::get_device_count();
+      device_index >= 0 && rbln_runtime_available() && device_index < c10::rbln::get_device_count();
   RBLN_LOG_DEBUG("has_context={}", has_context);
   return has_context;
 }

--- a/c10/rbln/RBLNHooksInterface.cpp
+++ b/c10/rbln/RBLNHooksInterface.cpp
@@ -51,7 +51,7 @@ bool RBLNHooksInterface::hasPrimaryContext(c10::DeviceIndex device_index) const 
   RBLN_LOG_DEBUG("device_index={}", static_cast<int>(device_index));
 
   // thunk_loadable() first so a missing runtime (incl. dummy) is a clean false (no
-  // segfault); throwing get_device_count() keeps a malformed config loud.
+  // segfault); throwing get_device_count() keeps a malformed config loud when present.
   const bool has_context =
       device_index >= 0 && c10::rbln::thunk_loadable() && device_index < c10::rbln::get_device_count();
   RBLN_LOG_DEBUG("has_context={}", has_context);

--- a/c10/rbln/RBLNHooksInterface.cpp
+++ b/c10/rbln/RBLNHooksInterface.cpp
@@ -32,14 +32,11 @@ bool RBLNHooksInterface::isAvailable() const {
 }
 
 bool RBLNHooksInterface::hasRBLN() const {
-  try {
-    const bool has_rbln = (c10::rbln::get_device_count() > 0);
-    RBLN_LOG_DEBUG("has_rbln={}", has_rbln);
-    return has_rbln;
-  } catch (const c10::Error& error) {
-    RBLN_LOG_DEBUG("Failed to get device count, returning false: {}", error.msg());
-    return false;
-  }
+  // isAvailable() must never throw (accelerator-hooks contract); runtime_available()
+  // is nothrow and already true in dummy mode.
+  const bool has_rbln = c10::rbln::runtime_available();
+  RBLN_LOG_DEBUG("has_rbln={}", has_rbln);
+  return has_rbln;
 }
 
 c10::Device RBLNHooksInterface::getDeviceFromPtr(void* data) const {
@@ -53,8 +50,10 @@ c10::Device RBLNHooksInterface::getDeviceFromPtr(void* data) const {
 bool RBLNHooksInterface::hasPrimaryContext(c10::DeviceIndex device_index) const {
   RBLN_LOG_DEBUG("device_index={}", static_cast<int>(device_index));
 
-  const auto device_count = c10::rbln::get_device_count();
-  const bool has_context = device_index >= 0 && device_index < device_count;
+  // thunk_loadable() first so a missing runtime (incl. dummy) is a clean false (no
+  // segfault); throwing get_device_count() keeps a malformed config loud.
+  const bool has_context =
+      device_index >= 0 && c10::rbln::thunk_loadable() && device_index < c10::rbln::get_device_count();
   RBLN_LOG_DEBUG("has_context={}", has_context);
   return has_context;
 }

--- a/c10/rbln/RBLNHooksInterface.cpp
+++ b/c10/rbln/RBLNHooksInterface.cpp
@@ -50,10 +50,10 @@ c10::Device RBLNHooksInterface::getDeviceFromPtr(void* data) const {
 bool RBLNHooksInterface::hasPrimaryContext(c10::DeviceIndex device_index) const {
   RBLN_LOG_DEBUG("device_index={}", static_cast<int>(device_index));
 
-  // thunk_loadable() first so a missing runtime (incl. dummy) is a clean false (no
+  // runtime_loaded() first so a missing runtime (incl. dummy) is a clean false (no
   // segfault); throwing get_device_count() keeps a malformed config loud when present.
   const bool has_context =
-      device_index >= 0 && c10::rbln::thunk_loadable() && device_index < c10::rbln::get_device_count();
+      device_index >= 0 && c10::rbln::runtime_loaded() && device_index < c10::rbln::get_device_count();
   RBLN_LOG_DEBUG("has_context={}", has_context);
   return has_context;
 }

--- a/constraints-build-dev.txt
+++ b/constraints-build-dev.txt
@@ -1,2 +1,2 @@
 # Build/dev dependency constraints (single source of truth).
-rebel-compiler==0.11.1.dev185+g828646e3
+rebel-compiler==0.11.1.dev262+gfbe54616

--- a/test/rbln/test_runtime_unavailable.py
+++ b/test/rbln/test_runtime_unavailable.py
@@ -1,14 +1,13 @@
 # Owner(s): ["module: PrivateUse1"]
 
 """Device-runtime liveness gate: torch-rbln must degrade like ``torch.cuda`` when
-the device runtime (``librbln-thunk.so``) is absent or torn down, and must NEVER
+the device runtime is absent or torn down, and must NEVER
 segfault.
 
-Background: torch-rbln links ``librbln.so``, which loads the device runtime
-``librbln-thunk.so``. When the runtime is missing (compile / CPU-only / CI nodes)
-or has been unmapped at interpreter shutdown, a raw ``rbln_*`` call dereferences a
-null handle and SEGFAULTs -- unlike CUDA, where a missing
-driver merely returns an error code. ``c10::rbln::runtime_available()`` is the
+Background: torch-rbln links ``librbln.so``, which loads the device runtime lazily.
+When the runtime is missing (compile / CPU-only / CI nodes) or has been unmapped at
+interpreter shutdown, a raw ``rbln_*`` call dereferences a null handle and SEGFAULTs
+-- unlike CUDA, where a missing driver merely returns an error code. ``c10::rbln::runtime_available()`` is the
 single source of truth that lets best-effort ops no-op, mandatory ops raise a
 clean error, and availability probes return False without raising.
 
@@ -140,15 +139,15 @@ class TestRuntimeUnavailable(TestCase):
         _assert_ok(self, result, "TOGGLE_OK")
 
     def test_runtime_absent_degrades_to_zero_devices(self):
-        """When librbln-thunk.so is genuinely absent, device enumeration degrades to
+        """When the RBLN runtime is genuinely absent, device enumeration degrades to
         0 (nothrow) and is_available() is False -- never a SEGFAULT -- mirroring
         torch.cuda on a host with no driver. The fix is at the source
-        (DeviceMappingManager gates the raw rbln_get_device_count() on runtime_loaded),
+        (DeviceMappingManager gates the raw rbln_get_device_count() on rbln_runtime_available()),
         so a missing runtime collapses into the well-tested no-device path. Skipped where
         the runtime is present (e.g. device-bearing CI); the shutdown-flag tests above
         cover the torn-down half of the gate hardware-free."""
         if torch_rbln._C.runtime_loaded() or torch_rbln._C.is_dummy_device():
-            self.skipTest("requires a host with librbln-thunk.so absent")
+            self.skipTest("requires a host with the RBLN runtime absent")
         result = _run_subprocess(
             """
             assert C.runtime_loaded() is False
@@ -183,7 +182,7 @@ class TestRuntimeUnavailable(TestCase):
 
     def test_dummy_with_runtime_proceeds(self):
         """Dummy mode (``RBLN_DUMMY_DEVICE``) delegates host-backing to the runtime, so
-        with a loadable ``librbln-thunk.so`` device ops proceed and materialize -- the
+        with the runtime loaded, device ops proceed and materialize -- the
         gate passes rather than no-ops."""
         result = _run_subprocess(
             """
@@ -200,7 +199,7 @@ class TestRuntimeUnavailable(TestCase):
 
     def test_dummy_without_runtime_is_gated(self):
         """Dummy mode is NOT exempt from the gate: it host-backs via the runtime, so
-        librbln-thunk.so is still required. When the runtime is unavailable (simulated
+        the runtime is still required. When the runtime is unavailable (simulated
         by the shutdown flag, standing in for a missing runtime), the gate fires --
         best-effort ops no-op and allocation raises a clean error, never a SEGFAULT."""
         result = _run_subprocess(

--- a/test/rbln/test_runtime_unavailable.py
+++ b/test/rbln/test_runtime_unavailable.py
@@ -68,8 +68,10 @@ class TestRuntimeUnavailable(TestCase):
     def test_bindings_exist_and_never_raise(self):
         """The liveness predicate and shutdown hook are exposed and total (nothrow)."""
         self.assertTrue(hasattr(torch_rbln._C, "runtime_available"))
+        self.assertTrue(hasattr(torch_rbln._C, "thunk_loadable"))
         self.assertTrue(hasattr(torch_rbln._C, "_set_runtime_shutting_down"))
         self.assertIsInstance(torch_rbln._C.runtime_available(), bool)
+        self.assertIsInstance(torch_rbln._C.thunk_loadable(), bool)
         # device_count() / is_available() must never raise (CUDA contract).
         self.assertIsInstance(torch.rbln.device_count(), int)
         self.assertIsInstance(torch.rbln.is_available(), bool)
@@ -81,11 +83,11 @@ class TestRuntimeUnavailable(TestCase):
         init-guard, so the C++ leaf gate is the only thing protecting it)."""
         result = _run_subprocess(
             """
-            dummy = C.is_dummy_device()
             C._set_runtime_shutting_down(True)
             assert C.runtime_available() is False, "shutdown flag must force runtime_available False"
-            # torch.rbln.is_available() is False unless in host-backed dummy mode.
-            assert torch.rbln.is_available() is (True if dummy else False)
+            # is_available() reflects runtime liveness, so it is False once shutting
+            # down -- in dummy mode too (dummy is not exempt from the gate).
+            assert torch.rbln.is_available() is False
             assert isinstance(torch.rbln.device_count(), int)  # still nothrow
 
             d = torch.device("rbln", 0)
@@ -106,6 +108,22 @@ class TestRuntimeUnavailable(TestCase):
         )
         _assert_ok(self, result, "GATE_OK")
 
+    def test_file_offloading_no_ops_when_runtime_unavailable(self):
+        """set_file_offloading_enabled (torch.rbln.offload()) is a global toggle
+        reachable with NO prior allocation -- unlike the copy/borrow leaves, which
+        are downstream of a gated malloc -- so it is gated directly: no-op, never a
+        SEGFAULT, when the runtime is unavailable."""
+        result = _run_subprocess(
+            """
+            C._set_runtime_shutting_down(True)
+            assert C.runtime_available() is False
+            C._set_file_offloading_enabled(True)   # best-effort: no-op, must not raise/crash
+            C._set_file_offloading_enabled(False)
+            print("OFFLOAD_OK")
+            """
+        )
+        _assert_ok(self, result, "OFFLOAD_OK")
+
     def test_flag_toggles_runtime_available(self):
         """Setting / clearing the shutdown flag flips runtime_available() and restores it."""
         result = _run_subprocess(
@@ -119,6 +137,32 @@ class TestRuntimeUnavailable(TestCase):
             """
         )
         _assert_ok(self, result, "TOGGLE_OK")
+
+    def test_thunk_absent_degrades_to_zero_devices(self):
+        """When librbln-thunk.so is genuinely absent, device enumeration degrades to
+        0 (nothrow) and is_available() is False -- never a SEGFAULT -- mirroring
+        torch.cuda on a host with no driver. The fix is at the source
+        (DeviceMappingManager gates the raw rbln_get_device_count() on thunk_loadable),
+        so thunk-absent collapses into the well-tested no-device path. Skipped where
+        the thunk is present (e.g. device-bearing CI); the shutdown-flag tests above
+        cover the torn-down half of the gate hardware-free."""
+        if torch_rbln._C.thunk_loadable() or torch_rbln._C.is_dummy_device():
+            self.skipTest("requires a host with librbln-thunk.so absent")
+        result = _run_subprocess(
+            """
+            assert C.thunk_loadable() is False
+            assert torch.rbln.device_count() == 0, "thunk-absent must degrade to 0 devices, not segfault"
+            assert torch.rbln.is_available() is False
+            C.set_device_index(0)  # bookkeeping only: must not throw or segfault
+            try:
+                torch.empty(4, device="rbln:0")  # use fails cleanly at the point of use
+                raise AssertionError("allocation must raise with no device")
+            except RuntimeError:
+                pass
+            print("THUNK_ABSENT_OK")
+            """
+        )
+        _assert_ok(self, result, "THUNK_ABSENT_OK")
 
     def test_dummy_with_runtime_proceeds(self):
         """Dummy mode (``RBLN_DUMMY_DEVICE``) delegates host-backing to the runtime, so

--- a/test/rbln/test_runtime_unavailable.py
+++ b/test/rbln/test_runtime_unavailable.py
@@ -91,7 +91,8 @@ class TestRuntimeUnavailable(TestCase):
             assert isinstance(torch.rbln.device_count(), int)  # still nothrow
 
             d = torch.device("rbln", 0)
-            # RBLN-direct best-effort leaves: no-op, must not raise or crash.
+            # Best-effort leaves no-op; synchronize no-ops under teardown too (it throws
+            # on a live no-device host -- see test_runtime_absent).
             C.empty_cache(d)
             C.synchronize(0)
             C.reset_peak_memory_stats(d)
@@ -154,11 +155,12 @@ class TestRuntimeUnavailable(TestCase):
             assert torch.rbln.device_count() == 0, "runtime-absent must degrade to 0 devices, not segfault"
             assert torch.rbln.is_available() is False
             C.set_device_index(0)  # bookkeeping only: must not throw or segfault
-            try:
-                torch.empty(4, device="rbln:0")  # use fails cleanly at the point of use
-                raise AssertionError("allocation must raise with no device")
-            except RuntimeError:
-                pass
+            for use in (lambda: torch.empty(4, device="rbln:0"), lambda: C.synchronize(0)):
+                try:
+                    use()  # device use fails cleanly at the point of use (torch.cuda parity)
+                    raise AssertionError("device use must raise with no device/runtime")
+                except RuntimeError:
+                    pass
             print("RUNTIME_ABSENT_OK")
             """
         )

--- a/test/rbln/test_runtime_unavailable.py
+++ b/test/rbln/test_runtime_unavailable.py
@@ -164,6 +164,21 @@ class TestRuntimeUnavailable(TestCase):
         )
         _assert_ok(self, result, "THUNK_ABSENT_OK")
 
+        # Dummy is NOT exempt: it host-backs via the runtime (DeviceMappingManager's
+        # rbln_register_device_id), so with the thunk absent enumeration must also
+        # degrade to 0 -- not segfault -- at init, BEFORE any shutdown flag is set.
+        # This covers the init/register path the flag-based tests cannot reach.
+        result = _run_subprocess(
+            """
+            assert C.is_dummy_device() is True and C.thunk_loadable() is False
+            assert torch.rbln.device_count() == 0, "dummy + absent thunk must degrade to 0, not segfault"
+            assert torch.rbln.is_available() is False
+            print("DUMMY_THUNK_ABSENT_OK")
+            """,
+            env_extra={"RBLN_DUMMY_DEVICE": "1"},
+        )
+        _assert_ok(self, result, "DUMMY_THUNK_ABSENT_OK")
+
     def test_dummy_with_runtime_proceeds(self):
         """Dummy mode (``RBLN_DUMMY_DEVICE``) delegates host-backing to the runtime, so
         with a loadable ``librbln-thunk.so`` device ops proceed and materialize -- the

--- a/test/rbln/test_runtime_unavailable.py
+++ b/test/rbln/test_runtime_unavailable.py
@@ -4,15 +4,15 @@
 the device runtime (``librbln-thunk.so``) is absent or torn down, and must NEVER
 segfault.
 
-Background: torch-rbln links ``librbln.so``, which lazily ``dlopen()``s
-``librbln-thunk.so`` on the first device op. When the thunk is missing (compile /
-CPU-only / CI nodes) or has been unmapped at interpreter shutdown, a raw thunk
-call dereferences a null handle and SEGFAULTs -- unlike CUDA, where a missing
+Background: torch-rbln links ``librbln.so``, which loads the device runtime
+``librbln-thunk.so``. When the runtime is missing (compile / CPU-only / CI nodes)
+or has been unmapped at interpreter shutdown, a raw ``rbln_*`` call dereferences a
+null handle and SEGFAULTs -- unlike CUDA, where a missing
 driver merely returns an error code. ``c10::rbln::runtime_available()`` is the
 single source of truth that lets best-effort ops no-op, mandatory ops raise a
 clean error, and availability probes return False without raising.
 
-These tests exercise the whole gate WITHOUT removing the thunk by flipping the
+These tests exercise the whole gate WITHOUT an actually-absent runtime by flipping the
 process-wide "shutting down" flag (``_set_runtime_shutting_down``), which forces
 ``runtime_available()`` to False. That makes the contract testable on any host,
 with or without an NPU. Each test runs in a fresh subprocess so the process-wide
@@ -68,10 +68,10 @@ class TestRuntimeUnavailable(TestCase):
     def test_bindings_exist_and_never_raise(self):
         """The liveness predicate and shutdown hook are exposed and total (nothrow)."""
         self.assertTrue(hasattr(torch_rbln._C, "runtime_available"))
-        self.assertTrue(hasattr(torch_rbln._C, "thunk_loadable"))
+        self.assertTrue(hasattr(torch_rbln._C, "runtime_loaded"))
         self.assertTrue(hasattr(torch_rbln._C, "_set_runtime_shutting_down"))
         self.assertIsInstance(torch_rbln._C.runtime_available(), bool)
-        self.assertIsInstance(torch_rbln._C.thunk_loadable(), bool)
+        self.assertIsInstance(torch_rbln._C.runtime_loaded(), bool)
         # device_count() / is_available() must never raise (CUDA contract).
         self.assertIsInstance(torch.rbln.device_count(), int)
         self.assertIsInstance(torch.rbln.is_available(), bool)
@@ -138,20 +138,20 @@ class TestRuntimeUnavailable(TestCase):
         )
         _assert_ok(self, result, "TOGGLE_OK")
 
-    def test_thunk_absent_degrades_to_zero_devices(self):
+    def test_runtime_absent_degrades_to_zero_devices(self):
         """When librbln-thunk.so is genuinely absent, device enumeration degrades to
         0 (nothrow) and is_available() is False -- never a SEGFAULT -- mirroring
         torch.cuda on a host with no driver. The fix is at the source
-        (DeviceMappingManager gates the raw rbln_get_device_count() on thunk_loadable),
-        so thunk-absent collapses into the well-tested no-device path. Skipped where
-        the thunk is present (e.g. device-bearing CI); the shutdown-flag tests above
+        (DeviceMappingManager gates the raw rbln_get_device_count() on runtime_loaded),
+        so a missing runtime collapses into the well-tested no-device path. Skipped where
+        the runtime is present (e.g. device-bearing CI); the shutdown-flag tests above
         cover the torn-down half of the gate hardware-free."""
-        if torch_rbln._C.thunk_loadable() or torch_rbln._C.is_dummy_device():
+        if torch_rbln._C.runtime_loaded() or torch_rbln._C.is_dummy_device():
             self.skipTest("requires a host with librbln-thunk.so absent")
         result = _run_subprocess(
             """
-            assert C.thunk_loadable() is False
-            assert torch.rbln.device_count() == 0, "thunk-absent must degrade to 0 devices, not segfault"
+            assert C.runtime_loaded() is False
+            assert torch.rbln.device_count() == 0, "runtime-absent must degrade to 0 devices, not segfault"
             assert torch.rbln.is_available() is False
             C.set_device_index(0)  # bookkeeping only: must not throw or segfault
             try:
@@ -159,25 +159,25 @@ class TestRuntimeUnavailable(TestCase):
                 raise AssertionError("allocation must raise with no device")
             except RuntimeError:
                 pass
-            print("THUNK_ABSENT_OK")
+            print("RUNTIME_ABSENT_OK")
             """
         )
-        _assert_ok(self, result, "THUNK_ABSENT_OK")
+        _assert_ok(self, result, "RUNTIME_ABSENT_OK")
 
         # Dummy is NOT exempt: it host-backs via the runtime (DeviceMappingManager's
-        # rbln_register_device_id), so with the thunk absent enumeration must also
+        # rbln_register_device_id), so with the runtime absent enumeration must also
         # degrade to 0 -- not segfault -- at init, BEFORE any shutdown flag is set.
         # This covers the init/register path the flag-based tests cannot reach.
         result = _run_subprocess(
             """
-            assert C.is_dummy_device() is True and C.thunk_loadable() is False
-            assert torch.rbln.device_count() == 0, "dummy + absent thunk must degrade to 0, not segfault"
+            assert C.is_dummy_device() is True and C.runtime_loaded() is False
+            assert torch.rbln.device_count() == 0, "dummy + absent runtime must degrade to 0, not segfault"
             assert torch.rbln.is_available() is False
-            print("DUMMY_THUNK_ABSENT_OK")
+            print("DUMMY_RUNTIME_ABSENT_OK")
             """,
             env_extra={"RBLN_DUMMY_DEVICE": "1"},
         )
-        _assert_ok(self, result, "DUMMY_THUNK_ABSENT_OK")
+        _assert_ok(self, result, "DUMMY_RUNTIME_ABSENT_OK")
 
     def test_dummy_with_runtime_proceeds(self):
         """Dummy mode (``RBLN_DUMMY_DEVICE``) delegates host-backing to the runtime, so
@@ -186,7 +186,7 @@ class TestRuntimeUnavailable(TestCase):
         result = _run_subprocess(
             """
             assert C.is_dummy_device() is True
-            assert C.runtime_available() is True, "dummy with a loadable thunk must be available"
+            assert C.runtime_available() is True, "dummy with a loaded runtime must be available"
             assert torch.rbln.is_available() is True
             t = torch.zeros(4, device="rbln:0")
             assert t.cpu().tolist() == [0.0, 0.0, 0.0, 0.0]
@@ -199,12 +199,12 @@ class TestRuntimeUnavailable(TestCase):
     def test_dummy_without_runtime_is_gated(self):
         """Dummy mode is NOT exempt from the gate: it host-backs via the runtime, so
         librbln-thunk.so is still required. When the runtime is unavailable (simulated
-        by the shutdown flag, standing in for a missing thunk), the gate fires --
+        by the shutdown flag, standing in for a missing runtime), the gate fires --
         best-effort ops no-op and allocation raises a clean error, never a SEGFAULT."""
         result = _run_subprocess(
             """
             assert C.is_dummy_device() is True
-            C._set_runtime_shutting_down(True)  # stand-in for an unavailable runtime (e.g. no thunk)
+            C._set_runtime_shutting_down(True)  # stand-in for an unavailable runtime (e.g. no runtime .so)
             assert C.runtime_available() is False, "dummy must not bypass the runtime gate"
             assert torch.rbln.is_available() is False
             d = torch.device("rbln", 0)
@@ -224,7 +224,7 @@ class TestRuntimeUnavailable(TestCase):
     def test_mandatory_op_raises_clean_error_not_segfault(self):
         """Allocation is a mandatory op: when the runtime is unavailable it must raise
         a clean, catchable RuntimeError (not SEGFAULT). Needs a real device so the
-        allocation would otherwise reach the thunk."""
+        allocation would otherwise reach the runtime."""
         result = _run_subprocess(
             """
             assert torch.rbln.device_count() > 0 and not C.is_dummy_device()
@@ -241,7 +241,7 @@ class TestRuntimeUnavailable(TestCase):
 
     @requires_physical_devices(1)
     def test_runtime_available_true_on_healthy_host(self):
-        """With a device present and the thunk loaded, runtime_available() is True and
+        """With a device present and the runtime loaded, runtime_available() is True and
         best-effort ops actually run (not gated off)."""
         result = _run_subprocess(
             """

--- a/test/rbln/test_runtime_unavailable.py
+++ b/test/rbln/test_runtime_unavailable.py
@@ -1,0 +1,202 @@
+# Owner(s): ["module: PrivateUse1"]
+
+"""Device-runtime liveness gate: torch-rbln must degrade like ``torch.cuda`` when
+the device runtime (``librbln-thunk.so``) is absent or torn down, and must NEVER
+segfault.
+
+Background: torch-rbln links ``librbln.so``, which lazily ``dlopen()``s
+``librbln-thunk.so`` on the first device op. When the thunk is missing (compile /
+CPU-only / CI nodes) or has been unmapped at interpreter shutdown, a raw thunk
+call dereferences a null handle and SEGFAULTs -- unlike CUDA, where a missing
+driver merely returns an error code. ``c10::rbln::runtime_available()`` is the
+single source of truth that lets best-effort ops no-op, mandatory ops raise a
+clean error, and availability probes return False without raising.
+
+These tests exercise the whole gate WITHOUT removing the thunk by flipping the
+process-wide "shutting down" flag (``_set_runtime_shutting_down``), which forces
+``runtime_available()`` to False. That makes the contract testable on any host,
+with or without an NPU. Each test runs in a fresh subprocess so the process-wide
+flag never leaks into other tests.
+"""
+
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+import torch
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+import torch_rbln  # noqa: F401
+from test.utils import requires_physical_devices
+
+
+_PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _run_subprocess(body: str, timeout: int = 90, env_extra=None) -> subprocess.CompletedProcess:
+    # Flat preamble (column 0) + dedented body, so the caller can pass an
+    # indented triple-quoted block without breaking Python's indentation.
+    preamble = f"import sys\nsys.path.insert(0, {_PROJECT_ROOT!r})\nimport torch, torch_rbln\nC = torch_rbln._C\n"
+    script = preamble + textwrap.dedent(body)
+    env = None
+    if env_extra is not None:
+        env = dict(os.environ)
+        for key, value in env_extra.items():
+            if value is None:
+                env.pop(key, None)  # remove a var for a hermetic env
+            else:
+                env[key] = value
+    return subprocess.run(
+        [sys.executable, "-c", script], cwd=_PROJECT_ROOT, capture_output=True, text=True, timeout=timeout, env=env
+    )
+
+
+def _assert_ok(self, result: subprocess.CompletedProcess, marker: str) -> None:
+    self.assertTrue(
+        result.returncode == 0 and marker in result.stdout,
+        f"runtime-liveness contract failed (rc={result.returncode})\n"
+        f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}",
+    )
+
+
+@pytest.mark.test_set_ci
+class TestRuntimeUnavailable(TestCase):
+    """``runtime_available()`` gates every runtime-touching leaf (torch.cuda parity)."""
+
+    def test_bindings_exist_and_never_raise(self):
+        """The liveness predicate and shutdown hook are exposed and total (nothrow)."""
+        self.assertTrue(hasattr(torch_rbln._C, "runtime_available"))
+        self.assertTrue(hasattr(torch_rbln._C, "_set_runtime_shutting_down"))
+        self.assertIsInstance(torch_rbln._C.runtime_available(), bool)
+        # device_count() / is_available() must never raise (CUDA contract).
+        self.assertIsInstance(torch.rbln.device_count(), int)
+        self.assertIsInstance(torch.rbln.is_available(), bool)
+
+    def test_best_effort_ops_no_op_when_runtime_unavailable(self):
+        """empty_cache / memory_stats / reset_* / synchronize no-op (never segfault)
+        when the runtime is unavailable -- both the RBLN-direct leaves and the
+        generic torch.accelerator surface (incl. reset_peak, which has no Python
+        init-guard, so the C++ leaf gate is the only thing protecting it)."""
+        result = _run_subprocess(
+            """
+            dummy = C.is_dummy_device()
+            C._set_runtime_shutting_down(True)
+            assert C.runtime_available() is False, "shutdown flag must force runtime_available False"
+            # torch.rbln.is_available() is False unless in host-backed dummy mode.
+            assert torch.rbln.is_available() is (True if dummy else False)
+            assert isinstance(torch.rbln.device_count(), int)  # still nothrow
+
+            d = torch.device("rbln", 0)
+            # RBLN-direct best-effort leaves: no-op, must not raise or crash.
+            C.empty_cache(d)
+            C.synchronize(0)
+            C.reset_peak_memory_stats(d)
+            C.reset_accumulated_memory_stats(d)
+            assert C.memory_stats(d) == {}, "memory_stats must be empty when unavailable"
+
+            # Generic torch.accelerator surface (the vLLM shutdown path). reset_peak
+            # has NO Python init-guard, so reaching it proves the leaf gate works.
+            torch.accelerator.empty_cache()
+            torch.accelerator.reset_peak_memory_stats()
+
+            print("GATE_OK")
+            """
+        )
+        _assert_ok(self, result, "GATE_OK")
+
+    def test_flag_toggles_runtime_available(self):
+        """Setting / clearing the shutdown flag flips runtime_available() and restores it."""
+        result = _run_subprocess(
+            """
+            before = C.runtime_available()
+            C._set_runtime_shutting_down(True)
+            assert C.runtime_available() is False
+            C._set_runtime_shutting_down(False)
+            assert C.runtime_available() == before, "runtime_available must restore after clearing the flag"
+            print("TOGGLE_OK")
+            """
+        )
+        _assert_ok(self, result, "TOGGLE_OK")
+
+    def test_dummy_with_runtime_proceeds(self):
+        """Dummy mode (``RBLN_DUMMY_DEVICE``) delegates host-backing to the runtime, so
+        with a loadable ``librbln-thunk.so`` device ops proceed and materialize -- the
+        gate passes rather than no-ops."""
+        result = _run_subprocess(
+            """
+            assert C.is_dummy_device() is True
+            assert C.runtime_available() is True, "dummy with a loadable thunk must be available"
+            assert torch.rbln.is_available() is True
+            t = torch.zeros(4, device="rbln:0")
+            assert t.cpu().tolist() == [0.0, 0.0, 0.0, 0.0]
+            print("DUMMY_PROCEEDS_OK")
+            """,
+            env_extra={"RBLN_DUMMY_DEVICE": "1", "RBLN_DEVICE_MAP": None, "RBLN_NPUS_PER_DEVICE": None},
+        )
+        _assert_ok(self, result, "DUMMY_PROCEEDS_OK")
+
+    def test_dummy_without_runtime_is_gated(self):
+        """Dummy mode is NOT exempt from the gate: it host-backs via the runtime, so
+        librbln-thunk.so is still required. When the runtime is unavailable (simulated
+        by the shutdown flag, standing in for a missing thunk), the gate fires --
+        best-effort ops no-op and allocation raises a clean error, never a SEGFAULT."""
+        result = _run_subprocess(
+            """
+            assert C.is_dummy_device() is True
+            C._set_runtime_shutting_down(True)  # stand-in for an unavailable runtime (e.g. no thunk)
+            assert C.runtime_available() is False, "dummy must not bypass the runtime gate"
+            assert torch.rbln.is_available() is False
+            d = torch.device("rbln", 0)
+            C.empty_cache(d); C.synchronize(0)  # best-effort: no-op, no crash
+            try:
+                torch.zeros(4, device="rbln:0")
+                raise AssertionError("allocation must raise when the runtime is unavailable in dummy")
+            except RuntimeError:
+                pass
+            print("DUMMY_GATED_OK")
+            """,
+            env_extra={"RBLN_DUMMY_DEVICE": "1", "RBLN_DEVICE_MAP": None, "RBLN_NPUS_PER_DEVICE": None},
+        )
+        _assert_ok(self, result, "DUMMY_GATED_OK")
+
+    @requires_physical_devices(1)
+    def test_mandatory_op_raises_clean_error_not_segfault(self):
+        """Allocation is a mandatory op: when the runtime is unavailable it must raise
+        a clean, catchable RuntimeError (not SEGFAULT). Needs a real device so the
+        allocation would otherwise reach the thunk."""
+        result = _run_subprocess(
+            """
+            assert torch.rbln.device_count() > 0 and not C.is_dummy_device()
+            C._set_runtime_shutting_down(True)
+            try:
+                torch.empty(4, device="rbln:0")
+                raise AssertionError("allocation must raise when the runtime is unavailable")
+            except RuntimeError as e:
+                assert "runtime" in str(e).lower(), str(e)
+            print("MALLOC_OK")
+            """
+        )
+        _assert_ok(self, result, "MALLOC_OK")
+
+    @requires_physical_devices(1)
+    def test_runtime_available_true_on_healthy_host(self):
+        """With a device present and the thunk loaded, runtime_available() is True and
+        best-effort ops actually run (not gated off)."""
+        result = _run_subprocess(
+            """
+            assert torch.rbln.device_count() > 0
+            assert C.runtime_available() is True, "healthy host with a device must be available"
+            assert torch.rbln.is_available() is True
+            d = torch.device("rbln", 0)
+            C.empty_cache(d)  # real flush, must not raise
+            assert isinstance(C.memory_stats(d), dict)
+            print("HEALTHY_OK")
+            """
+        )
+        _assert_ok(self, result, "HEALTHY_OK")
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/third_party/rebel_compiler/include/rebel/runtime/api/rbln_runtime_api.h
+++ b/third_party/rebel_compiler/include/rebel/runtime/api/rbln_runtime_api.h
@@ -53,6 +53,17 @@ RBLNRetCode rbln_register_device_id(int torch_device_id, int* device_ids, int nu
 RBLNRetCode rbln_get_device_count(int* count);
 
 /**
+ * @brief Reports whether the device runtime (driver) is loaded and usable.
+ *
+ * The driver is loaded lazily and is absent on compile/CPU-only/CI hosts.
+ * Callers gate device ops on this so a missing runtime degrades gracefully
+ * instead of segfaulting. Never throws.
+ *
+ * @return true if the runtime is available; false otherwise.
+ */
+bool rbln_runtime_available(void);
+
+/**
  * @brief Allocates memory on the device, with caching allocator enabled.
  *
  * @details It is an alias to the `rbln_malloc_cache` function.

--- a/torch_rbln/__init__.py
+++ b/torch_rbln/__init__.py
@@ -58,8 +58,8 @@ def torch_backends_entry_point() -> None:
         torch._register_device_module("rbln", torch_rbln.device)
 
         # At interpreter teardown, mark the runtime as shutting down so late frees /
-        # best-effort ops stop dispatching into a possibly-unmapped librbln-thunk.so
-        # (which would SEGFAULT). Best-effort defense; mirrors CUDA teardown handling.
+        # best-effort ops stop dispatching into a possibly-unmapped runtime (which
+        # would SEGFAULT). Best-effort defense; mirrors CUDA teardown handling.
         import atexit
 
         import torch_rbln._C

--- a/torch_rbln/__init__.py
+++ b/torch_rbln/__init__.py
@@ -57,6 +57,15 @@ def torch_backends_entry_point() -> None:
 
         torch._register_device_module("rbln", torch_rbln.device)
 
+        # At interpreter teardown, mark the runtime as shutting down so late frees /
+        # best-effort ops stop dispatching into a possibly-unmapped librbln-thunk.so
+        # (which would SEGFAULT). Best-effort defense; mirrors CUDA teardown handling.
+        import atexit
+
+        import torch_rbln._C
+
+        atexit.register(torch_rbln._C._set_runtime_shutting_down, True)
+
         # Import operators #####################################################
         import torch_rbln._internal.register_ops
 

--- a/torch_rbln/csrc/rbln/Module.cpp
+++ b/torch_rbln/csrc/rbln/Module.cpp
@@ -73,8 +73,8 @@ void register_public_device_api(py::module_& module) {
   module.def(
       "thunk_loadable",
       &c10::rbln::thunk_loadable,
-      "Whether librbln-thunk.so is loadable (cheap dlopen probe); False on a compile/CPU-only host. "
-      "Never raises.");
+      "Whether the RBLN device runtime (librbln-thunk.so) is loaded/usable, via librbln's "
+      "rbln_runtime_available(); False on a compile/CPU-only host. Never raises.");
   module.def(
       "_set_runtime_shutting_down",
       &c10::rbln::set_runtime_shutting_down,

--- a/torch_rbln/csrc/rbln/Module.cpp
+++ b/torch_rbln/csrc/rbln/Module.cpp
@@ -52,9 +52,8 @@ void add_py_method_definitions(std::vector<PyMethodDef>& method_vector, PyMethod
  */
 void register_public_device_api(py::module_& module) {
   module.def("current_device", &c10::rbln::get_device_index, "Get the current device.");
-  // Throwing on purpose: "no hardware/runtime -> 0" is already graceful inside
-  // get_device_count(), but a malformed RBLN_DEVICE_MAP with the runtime present must
-  // be rejected loudly (config error, not graceful degradation). Nothrow variant is internal-only.
+  // Throws on a malformed RBLN_DEVICE_MAP (config error); "no hardware/runtime -> 0"
+  // is already graceful inside get_device_count().
   module.def("device_count", &c10::rbln::get_device_count, "Get the number of devices.");
   module.def("set_device", &c10::rbln::set_device_index, "Set the current device.");
   module.def(
@@ -68,17 +67,16 @@ void register_public_device_api(py::module_& module) {
   module.def(
       "runtime_available",
       &c10::rbln::runtime_available,
-      "Whether the RBLN device runtime (librbln-thunk.so) is loadable/live and a device exists. "
-      "Single source of truth for device-runtime liveness; never raises.");
+      "Single source of truth for device-runtime liveness (loaded, not shutting down, a device exists). "
+      "Never raises.");
   module.def(
       "runtime_loaded",
-      &c10::rbln::runtime_loaded,
-      "Whether the RBLN device runtime (librbln-thunk.so) is loaded/usable, via librbln's "
-      "rbln_runtime_available(); False on a compile/CPU-only host. Never raises.");
+      &rbln_runtime_available,
+      "Whether the RBLN device runtime is loaded (librbln's rbln_runtime_available()). Never raises.");
   module.def(
       "_set_runtime_shutting_down",
       &c10::rbln::set_runtime_shutting_down,
-      "Mark the RBLN runtime as shutting down so late frees/best-effort ops stop dispatching into it.");
+      "Mark the RBLN runtime as shutting down so late ops stop dispatching into it.");
   module.def(
       "_exchange_device",
       &c10::rbln::exchange_device_index,

--- a/torch_rbln/csrc/rbln/Module.cpp
+++ b/torch_rbln/csrc/rbln/Module.cpp
@@ -71,6 +71,11 @@ void register_public_device_api(py::module_& module) {
       "Whether the RBLN device runtime (librbln-thunk.so) is loadable/live and a device exists. "
       "Single source of truth for device-runtime liveness; never raises.");
   module.def(
+      "thunk_loadable",
+      &c10::rbln::thunk_loadable,
+      "Whether librbln-thunk.so is loadable (cheap dlopen probe); False on a compile/CPU-only host. "
+      "Never raises.");
+  module.def(
       "_set_runtime_shutting_down",
       &c10::rbln::set_runtime_shutting_down,
       "Mark the RBLN runtime as shutting down so late frees/best-effort ops stop dispatching into it.");

--- a/torch_rbln/csrc/rbln/Module.cpp
+++ b/torch_rbln/csrc/rbln/Module.cpp
@@ -52,9 +52,9 @@ void add_py_method_definitions(std::vector<PyMethodDef>& method_vector, PyMethod
  */
 void register_public_device_api(py::module_& module) {
   module.def("current_device", &c10::rbln::get_device_index, "Get the current device.");
-  // Throwing on purpose: "no hardware -> 0" is already graceful inside
-  // get_device_count(), but a malformed RBLN_DEVICE_MAP must be rejected loudly
-  // (config error, not graceful degradation). The nothrow variant is internal-only.
+  // Throwing on purpose: "no hardware/runtime -> 0" is already graceful inside
+  // get_device_count(), but a malformed RBLN_DEVICE_MAP with the runtime present must
+  // be rejected loudly (config error, not graceful degradation). Nothrow variant is internal-only.
   module.def("device_count", &c10::rbln::get_device_count, "Get the number of devices.");
   module.def("set_device", &c10::rbln::set_device_index, "Set the current device.");
   module.def(

--- a/torch_rbln/csrc/rbln/Module.cpp
+++ b/torch_rbln/csrc/rbln/Module.cpp
@@ -52,6 +52,9 @@ void add_py_method_definitions(std::vector<PyMethodDef>& method_vector, PyMethod
  */
 void register_public_device_api(py::module_& module) {
   module.def("current_device", &c10::rbln::get_device_index, "Get the current device.");
+  // Throwing on purpose: "no hardware -> 0" is already graceful inside
+  // get_device_count(), but a malformed RBLN_DEVICE_MAP must be rejected loudly
+  // (config error, not graceful degradation). The nothrow variant is internal-only.
   module.def("device_count", &c10::rbln::get_device_count, "Get the number of devices.");
   module.def("set_device", &c10::rbln::set_device_index, "Set the current device.");
   module.def(
@@ -62,6 +65,15 @@ void register_public_device_api(py::module_& module) {
       "is_dummy_device",
       &c10::rbln::is_dummy_device,
       "Whether host-backed dummy device mode (RBLN_DUMMY_DEVICE) is active.");
+  module.def(
+      "runtime_available",
+      &c10::rbln::runtime_available,
+      "Whether the RBLN device runtime (librbln-thunk.so) is loadable/live and a device exists. "
+      "Single source of truth for device-runtime liveness; never raises.");
+  module.def(
+      "_set_runtime_shutting_down",
+      &c10::rbln::set_runtime_shutting_down,
+      "Mark the RBLN runtime as shutting down so late frees/best-effort ops stop dispatching into it.");
   module.def(
       "_exchange_device",
       &c10::rbln::exchange_device_index,

--- a/torch_rbln/csrc/rbln/Module.cpp
+++ b/torch_rbln/csrc/rbln/Module.cpp
@@ -71,8 +71,8 @@ void register_public_device_api(py::module_& module) {
       "Whether the RBLN device runtime (librbln-thunk.so) is loadable/live and a device exists. "
       "Single source of truth for device-runtime liveness; never raises.");
   module.def(
-      "thunk_loadable",
-      &c10::rbln::thunk_loadable,
+      "runtime_loaded",
+      &c10::rbln::runtime_loaded,
       "Whether the RBLN device runtime (librbln-thunk.so) is loaded/usable, via librbln's "
       "rbln_runtime_available(); False on a compile/CPU-only host. Never raises.");
   module.def(

--- a/torch_rbln/device/device.py
+++ b/torch_rbln/device/device.py
@@ -78,13 +78,16 @@ def physical_device_count() -> int:
 
 
 def is_available() -> bool:
-    """
-    Check if any RBLN devices are available.
+    """Whether RBLN is usable as an accelerator (``torch.cuda.is_available()`` parity).
 
-    Returns:
-        bool: True if at least one RBLN device is available, False otherwise.
+    ``True`` when the device runtime (``librbln-thunk.so``, required even in dummy
+    mode) is loadable with a device; ``False`` when it is absent/torn down. Raises on
+    a malformed ``RBLN_*`` config (like :func:`device_count`), which torch's
+    ``is_privateuse1_backend_available()`` relies on.
     """
-    return device_count() > 0
+    # device_count() raises on a malformed RBLN_* config (loud); runtime_available()
+    # then reflects real liveness (thunk loadable, not shutting down), dummy included.
+    return torch_rbln._C.device_count() > 0 and torch_rbln._C.runtime_available()
 
 
 def is_dummy_device() -> bool:

--- a/torch_rbln/device/device.py
+++ b/torch_rbln/device/device.py
@@ -81,12 +81,12 @@ def is_available() -> bool:
     """Whether RBLN is usable as an accelerator (``torch.cuda.is_available()`` parity).
 
     ``True`` when the device runtime (``librbln-thunk.so``, required even in dummy
-    mode) is loadable with a device; ``False`` when it is absent/torn down. Raises on
-    a malformed ``RBLN_*`` config (like :func:`device_count`), which torch's
-    ``is_privateuse1_backend_available()`` relies on.
+    mode) is loadable with a device; ``False`` when it is absent/torn down. With the
+    runtime present, raises on a malformed ``RBLN_*`` config (like :func:`device_count`),
+    which torch's ``is_privateuse1_backend_available()`` relies on.
     """
-    # device_count() raises on a malformed RBLN_* config (loud); runtime_available()
-    # then reflects real liveness (thunk loadable, not shutting down), dummy included.
+    # device_count() raises on a malformed RBLN_* config when the thunk is present
+    # (loud); runtime_available() reflects liveness (thunk loadable, not shutting down).
     return torch_rbln._C.device_count() > 0 and torch_rbln._C.runtime_available()
 
 

--- a/torch_rbln/device/device.py
+++ b/torch_rbln/device/device.py
@@ -85,8 +85,8 @@ def is_available() -> bool:
     runtime present, raises on a malformed ``RBLN_*`` config (like :func:`device_count`),
     which torch's ``is_privateuse1_backend_available()`` relies on.
     """
-    # device_count() raises on a malformed RBLN_* config when the thunk is present
-    # (loud); runtime_available() reflects liveness (thunk loadable, not shutting down).
+    # device_count() raises on a malformed RBLN_* config when the runtime is present
+    # (loud); runtime_available() reflects liveness (runtime loaded, not shutting down).
     return torch_rbln._C.device_count() > 0 and torch_rbln._C.runtime_available()
 
 

--- a/torch_rbln/device/device.py
+++ b/torch_rbln/device/device.py
@@ -80,13 +80,10 @@ def physical_device_count() -> int:
 def is_available() -> bool:
     """Whether RBLN is usable as an accelerator (``torch.cuda.is_available()`` parity).
 
-    ``True`` when the device runtime (``librbln-thunk.so``, required even in dummy
-    mode) is loadable with a device; ``False`` when it is absent/torn down. With the
-    runtime present, raises on a malformed ``RBLN_*`` config (like :func:`device_count`),
+    ``False`` when the runtime is absent/torn down or no device is present. Raises on a
+    malformed ``RBLN_*`` config when the runtime is present (like :func:`device_count`),
     which torch's ``is_privateuse1_backend_available()`` relies on.
     """
-    # device_count() raises on a malformed RBLN_* config when the runtime is present
-    # (loud); runtime_available() reflects liveness (runtime loaded, not shutting down).
     return torch_rbln._C.device_count() > 0 and torch_rbln._C.runtime_available()
 
 


### PR DESCRIPTION
## Problem

`torch-rbln` registers itself as the PrivateUse1 accelerator at `import` (via the `torch.backends` autoload entry point), so torch's device-agnostic APIs dispatch into it even when no device tensor is ever created. It links `librbln.so`, which loads the device runtime (driver) lazily. When that runtime is absent (compile / CPU-only / CI hosts) or torn down at interpreter shutdown, a raw `rbln_*` call dereferences a null handle → **uncatchable SEGFAULT** — unlike CUDA, where a missing driver returns an error code. vLLM's shutdown `torch.accelerator.empty_cache()` hits exactly this ([vllm-rbln#756](https://github.com/RBLN-SW/vllm-rbln/pull/756)).

## Solution

One nothrow liveness predicate — `runtime_available()` (runtime loaded, not shutting down, a device present) — is the single source of truth. It gates the runtime **entry points**, not every raw call, because most raw calls can't be reached with a dead runtime:

| op class | when the runtime is unavailable |
|---|---|
| best-effort entry points (`empty_cache` / `memory_stats` / `reset_*` / `set_file_offloading_enabled`) | **no-op** |
| `malloc` (allocation is the gateway) | **clean `RuntimeError`** via `require_runtime()` |
| `synchronize` | **throws when no device is usable** (no driver or no NPU; `torch.cuda` parity); no-op only on teardown |
| availability (`is_available` / `device_count` / `initialized` / `hasPrimaryContext`) | derive from it, **never segfault** |

`torch.accelerator.empty_cache()` then no-ops through torch's own `initialized()` guard, so **vLLM can drop its `empty_cache` monkeypatch**. A Python `atexit` hook flags shutdown so late frees leak instead of crashing at teardown.

**Runtime-loaded state comes from librbln.** The gate calls librbln's own `rbln_runtime_available()` ([rebel_compiler#12029](https://github.com/rebellions-sw/rebel_compiler/pull/12029)) directly, rather than torch-rbln probing the driver `.so` itself — authoritative (reflects librbln's real symbol-load state) and with no `dlopen`/soname coupling. Requires `rebel-compiler>=0.11.1.dev262+gfbe54616`.

**Why not gate every raw leaf?** The copy / borrow / layout leaves (`memcpy_*`, `borrow_host_ptr`, `set_device_layout_like`, …) all take a device address, which only exists after a successful `malloc` — and `malloc` is gated. So a dead runtime makes them unreachable; gating them would be dead code. The one runtime leaf reachable *without* an allocation is `set_file_offloading_enabled` (via `torch.rbln.offload()`), so it is gated directly.

**Root-cause fix for availability:** `device_count()` reaches a raw `rbln_get_device_count()` / (dummy) `rbln_register_device_id()` in `DeviceMappingManager`, so it would segfault before any Python-level guard. Enumeration is now gated on `rbln_runtime_available()` (before the dummy branch too) and degrades to 0 logical devices — fixing every enumeration entry point at the source (`torch.cuda.device_count() == 0` parity).

### Two failure modes, kept distinct

- **Runtime absent / torn down** → degrade gracefully (no-op / clean error / 0 devices).
- **Malformed `RBLN_DEVICE_MAP` / `RBLN_NPUS_PER_DEVICE`** → stay **loud** *when the runtime is present*: enumeration reaches config parse and throws (torch's `is_privateuse1_backend_available()` relies on this). With the runtime absent, enumeration degrades to 0 before parse — there is no device to configure anyway.

### Dummy mode

`RBLN_DUMMY_DEVICE` host-backs via the runtime, so it needs the runtime too — it is gated the **same** way everywhere (enumeration, allocation, free), proceeding when the runtime is present and degrading cleanly when not, not exempt.

## Testing

`test/rbln/test_runtime_unavailable.py` simulates a torn-down runtime via a process-wide shutdown flag (hardware-independent, runs in CI): best-effort no-op, `set_file_offloading_enabled` no-op, mandatory clean-throw, `is_available()` False, and dummy gating. A self-skipping test covers genuine runtime-absence (real + dummy) on compile-only lanes; `RBLNNoDeviceTest` covers the no-device `synchronize`/`malloc` throw contract. The full core suite (`test_device_mapping` / `test_no_device` / `test_dummy_device` / `test_file_offloading`) passes.

* Related to vllm-rbln#756, rebel_compiler#12029

🤖 Generated with [Claude Code](https://claude.com/claude-code)
