### PR TITLE
chore: rename RBLN_TARGET_SOC to RBLN_FORCE_NPU_NAME

### DIFF
--- a/test/cpp/core/RBLNDummyDeviceTest.cpp
+++ b/test/cpp/core/RBLNDummyDeviceTest.cpp
@@ -10,7 +10,7 @@
 //
 // The env MUST be set before the DeviceMappingManager singleton initializes (it
 // reads the flags once at init). A file-scope static initializer sets them
-// before main(). RBLN_TARGET_SOC is set too: with no NPU to probe, dummy
+// before main(). RBLN_FORCE_NPU_NAME is set too: with no NPU to probe, dummy
 // registration resolves the target SoC from it.
 #include <c10/rbln/DeviceMappingManager.h>
 #include <c10/rbln/RBLNFunctions.h>
@@ -26,7 +26,7 @@ namespace {
 [[maybe_unused]] const int kSetDummyEnv = []() {
   setenv("RBLN_DUMMY_DEVICE", "1", /*overwrite=*/1);
   setenv("RBLN_DEVICE_MAP", "[0],[1]", /*overwrite=*/1);
-  setenv("RBLN_TARGET_SOC", "RBLN-CA25", /*overwrite=*/1);
+  setenv("RBLN_FORCE_NPU_NAME", "RBLN-CA25", /*overwrite=*/1);
   return 0;
 }();
 } // namespace

--- a/test/models/test_transformers.py
+++ b/test/models/test_transformers.py
@@ -125,7 +125,7 @@ class TestCausalLMBase(TestCase):
         self.assertEqual(outputs.size(), (batch_size, seq_len + self.max_new_tokens))
         return outputs
 
-    # RBLN runs 16-bit ops in DLFloat16 and matches an fp32 CPU reference to within
+    # RBLN runs 16-bit ops in custom float and matches an fp32 CPU reference to within
     # ~1.3 logits (measured); a real regression diverges by orders of magnitude.
     LOGIT_ATOL = 3.0
 
@@ -150,7 +150,7 @@ class TestCausalLMBase(TestCase):
         """Compare RBLN's next-token logits against an fp32 CPU reference (ground truth).
 
         Greedy token-id equality between RBLN and a same-dtype CPU run is too strict: the
-        two are different 16-bit formats (RBLN DLFloat16 vs CPU bfloat16) and disagree by
+        two are different 16-bit formats (RBLN custom float vs CPU bfloat16) and disagree by
         a few logits even when both are correct, which flips near-tie argmaxes and cascades
         during generation (an intermittent failure). We instead check that RBLN tracks the
         fp32 truth, where its deviation is small and bounded by its own precision. Configs

--- a/test/models/test_vllm_llm.py
+++ b/test/models/test_vllm_llm.py
@@ -389,7 +389,7 @@ def test_vllm_compile_only_no_npu_via_dummy(tmp_path):
         env.pop(key, None)
     env.update(
         RBLN_DUMMY_DEVICE="1",
-        RBLN_TARGET_SOC="RBLN-CA25",
+        RBLN_FORCE_NPU_NAME="RBLN-CA25",
         VLLM_RBLN_USE_VLLM_MODEL="1",
         VLLM_RBLN_COMPILE_ONLY="1",
         VLLM_CACHE_ROOT=str(tmp_path / "vllm_cache"),
@@ -481,7 +481,7 @@ def test_vllm_dummy_compiled_runs_on_real_npu(tmp_path):
         p1_env.pop(key, None)
     p1_env.update(
         RBLN_DUMMY_DEVICE="1",
-        RBLN_TARGET_SOC=npu,
+        RBLN_FORCE_NPU_NAME=npu,
         VLLM_RBLN_USE_VLLM_MODEL="1",
         VLLM_RBLN_COMPILE_ONLY="1",
         VLLM_CACHE_ROOT=cache,
@@ -498,7 +498,7 @@ def test_vllm_dummy_compiled_runs_on_real_npu(tmp_path):
 
     # Phase 2: load those dummy-built artifacts on the real NPU and generate.
     p2_env = dict(os.environ)
-    for key in ("RBLN_DUMMY_DEVICE", "RBLN_TARGET_SOC", "VLLM_RBLN_COMPILE_ONLY"):
+    for key in ("RBLN_DUMMY_DEVICE", "RBLN_FORCE_NPU_NAME", "VLLM_RBLN_COMPILE_ONLY"):
         p2_env.pop(key, None)
     p2_env.update(
         VLLM_RBLN_USE_VLLM_MODEL="1",

--- a/test/rbln/test_dummy_device.py
+++ b/test/rbln/test_dummy_device.py
@@ -8,8 +8,8 @@ on a host without hardware. Allocations and copies are backed by rebel's
 v-memory host mirror through a dummy runtime context; torch adds no host-memory
 shim of its own. It is forced regardless of physical NPU presence.
 
-Dummy mode registers the device against RBLN_TARGET_SOC (there is no NPU to
-probe for the SoC), so RBLN_TARGET_SOC must be set alongside RBLN_DUMMY_DEVICE.
+Dummy mode registers the device against RBLN_FORCE_NPU_NAME (there is no NPU to
+probe for the SoC), so RBLN_FORCE_NPU_NAME must be set alongside RBLN_DUMMY_DEVICE.
 
 RBLN_DUMMY_DEVICE must be set before ``import torch_rbln`` (the device-mapping
 singleton reads it once at init), so each case runs in a fresh subprocess with
@@ -34,7 +34,7 @@ def _clean_env() -> dict:
       - RBLN_DEVICE_MAP / RBLN_NPUS_PER_DEVICE: a parent shell/CI mapping would
         change the dummy logical device count; tests assume the default of 1 and
         set their own map via ``env_extra`` when they need one.
-      - RBLN_TARGET_SOC / RBLN_DEVICES: both feed get_npu_name() and thus the
+      - RBLN_FORCE_NPU_NAME / RBLN_DEVICES: both feed get_npu_name() and thus the
         resolved compile target; a parent-set value would flip the no-NPU cases
         below. Tests set these explicitly via ``env_extra`` when they need them.
     """
