### PR TITLE
test(dummy): run dummy-device coverage in CI

### DIFF
--- a/test/rbln/test_dummy_device.py
+++ b/test/rbln/test_dummy_device.py
@@ -24,6 +24,9 @@ import textwrap
 import pytest
 
 
+pytestmark = pytest.mark.test_set_ci
+
+
 def _clean_env() -> dict:
     """A hermetic env copy for subprocess tests.
 
@@ -746,6 +749,7 @@ print("OK")
 )
 
 
+@pytest.mark.single_worker
 def test_dummy_compiled_prefill_decode_runs_on_real_npu(tmp_path):
     # End-to-end purpose of dummy mode: prefill/decode graphs compiled with no NPU
     # (allocations host-backed by rebel v-memory, no device opened) must load and run


### PR DESCRIPTION
## Summary of Changes

- Include all dummy-device tests in the default CI suite.
- Run the real-NPU end-to-end test with a single worker.

---

## Type of Change

- [x] `fix` — Bug fix
- [x] `other` — Test coverage and CI scheduling

---

## How to Test (if applicable)

1. Run `lintrunner test/rbln/test_dummy_device.py`.
2. Collect tests using the CI marker expressions.
3. Verify that 35 tests run in parallel and 1 real-NPU E2E test runs serially.

---

## Notes

This PR only changes test selection and scheduling. Runtime behavior is unchanged.