### PR TITLE
feat(memory): add torch.rbln.physical_shape to query the compiler-assigned layout

### DIFF
--- a/test/rbln/test_physical_shape.py
+++ b/test/rbln/test_physical_shape.py
@@ -49,3 +49,9 @@ class TestPhysicalShape:
         pv = torch.rbln.physical_shape(out)
         assert pv != ()
         assert math.prod(pv) >= out.numel()
+
+
+if __name__ == "__main__":
+    from torch.testing._internal.common_utils import run_tests
+
+    run_tests()

--- a/test/rbln/test_physical_shape.py
+++ b/test/rbln/test_physical_shape.py
@@ -1,0 +1,51 @@
+# Owner(s): ["module: PrivateUse1"]
+
+"""Tests for ``torch.rbln.physical_shape(tensor)`` — the compiler-assigned
+physical shape of an RBLN tensor's allocation (may differ from ``tensor.shape``;
+``()`` when no physical view is bound)."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+
+import torch_rbln  # noqa: F401  # binds the RBLN device + torch.rbln namespace
+
+
+DEVICE = torch.device("rbln:0")
+
+
+@pytest.mark.test_set_ci
+class TestPhysicalShape:
+    def test_api_visible(self):
+        assert hasattr(torch.rbln, "physical_shape")
+        assert callable(torch.rbln.physical_shape)
+
+    def test_cpu_tensor_raises(self):
+        with pytest.raises(RuntimeError, match="must be an RBLN tensor"):
+            torch.rbln.physical_shape(torch.zeros(2, 3))
+
+    def test_unbound_tensor_is_empty(self):
+        # A bare allocation has no physical view bound yet.
+        assert torch.rbln.physical_shape(torch.zeros(2, 4, 8, device=DEVICE)) == ()
+
+    def test_view_resolves_to_owning_allocation(self):
+        base = torch.zeros(2, 4, 8, device=DEVICE)
+        view = base.permute(2, 0, 1)
+        assert torch.rbln.physical_shape(view) == torch.rbln.physical_shape(base)
+
+    def test_materialized_op_exposes_real_physical_layout(self):
+        # A device-run, materialized op output carries a physical view that can
+        # differ from the logical shape (compiler tiling/relayout): a (128, 256)
+        # matmul is physically e.g. (128, 4, 64). Assert it is populated and a
+        # faithful relayout (same element count), without pinning the exact
+        # compiler-version-dependent shape.
+        out = torch.randn(128, 64, device=DEVICE, dtype=torch.bfloat16) @ torch.randn(
+            64, 256, device=DEVICE, dtype=torch.bfloat16
+        )
+        out.cpu()  # force execution so the physical view binds
+        pv = torch.rbln.physical_shape(out)
+        assert pv != ()
+        assert math.prod(pv) >= out.numel()

--- a/torch_rbln/csrc/rbln/Module.cpp
+++ b/torch_rbln/csrc/rbln/Module.cpp
@@ -175,6 +175,18 @@ void register_internal_api(py::module_& module) {
       },
       "Internal: configure target's device layout like ref (no data copy)");
 
+  // Compiler-assigned physical shape of a tensor's allocation (may differ from
+  // the logical shape; empty when no physical view is bound). Resolves a view
+  // to its owning allocation via the existing get_memory_info().
+  module.def(
+      "_physical_shape",
+      [](const at::Tensor& t) -> std::vector<int64_t> {
+        TORCH_CHECK(t.device().is_privateuseone(), "physical_shape: tensor must be an RBLN tensor, got ", t.device());
+        return c10::rbln::get_memory_info(t.data_ptr()).physical_shape;
+      },
+      "Internal: compiler-assigned physical shape of an RBLN tensor "
+      "(empty if no physical view is bound yet)");
+
   // Logging utilities
   module.def("_log_cpu_fallback", &c10::rbln::log_cpu_fallback, "Internal: log CPU fallback");
 

--- a/torch_rbln/memory.py
+++ b/torch_rbln/memory.py
@@ -16,6 +16,7 @@ import torch_rbln._C
 __all__ = [
     "empty_cache",
     "set_device_layout_like",
+    "physical_shape",
     "max_memory_allocated",
     "max_memory_reserved",
     "memory_allocated",
@@ -60,6 +61,16 @@ def set_device_layout_like(target: torch.Tensor, ref: torch.Tensor) -> None:
     the bulk upload and the per-slot device-to-device scatter are both fast.
     """
     torch_rbln._C._set_device_layout_like(target, ref)
+
+
+def physical_shape(tensor: torch.Tensor) -> "tuple[int, ...]":
+    """Compiler-assigned physical shape of an RBLN tensor's allocation.
+
+    May differ from ``tensor.shape`` (the compiler tiles/relays out); ``()`` when
+    no physical view is bound. Lets a consumer check a device tensor's on-device
+    layout against what it declared.
+    """
+    return tuple(torch_rbln._C._physical_shape(tensor))
 
 
 def _no_rbln_device() -> bool:


### PR DESCRIPTION
## Why

RBLN is a *compiler-decides-layout* backend (physical ≠ logical), like XLA — the KV cache's physical layout is chosen by the compiler and can differ from `tensor.shape`. Today the layout is hand-declared in several places (backend `get_kv_cache_shape`, the attention kernel strides, and each KV consumer such as LMCache), with nothing checking they agree. When they drift, the kernel reads the wrong addresses → **silent KV corruption**.

This adds the *read* side of the XLA-style "layout as a queryable property" model: let consumers ask the runtime what physical layout it actually allocated, so they can verify it matches what they declared and fail loudly on mismatch. Context: fsw-inference#381.

## What

- **`torch.rbln.physical_shape(tensor) -> tuple[int, ...]`** (`torch_rbln/memory.py`): the compiler-assigned physical shape of an RBLN tensor's allocation. Returns `()` when no physical view is bound yet (e.g. before warm-up / first compile). Read-only — exposes the layout, never a raw v-mem handle. Reachable as `torch.rbln.physical_shape` via the existing device-module star-import.
- **`_physical_shape` internal binding** (`csrc/rbln/Module.cpp`): thin wrapper over the existing `c10::rbln::get_memory_info(data_ptr).physical_shape`, mirroring the `_set_device_layout_like` seam. Rejects non-RBLN tensors; `get_memory_info` resolves a view's `data_ptr` back to its owning allocation.
- No new C++ machinery — surfaces data the runtime already tracks.

## Testing

- `test/rbln/test_physical_shape.py` (`test_set_ci`): API visibility, CPU-tensor rejection, tuple/return contract, and view→owning-allocation resolution. The non-empty success path (physical shape of a bound KV cache matching the declared layout) is deferred to the consumer integration, mirroring `test_set_device_layout_like`.
- ruff / isort / clang-format clean.
- **End-to-end**: consumed by the vllm-rbln warm-up layout-drift check on real serves — Qwen3-1.7B (**28/28 layers**) and MiniMax-M2.5 (**62/62 layers, DP4+EP**), **0 drift** on both (physical layout == declared).

🤖 Generated with [Claude Code](https://claude.com/claude-code)