@@ -43,7 +43,7 @@ def _clean_env() -> dict:
         "TORCH_RBLN_DIAGNOSE",
         "RBLN_DEVICE_MAP",
         "RBLN_NPUS_PER_DEVICE",
-        "RBLN_TARGET_SOC",
+        "RBLN_FORCE_NPU_NAME",
         "RBLN_DEVICES",
     ):
         env.pop(key, None)
@@ -54,9 +54,9 @@ def _run_with_dummy(snippet: str, env_extra: dict | None = None) -> subprocess.C
     env = _clean_env()
     env["RBLN_DUMMY_DEVICE"] = "1"
     # Dummy mode registers the device with the runtime, which resolves the target
-    # SoC from RBLN_TARGET_SOC (no NPU to probe). Provide a default; tests may
+    # SoC from RBLN_FORCE_NPU_NAME (no NPU to probe). Provide a default; tests may
     # override via env_extra.
-    env["RBLN_TARGET_SOC"] = "RBLN-CA25"
+    env["RBLN_FORCE_NPU_NAME"] = "RBLN-CA25"
     if env_extra:
         env.update(env_extra)
     return subprocess.run(
@@ -361,7 +361,7 @@ def test_device_map_shapes(device_map, expected_count, expected_ids0):
     assert "OK" in proc.stdout
 
 
-# A physical device id past any realistic host's range. With RBLN_TARGET_SOC set,
+# A physical device id past any realistic host's range. With RBLN_FORCE_NPU_NAME set,
 # dummy registration takes the SoC from the env instead of probing hardware, so
 # this id is a pure shape marker and no real NPU is ever touched -- the no-device
 # path is exercised even on a machine that physically has NPUs.
@@ -396,12 +396,12 @@ print("OK")
 """
 
 
-def test_compile_only_uses_target_soc_when_no_npu_option():
-    # No `npu` option: the compile target is resolved from RBLN_TARGET_SOC (the SoC
+def test_compile_only_uses_force_npu_name_when_no_npu_option():
+    # No `npu` option: the compile target is resolved from RBLN_FORCE_NPU_NAME (the SoC
     # dummy mode registers against), and a .rbln artifact is written for it.
     proc = _run_with_dummy(
         _COMPILE_ONLY_SNIPPET,
-        env_extra={"RBLN_TARGET_SOC": "RBLN-CA25", "RBLN_DEVICE_MAP": _NO_NPU_MAP},
+        env_extra={"RBLN_FORCE_NPU_NAME": "RBLN-CA25", "RBLN_DEVICE_MAP": _NO_NPU_MAP},
     )
     _assert_ok(proc)
     assert "OK" in proc.stdout
@@ -411,13 +411,13 @@ def test_compile_only_uses_target_soc_when_no_npu_option():
     assert "differs from" not in out, proc.stderr
 
 
-def test_compile_only_npu_option_overrides_target_soc():
-    # An explicit `npu` option wins over RBLN_TARGET_SOC: the artifact targets the
+def test_compile_only_npu_option_overrides_force_npu_name():
+    # An explicit `npu` option wins over RBLN_FORCE_NPU_NAME: the artifact targets the
     # requested SoC and rebel warns that it differs from the registered machine SoC.
     proc = _run_with_dummy(
         _COMPILE_ONLY_SNIPPET,
         env_extra={
-            "RBLN_TARGET_SOC": "RBLN-CA25",
+            "RBLN_FORCE_NPU_NAME": "RBLN-CA25",
             "RBLN_DUMMY_TEST_NPU": "RBLN-CR03",
             "RBLN_DEVICE_MAP": _NO_NPU_MAP,
         },
@@ -693,7 +693,7 @@ import glob, os
 import torch, torch_rbln
 from rebel._C import get_npu_name
 
-npu = get_npu_name(0)  # dummy mode: resolves to RBLN_TARGET_SOC (the real machine SoC)
+npu = get_npu_name(0)  # dummy mode: resolves to RBLN_FORCE_NPU_NAME (the real machine SoC)
 print("NPU", npu)
 """
     + _DECODER_MODEL
@@ -765,8 +765,8 @@ def test_dummy_compiled_prefill_decode_runs_on_real_npu(tmp_path):
         pytest.skip("no NPU available to compile/run the decoder against")
 
     cache = str(tmp_path / "cache")
-    # Dummy compile targets the real machine SoC via RBLN_TARGET_SOC; no NPU is opened.
-    proc = _run_with_dummy(_DECODER_COMPILE.format(cache=cache), env_extra={"RBLN_TARGET_SOC": npu})
+    # Dummy compile targets the real machine SoC via RBLN_FORCE_NPU_NAME; no NPU is opened.
+    proc = _run_with_dummy(_DECODER_COMPILE.format(cache=cache), env_extra={"RBLN_FORCE_NPU_NAME": npu})
     _assert_ok(proc)
     assert "OK" in proc.stdout
 


### PR DESCRIPTION
rebel-compiler renamed the target-SoC env var to `RBLN_FORCE_NPU_NAME`, keeping `RBLN_TARGET_SOC` as a deprecated alias. Update the tests that set it to the new name so they no longer trip the deprecation warning. Mirrors the vllm-rbln rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)