### PR TITLE
fix(rbln): preserve compiled nn.Module attrs and flush warm cache on reset

### DIFF
--- a/test/rbln/test_torch_compile_patch.py
+++ b/test/rbln/test_torch_compile_patch.py
@@ -800,6 +800,22 @@ class TestCompiledFunctionWrapper(TestCase):
         self.assertIs(seen["args"][0], c)  # self bound
         self.assertIsInstance(C.method, CompiledFunctionWrapper)  # class access returns wrapper
 
+    def test_wrapper_module_not_bound_as_method_descriptor(self):
+        """A compiled nn.Module (or other callable object) stored as a class attribute must
+        NOT get the owner bound as its first arg: __get__ returns the wrapper as-is. Regression
+        -- the descriptor used to prepend the owner unconditionally, so `H().model(x)` would
+        call the module as `model(H(), x)` instead of `model(x)`."""
+        model = torch.nn.Linear(4, 4)
+        wrapper = CompiledFunctionWrapper(lambda *a, **k: None, model, Mock(), compile_kwargs={})
+
+        class Holder:
+            m = wrapper
+
+        # Instance access fires the descriptor but must return the wrapper itself, not a
+        # functools.partial that would inject the Holder instance as the first positional arg.
+        self.assertIs(Holder().m, wrapper)
+        self.assertIs(Holder.m, wrapper)  # class access likewise returns the wrapper
+
 
 @pytest.mark.test_set_ci
 class TestChromiumEventStatePreservation(TestCase):

--- a/test/rbln/test_torch_compile_patch.py
+++ b/test/rbln/test_torch_compile_patch.py
@@ -695,9 +695,8 @@ class TestCompiledFunctionWrapper(TestCase):
         self.assertEqual(len(list(wrapper.parameters())), len(list(model.parameters())))
 
     def test_wrapper_self_returning_methods_keep_wrapper(self):
-        """Self-returning nn.Module methods (eval/train/to) must return the wrapper,
-        not the bare model — else `compiled = compiled.eval()` silently drops the
-        guard/failover. The mode toggle still lands on the wrapped model."""
+        """Self-returning methods (eval/train/to) return the wrapper, not the bare model, and
+        the mode toggle still lands on the model."""
         model = torch.nn.Linear(4, 4)
         wrapper = CompiledFunctionWrapper(lambda *a, **k: None, model, Mock(), compile_kwargs={})
         self.assertIs(wrapper.eval(), wrapper)
@@ -709,8 +708,8 @@ class TestCompiledFunctionWrapper(TestCase):
         self.assertEqual(len(list(wrapper.parameters())), len(list(model.parameters())))
 
     def test_wrapper_setattr_delegates_to_model(self):
-        """Writes to the wrapper (training flag, parameter swap, arbitrary attrs) must land on
-        the wrapped model — the actually-executed object — not diverge onto the wrapper."""
+        """Writes (training flag, parameter swap, arbitrary attrs) land on the wrapped model,
+        not the wrapper."""
         model = torch.nn.Linear(4, 4)
         wrapper = CompiledFunctionWrapper(lambda *a, **k: None, model, Mock(), compile_kwargs={})
 
@@ -746,9 +745,8 @@ class TestCompiledFunctionWrapper(TestCase):
         self.assertFalse(hasattr(model, "_failover_attempted"))
 
     def test_wrapper_over_plain_function_keeps_attrs_local(self):
-        """A plain-function target has no attribute state to sync, so writes must stay on the
-        wrapper — not leak onto the function object or get shared across wrappers over the
-        same function. Only nn.Module targets are delegated to."""
+        """With a plain-function target (not nn.Module), writes stay on the wrapper -- not
+        leaked onto the function or shared across wrappers over the same function."""
 
         def fn(*args, **kwargs):
             return None

--- a/test/rbln/test_torch_compile_patch.py
+++ b/test/rbln/test_torch_compile_patch.py
@@ -763,6 +763,27 @@ class TestCompiledFunctionWrapper(TestCase):
         self.assertFalse(hasattr(w1, "custom_flag"))
 
     @patch("torch_rbln._internal.torch_compile_patch_helpers.auto_determine_num_devices_if_needed")
+    def test_wrapper_forward_routes_through_compiled_path(self, mock_auto):
+        """`compiled.forward(...)` must run the wrapper's compiled path, not delegate to the
+        wrapped module's raw forward and bypass compilation/guard/failover."""
+        mock_auto.return_value = None  # keep our recording compiled_fn as _compiled_fn
+        seen = []
+
+        class _M(torch.nn.Module):
+            def forward(self, x):
+                seen.append("raw_forward")  # the bypass — must NOT be reached
+                return x
+
+        def compiled_fn(*args, **kwargs):
+            seen.append("compiled")
+            return args[0] if args else None
+
+        wrapper = CompiledFunctionWrapper(compiled_fn, _M(), Mock(), compile_kwargs={})
+        wrapper.forward(torch.tensor([1], device="rbln"))
+        self.assertIn("compiled", seen)  # went through the compiled path
+        self.assertNotIn("raw_forward", seen)  # did not bypass to raw module.forward
+
+    @patch("torch_rbln._internal.torch_compile_patch_helpers.auto_determine_num_devices_if_needed")
     def test_wrapper_binds_self_as_method_descriptor(self, mock_auto):
         """@torch.compile(backend="rbln") on an instance method: __get__ must bind
         the instance as the first argument, and class access returns the wrapper."""

--- a/test/rbln/test_torch_compile_patch.py
+++ b/test/rbln/test_torch_compile_patch.py
@@ -686,6 +686,34 @@ class TestCompiledFunctionWrapper(TestCase):
                 self.assertEqual(result.item(), 12)
                 self.assertTrue(recompiled_called[0])
 
+    def test_wrapper_delegates_module_attributes(self):
+        """torch.compile(nn.Module) must keep state_dict()/eval()/parameters() —
+        __getattr__ delegates unknown attributes to the wrapped model."""
+        model = torch.nn.Linear(4, 4)
+        wrapper = CompiledFunctionWrapper(lambda *a, **k: None, model, Mock(), compile_kwargs={})
+        self.assertIs(wrapper.eval(), model)  # nn.Module.eval() returns self
+        self.assertEqual(list(wrapper.state_dict().keys()), list(model.state_dict().keys()))
+        self.assertEqual(len(list(wrapper.parameters())), len(list(model.parameters())))
+
+    @patch("torch_rbln._internal.torch_compile_patch_helpers.auto_determine_num_devices_if_needed")
+    def test_wrapper_binds_self_as_method_descriptor(self, mock_auto):
+        """@torch.compile(backend="rbln") on an instance method: __get__ must bind
+        the instance as the first argument, and class access returns the wrapper."""
+        mock_auto.return_value = None
+        seen = {}
+
+        def echo(*args, **kwargs):
+            seen["args"] = args
+            return args
+
+        class C:
+            method = CompiledFunctionWrapper(echo, echo, Mock(), compile_kwargs={})
+
+        c = C()
+        c.method(torch.tensor([1], device="rbln"))
+        self.assertIs(seen["args"][0], c)  # self bound
+        self.assertIsInstance(C.method, CompiledFunctionWrapper)  # class access returns wrapper
+
 
 @pytest.mark.test_set_ci
 class TestChromiumEventStatePreservation(TestCase):
@@ -1016,6 +1044,17 @@ class TestTorchCompileMonkeyPatch(TestCase):
             )
 
         self.assertEqual(mock_compile.call_count, 2)
+
+    def test_dynamo_reset_clears_warm_cache(self):
+        """torch._dynamo.reset must also flush the C++ warm cache, not just the
+        Python compile cache — else a stale runtime is executed directly after
+        reset, bypassing Dynamo."""
+        patch_torch_compile()
+        from torch_rbln._internal import warm_cache
+
+        with patch.object(warm_cache, "clear") as mock_clear:
+            torch._dynamo.reset()
+            mock_clear.assert_called_once()
 
     @patch("torch_rbln._internal.torch_compile_patch_helpers.auto_determine_num_devices_if_needed")
     def test_patch_torch_compile_wrapper_integration(self, mock_auto_determine):

--- a/test/rbln/test_torch_compile_patch.py
+++ b/test/rbln/test_torch_compile_patch.py
@@ -745,6 +745,23 @@ class TestCompiledFunctionWrapper(TestCase):
         self.assertTrue(wrapper._failover_attempted)
         self.assertFalse(hasattr(model, "_failover_attempted"))
 
+    def test_wrapper_over_plain_function_keeps_attrs_local(self):
+        """A plain-function target has no attribute state to sync, so writes must stay on the
+        wrapper — not leak onto the function object or get shared across wrappers over the
+        same function. Only nn.Module targets are delegated to."""
+
+        def fn(*args, **kwargs):
+            return None
+
+        w1 = CompiledFunctionWrapper(fn, fn, Mock(), compile_kwargs={})
+        w2 = CompiledFunctionWrapper(fn, fn, Mock(), compile_kwargs={})
+        w1.custom_flag = 1
+        self.assertEqual(w1.custom_flag, 1)
+        self.assertFalse(hasattr(fn, "custom_flag"))  # not written onto the function
+        self.assertFalse(hasattr(w2, "custom_flag"))  # not shared with another wrapper over fn
+        del w1.custom_flag
+        self.assertFalse(hasattr(w1, "custom_flag"))
+
     @patch("torch_rbln._internal.torch_compile_patch_helpers.auto_determine_num_devices_if_needed")
     def test_wrapper_binds_self_as_method_descriptor(self, mock_auto):
         """@torch.compile(backend="rbln") on an instance method: __get__ must bind

--- a/test/rbln/test_torch_compile_patch.py
+++ b/test/rbln/test_torch_compile_patch.py
@@ -708,6 +708,43 @@ class TestCompiledFunctionWrapper(TestCase):
         # Non-self-returning delegates still return their real values.
         self.assertEqual(len(list(wrapper.parameters())), len(list(model.parameters())))
 
+    def test_wrapper_setattr_delegates_to_model(self):
+        """Writes to the wrapper (training flag, parameter swap, arbitrary attrs) must land on
+        the wrapped model — the actually-executed object — not diverge onto the wrapper."""
+        model = torch.nn.Linear(4, 4)
+        wrapper = CompiledFunctionWrapper(lambda *a, **k: None, model, Mock(), compile_kwargs={})
+
+        wrapper.training = False
+        self.assertFalse(model.training)  # write reached the model...
+        self.assertFalse(wrapper.training)  # ...and the read reflects it
+
+        # A parameter swap must register on the model as a real Parameter.
+        new_weight = torch.nn.Parameter(torch.zeros(4, 4))
+        wrapper.weight = new_weight
+        self.assertIs(model.weight, new_weight)
+        self.assertIn("weight", dict(model.named_parameters()))
+
+        # Arbitrary user attribute delegates too.
+        wrapper.custom_flag = 123
+        self.assertEqual(model.custom_flag, 123)
+
+    def test_wrapper_delattr_delegates_to_model(self):
+        """`del compiled.attr` must remove it from the wrapped model."""
+        model = torch.nn.Linear(4, 4)
+        wrapper = CompiledFunctionWrapper(lambda *a, **k: None, model, Mock(), compile_kwargs={})
+        wrapper.custom_flag = 7
+        self.assertEqual(model.custom_flag, 7)
+        del wrapper.custom_flag
+        self.assertFalse(hasattr(model, "custom_flag"))
+
+    def test_wrapper_own_attrs_stay_on_wrapper(self):
+        """The wrapper's bookkeeping must not leak onto the wrapped model."""
+        model = torch.nn.Linear(4, 4)
+        wrapper = CompiledFunctionWrapper(lambda *a, **k: None, model, Mock(), compile_kwargs={})
+        wrapper._failover_attempted = True
+        self.assertTrue(wrapper._failover_attempted)
+        self.assertFalse(hasattr(model, "_failover_attempted"))
+
     @patch("torch_rbln._internal.torch_compile_patch_helpers.auto_determine_num_devices_if_needed")
     def test_wrapper_binds_self_as_method_descriptor(self, mock_auto):
         """@torch.compile(backend="rbln") on an instance method: __get__ must bind

--- a/test/rbln/test_torch_compile_patch.py
+++ b/test/rbln/test_torch_compile_patch.py
@@ -4,6 +4,7 @@
 Test suite for torch_compile_patch_helpers module.
 """
 
+import types
 from contextlib import nullcontext
 from unittest.mock import Mock, patch
 
@@ -815,6 +816,25 @@ class TestCompiledFunctionWrapper(TestCase):
         # functools.partial that would inject the Holder instance as the first positional arg.
         self.assertIs(Holder().m, wrapper)
         self.assertIs(Holder.m, wrapper)  # class access likewise returns the wrapper
+
+    def test_wrapper_bound_method_target_not_rebound(self):
+        """A wrapper whose target is an already-bound method must NOT get the owner re-bound:
+        __get__ returns it as-is, so the original receiver stays the only bound self (binding
+        again would inject the holder as a second, spurious first arg)."""
+
+        class Target:
+            def method(self, x):
+                return x
+
+        target = Target()
+        self.assertIsInstance(target.method, types.MethodType)  # precondition: already bound
+        wrapper = CompiledFunctionWrapper(lambda *a, **k: None, target.method, Mock(), compile_kwargs={})
+
+        class Holder:
+            m = wrapper
+
+        self.assertIs(Holder().m, wrapper)  # not re-bound to the Holder instance
+        self.assertIs(Holder.m, wrapper)
 
 
 @pytest.mark.test_set_ci

--- a/test/rbln/test_torch_compile_patch.py
+++ b/test/rbln/test_torch_compile_patch.py
@@ -691,8 +691,21 @@ class TestCompiledFunctionWrapper(TestCase):
         __getattr__ delegates unknown attributes to the wrapped model."""
         model = torch.nn.Linear(4, 4)
         wrapper = CompiledFunctionWrapper(lambda *a, **k: None, model, Mock(), compile_kwargs={})
-        self.assertIs(wrapper.eval(), model)  # nn.Module.eval() returns self
         self.assertEqual(list(wrapper.state_dict().keys()), list(model.state_dict().keys()))
+        self.assertEqual(len(list(wrapper.parameters())), len(list(model.parameters())))
+
+    def test_wrapper_self_returning_methods_keep_wrapper(self):
+        """Self-returning nn.Module methods (eval/train/to) must return the wrapper,
+        not the bare model — else `compiled = compiled.eval()` silently drops the
+        guard/failover. The mode toggle still lands on the wrapped model."""
+        model = torch.nn.Linear(4, 4)
+        wrapper = CompiledFunctionWrapper(lambda *a, **k: None, model, Mock(), compile_kwargs={})
+        self.assertIs(wrapper.eval(), wrapper)
+        self.assertFalse(model.training)  # toggle reached the model
+        self.assertIs(wrapper.train(), wrapper)
+        self.assertTrue(model.training)
+        self.assertIs(wrapper.to("cpu"), wrapper)
+        # Non-self-returning delegates still return their real values.
         self.assertEqual(len(list(wrapper.parameters())), len(list(model.parameters())))
 
     @patch("torch_rbln._internal.torch_compile_patch_helpers.auto_determine_num_devices_if_needed")

--- a/torch_rbln/_internal/monkey_patches.py
+++ b/torch_rbln/_internal/monkey_patches.py
@@ -125,6 +125,13 @@ def patch_torch_compile() -> None:
 
         def reset_wrapper(*args, **kwargs):
             clear_rbln_compile_cache()
+            # torch._dynamo.reset() means "forget all compiled state". Also flush
+            # the C++ warm cache — otherwise a matching input profile still hits a
+            # stale runtime directly after reset, bypassing the cleared Python
+            # cache and Dynamo. Lazy import avoids an import cycle.
+            from torch_rbln._internal import warm_cache
+
+            warm_cache.clear()
             return original_dynamo_reset(*args, **kwargs)
 
         torch._dynamo.reset = reset_wrapper

--- a/torch_rbln/_internal/monkey_patches.py
+++ b/torch_rbln/_internal/monkey_patches.py
@@ -129,6 +129,10 @@ def patch_torch_compile() -> None:
             # the C++ warm cache — otherwise a matching input profile still hits a
             # stale runtime directly after reset, bypassing the cleared Python
             # cache and Dynamo. Lazy import avoids an import cycle.
+            #
+            # Caveat: the flush can drop the last reference to a warm runtime and
+            # free its device buffers. Drain in-flight work (torch.rbln.synchronize)
+            # before reset(); resetting a device with pending DMA is undefined.
             from torch_rbln._internal import warm_cache
 
             warm_cache.clear()
@@ -159,6 +163,11 @@ def remove_all_patches() -> None:
         torch._dynamo.reset = _original_dynamo_reset
 
     clear_rbln_compile_cache()
+    # Mirror reset_wrapper's teardown: drop the C++ warm cache's runtime
+    # references too, so removal fully undoes apply. Lazy import avoids a cycle.
+    from torch_rbln._internal import warm_cache
+
+    warm_cache.clear()
     _torch_compile_patched = False
     _torch_dynamo_reset_patched = False
     _rbln_backend_registered = False

--- a/torch_rbln/_internal/torch_compile_patch_helpers.py
+++ b/torch_rbln/_internal/torch_compile_patch_helpers.py
@@ -7,6 +7,7 @@ auto-determination, tensor-parallel failover support, and CPU fallback functiona
 
 import functools
 import threading
+import types
 
 import torch
 
@@ -333,7 +334,22 @@ class CompiledFunctionWrapper:
         # lookups don't get silently redirected to the wrapped object.
         if name.startswith("__") and name.endswith("__"):
             raise AttributeError(name)
-        return getattr(object.__getattribute__(self, "_original_fn"), name)
+        model = object.__getattribute__(self, "_original_fn")
+        attr = getattr(model, name)
+        # Self-returning nn.Module methods (eval/train/to/cpu/half/requires_grad_/
+        # ...) return the wrapped model. Re-wrap the return so `compiled =
+        # compiled.eval()` keeps the wrapper — and its guard/failover — instead of
+        # silently unwrapping to the bare model. Only bound methods are intercepted;
+        # submodules, parameters and tensors pass through untouched.
+        if isinstance(attr, types.MethodType):
+
+            @functools.wraps(attr)
+            def keep_wrapper(*args, **kwargs):
+                result = attr(*args, **kwargs)
+                return self if result is model else result
+
+            return keep_wrapper
+        return attr
 
     def __get__(self, obj, objtype=None):
         # Descriptor protocol so `@torch.compile(backend="rbln")` on an instance

--- a/torch_rbln/_internal/torch_compile_patch_helpers.py
+++ b/torch_rbln/_internal/torch_compile_patch_helpers.py
@@ -355,16 +355,29 @@ class CompiledFunctionWrapper:
         # leaking onto the model.
         if name in type(self)._WRAPPER_OWN_ATTRS or hasattr(type(self), name):
             object.__setattr__(self, name, value)
+            return
+        model = object.__getattribute__(self, "_original_fn")
+        # Only delegate to an nn.Module target: it has real attribute state to keep in sync
+        # (training flag, params, buffers). A plain-function target has no such state, and
+        # writing onto the function object would be meaningless and would leak/share state
+        # across wrappers over the same function — keep it on the wrapper instead.
+        if isinstance(model, torch.nn.Module):
+            setattr(model, name, value)
         else:
-            setattr(object.__getattribute__(self, "_original_fn"), name, value)
+            object.__setattr__(self, name, value)
 
     def __delattr__(self, name):
         # Symmetric with __setattr__: own bookkeeping / wrapper-class names are deleted from
-        # the wrapper, everything else from the wrapped model.
+        # the wrapper; a real attribute is deleted from the wrapped model only when it is an
+        # nn.Module, otherwise from the wrapper.
         if name in type(self)._WRAPPER_OWN_ATTRS or hasattr(type(self), name):
             object.__delattr__(self, name)
+            return
+        model = object.__getattribute__(self, "_original_fn")
+        if isinstance(model, torch.nn.Module):
+            delattr(model, name)
         else:
-            delattr(object.__getattribute__(self, "_original_fn"), name)
+            object.__delattr__(self, name)
 
     def __getattr__(self, name):
         # Only fires for attributes not found on the wrapper. Delegate to the

--- a/torch_rbln/_internal/torch_compile_patch_helpers.py
+++ b/torch_rbln/_internal/torch_compile_patch_helpers.py
@@ -376,10 +376,13 @@ class CompiledFunctionWrapper:
         return attr
 
     def __get__(self, obj, objtype=None):
-        # Descriptor protocol so `@torch.compile(backend="rbln")` on an instance
-        # method binds `self`. Only affects class-attribute use; a wrapper stored
-        # as a plain object or instance attribute is unaffected.
-        if obj is None:
+        # Descriptor protocol so `@torch.compile(backend="rbln")` on a *method* binds `self`.
+        # Bind only when the wrapped target is a function/method (the method case); a compiled
+        # nn.Module or other callable object stored as a class attribute is returned as-is --
+        # otherwise we'd wrongly prepend the owner instance as its first positional arg (e.g.
+        # `class H: m = torch.compile(nn.Linear(...))`; `H().m(x)` would call `Linear(H(), x)`).
+        # Only affects class-attribute use; an instance-attribute wrapper never triggers this.
+        if obj is None or not isinstance(self._original_fn, (types.FunctionType, types.MethodType)):
             return self
         return functools.partial(self.__call__, obj)
 

--- a/torch_rbln/_internal/torch_compile_patch_helpers.py
+++ b/torch_rbln/_internal/torch_compile_patch_helpers.py
@@ -318,6 +318,21 @@ class CompiledFunctionWrapper:
 
     """
 
+    # The wrapper's own bookkeeping attributes. Every other attribute set on the wrapper is
+    # delegated to the wrapped model (see __setattr__), so these must be listed here to keep
+    # them on the wrapper itself.
+    _WRAPPER_OWN_ATTRS = frozenset(
+        {
+            "_compiled_fn",
+            "_original_fn",
+            "_original_compile_fn",
+            "_compile_kwargs",
+            "_max_retries",
+            "_auto_num_devices_determined",
+            "_failover_attempted",
+        }
+    )
+
     def __init__(self, compiled_fn, original_fn, original_compile_fn, compile_kwargs=None):
         self._compiled_fn = compiled_fn
         self._original_fn = original_fn
@@ -326,6 +341,30 @@ class CompiledFunctionWrapper:
         self._max_retries = 1
         self._auto_num_devices_determined = False
         self._failover_attempted = False
+
+    def __setattr__(self, name, value):
+        # Mirror __getattr__'s read delegation for writes: the wrapper's own bookkeeping
+        # stays on the wrapper, but everything else (the training flag, parameter/buffer
+        # swaps, arbitrary user attrs) is set on the wrapped model — the actually-executed
+        # object — so it can't silently diverge onto the wrapper. Delegating to the model's
+        # __setattr__ also lets nn.Module register a Parameter/Module/buffer properly.
+        #
+        # "Own" = the bookkeeping attrs above OR anything the wrapper class defines (methods,
+        # class attrs); keeping the latter on the wrapper lets e.g.
+        # mock.patch.object(wrapper, "_try_tp_failover") shadow the method here instead of
+        # leaking onto the model.
+        if name in type(self)._WRAPPER_OWN_ATTRS or hasattr(type(self), name):
+            object.__setattr__(self, name, value)
+        else:
+            setattr(object.__getattribute__(self, "_original_fn"), name, value)
+
+    def __delattr__(self, name):
+        # Symmetric with __setattr__: own bookkeeping / wrapper-class names are deleted from
+        # the wrapper, everything else from the wrapped model.
+        if name in type(self)._WRAPPER_OWN_ATTRS or hasattr(type(self), name):
+            object.__delattr__(self, name)
+        else:
+            delattr(object.__getattribute__(self, "_original_fn"), name)
 
     def __getattr__(self, name):
         # Only fires for attributes not found on the wrapper. Delegate to the

--- a/torch_rbln/_internal/torch_compile_patch_helpers.py
+++ b/torch_rbln/_internal/torch_compile_patch_helpers.py
@@ -5,6 +5,7 @@ This module contains utilities for wrapping compiled functions with num_devices
 auto-determination, tensor-parallel failover support, and CPU fallback functionality.
 """
 
+import functools
 import threading
 
 import torch
@@ -324,6 +325,23 @@ class CompiledFunctionWrapper:
         self._max_retries = 1
         self._auto_num_devices_determined = False
         self._failover_attempted = False
+
+    def __getattr__(self, name):
+        # Only fires for attributes not found on the wrapper. Delegate to the
+        # wrapped model/callable so torch.compile(nn.Module) keeps state_dict(),
+        # eval(), parameters(), etc. Dunders are excluded so copy/pickle protocol
+        # lookups don't get silently redirected to the wrapped object.
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
+        return getattr(object.__getattribute__(self, "_original_fn"), name)
+
+    def __get__(self, obj, objtype=None):
+        # Descriptor protocol so `@torch.compile(backend="rbln")` on an instance
+        # method binds `self`. Only affects class-attribute use; a wrapper stored
+        # as a plain object or instance attribute is unaffected.
+        if obj is None:
+            return self
+        return functools.partial(self.__call__, obj)
 
     def _try_tp_failover(self, device_id):
         """Try tensor parallel failover on RuntimeError."""

--- a/torch_rbln/_internal/torch_compile_patch_helpers.py
+++ b/torch_rbln/_internal/torch_compile_patch_helpers.py
@@ -376,13 +376,11 @@ class CompiledFunctionWrapper:
         return attr
 
     def __get__(self, obj, objtype=None):
-        # Descriptor protocol so `@torch.compile(backend="rbln")` on a *method* binds `self`.
-        # Bind only when the wrapped target is a function/method (the method case); a compiled
-        # nn.Module or other callable object stored as a class attribute is returned as-is --
-        # otherwise we'd wrongly prepend the owner instance as its first positional arg (e.g.
-        # `class H: m = torch.compile(nn.Linear(...))`; `H().m(x)` would call `Linear(H(), x)`).
-        # Only affects class-attribute use; an instance-attribute wrapper never triggers this.
-        if obj is None or not isinstance(self._original_fn, (types.FunctionType, types.MethodType)):
+        # Descriptor: bind the owner only for a decorated *function* target (the usual
+        # `@torch.compile` on a method). A compiled nn.Module / callable object -- or an
+        # already-bound method -- is returned unchanged, so the owner is not injected as a
+        # spurious first argument (and a bound method is not bound a second time).
+        if obj is None or not isinstance(self._original_fn, types.FunctionType):
             return self
         return functools.partial(self.__call__, obj)
 

--- a/torch_rbln/_internal/torch_compile_patch_helpers.py
+++ b/torch_rbln/_internal/torch_compile_patch_helpers.py
@@ -411,6 +411,13 @@ class CompiledFunctionWrapper:
             return self
         return functools.partial(self.__call__, obj)
 
+    def forward(self, *args, **kwargs):
+        # Route an explicit `compiled.forward(...)` through the wrapper's compiled path
+        # (guard / failover / CPU fallback), exactly like calling the wrapper directly.
+        # Without this, __getattr__ would delegate `forward` to the wrapped module and
+        # silently bypass compilation. Defined on the class so __getattr__ never sees it.
+        return self(*args, **kwargs)
+
     def _try_tp_failover(self, device_id):
         """Try tensor parallel failover on RuntimeError."""
         if self._failover_attempted:

--- a/torch_rbln/_internal/torch_compile_patch_helpers.py
+++ b/torch_rbln/_internal/torch_compile_patch_helpers.py
@@ -318,81 +318,53 @@ class CompiledFunctionWrapper:
 
     """
 
-    # The wrapper's own bookkeeping attributes. Every other attribute set on the wrapper is
-    # delegated to the wrapped model (see __setattr__), so these must be listed here to keep
-    # them on the wrapper itself.
-    _WRAPPER_OWN_ATTRS = frozenset(
-        {
-            "_compiled_fn",
-            "_original_fn",
-            "_original_compile_fn",
-            "_compile_kwargs",
-            "_max_retries",
-            "_auto_num_devices_determined",
-            "_failover_attempted",
-        }
-    )
-
     def __init__(self, compiled_fn, original_fn, original_compile_fn, compile_kwargs=None):
-        self._compiled_fn = compiled_fn
-        self._original_fn = original_fn
-        self._original_compile_fn = original_compile_fn
-        self._compile_kwargs = compile_kwargs or {}
-        self._max_retries = 1
-        self._auto_num_devices_determined = False
-        self._failover_attempted = False
+        # object.__setattr__ so __setattr__'s delegation (which reads _original_fn) isn't
+        # triggered before the fields exist. Each field lands in __dict__ and is thereafter
+        # treated as the wrapper's own -- no hand-maintained field list to keep in sync.
+        object.__setattr__(self, "_compiled_fn", compiled_fn)
+        object.__setattr__(self, "_original_fn", original_fn)
+        object.__setattr__(self, "_original_compile_fn", original_compile_fn)
+        object.__setattr__(self, "_compile_kwargs", compile_kwargs or {})
+        object.__setattr__(self, "_max_retries", 1)
+        object.__setattr__(self, "_auto_num_devices_determined", False)
+        object.__setattr__(self, "_failover_attempted", False)
+
+    def _is_own_attr(self, name):
+        # Own = an existing instance field or anything the wrapper class defines (methods,
+        # `forward`). Keeps e.g. patch.object(wrapper, "_try_tp_failover") shadowing the
+        # method here rather than leaking onto the model.
+        return name in self.__dict__ or hasattr(type(self), name)
 
     def __setattr__(self, name, value):
-        # Mirror __getattr__'s read delegation for writes: the wrapper's own bookkeeping
-        # stays on the wrapper, but everything else (the training flag, parameter/buffer
-        # swaps, arbitrary user attrs) is set on the wrapped model — the actually-executed
-        # object — so it can't silently diverge onto the wrapper. Delegating to the model's
-        # __setattr__ also lets nn.Module register a Parameter/Module/buffer properly.
-        #
-        # "Own" = the bookkeeping attrs above OR anything the wrapper class defines (methods,
-        # class attrs); keeping the latter on the wrapper lets e.g.
-        # mock.patch.object(wrapper, "_try_tp_failover") shadow the method here instead of
-        # leaking onto the model.
-        if name in type(self)._WRAPPER_OWN_ATTRS or hasattr(type(self), name):
+        # Own state stays on the wrapper; everything else is delegated to the wrapped model,
+        # but only an nn.Module (which has training/param/buffer state to keep in sync). A
+        # plain-function target has none, so keep the attr on the wrapper.
+        if self._is_own_attr(name):
             object.__setattr__(self, name, value)
-            return
-        model = object.__getattribute__(self, "_original_fn")
-        # Only delegate to an nn.Module target: it has real attribute state to keep in sync
-        # (training flag, params, buffers). A plain-function target has no such state, and
-        # writing onto the function object would be meaningless and would leak/share state
-        # across wrappers over the same function — keep it on the wrapper instead.
-        if isinstance(model, torch.nn.Module):
-            setattr(model, name, value)
+        elif isinstance(self._original_fn, torch.nn.Module):
+            setattr(self._original_fn, name, value)
         else:
             object.__setattr__(self, name, value)
 
     def __delattr__(self, name):
-        # Symmetric with __setattr__: own bookkeeping / wrapper-class names are deleted from
-        # the wrapper; a real attribute is deleted from the wrapped model only when it is an
-        # nn.Module, otherwise from the wrapper.
-        if name in type(self)._WRAPPER_OWN_ATTRS or hasattr(type(self), name):
+        if self._is_own_attr(name):
             object.__delattr__(self, name)
-            return
-        model = object.__getattribute__(self, "_original_fn")
-        if isinstance(model, torch.nn.Module):
-            delattr(model, name)
+        elif isinstance(self._original_fn, torch.nn.Module):
+            delattr(self._original_fn, name)
         else:
             object.__delattr__(self, name)
 
     def __getattr__(self, name):
-        # Only fires for attributes not found on the wrapper. Delegate to the
-        # wrapped model/callable so torch.compile(nn.Module) keeps state_dict(),
-        # eval(), parameters(), etc. Dunders are excluded so copy/pickle protocol
-        # lookups don't get silently redirected to the wrapped object.
+        # Fires only for attributes missing on the wrapper: delegate reads to the wrapped
+        # model/callable (state_dict/eval/parameters/...). Dunders are excluded so
+        # copy/pickle protocol lookups aren't redirected.
         if name.startswith("__") and name.endswith("__"):
             raise AttributeError(name)
         model = object.__getattribute__(self, "_original_fn")
         attr = getattr(model, name)
-        # Self-returning nn.Module methods (eval/train/to/cpu/half/requires_grad_/
-        # ...) return the wrapped model. Re-wrap the return so `compiled =
-        # compiled.eval()` keeps the wrapper — and its guard/failover — instead of
-        # silently unwrapping to the bare model. Only bound methods are intercepted;
-        # submodules, parameters and tensors pass through untouched.
+        # Re-wrap a bound method that returns the model (eval/train/to/...) so
+        # `compiled = compiled.eval()` keeps the wrapper, not the bare model.
         if isinstance(attr, types.MethodType):
 
             @functools.wraps(attr)
@@ -412,10 +384,8 @@ class CompiledFunctionWrapper:
         return functools.partial(self.__call__, obj)
 
     def forward(self, *args, **kwargs):
-        # Route an explicit `compiled.forward(...)` through the wrapper's compiled path
-        # (guard / failover / CPU fallback), exactly like calling the wrapper directly.
-        # Without this, __getattr__ would delegate `forward` to the wrapped module and
-        # silently bypass compilation. Defined on the class so __getattr__ never sees it.
+        # Route an explicit .forward(...) through the compiled path, like calling the wrapper
+        # directly -- else __getattr__ would delegate it to the module and bypass compilation.
         return self(*args, **kwargs)
 
     def _try_tp_failover(self, device_id):


### PR DESCRIPTION
## Summary of Changes

Two `torch.compile` lifecycle fixes:

- **`CompiledFunctionWrapper` attribute / descriptor delegation.** The wrapper had no `__getattr__`/`__get__`, so `torch.compile(nn.Module)` dropped `state_dict()` / `eval()` / `parameters()` (all raised `AttributeError`), and the `@torch.compile(backend="rbln")` method-decorator form did not bind `self`. Now delegates unknown (non-dunder) attributes to the wrapped model, and implements the descriptor protocol. `__get__` binds the owner **only when the wrapped target is a plain function** (the method-decorator case); a compiled `nn.Module`, another callable object, or an already-bound method is returned **as-is** — otherwise the owner instance would be injected as a spurious first positional argument (e.g. `class H: m = torch.compile(nn.Linear(...))`; `H().m(x)`). This is attribute-forwarding, not full `nn.Module` transparency (`isinstance(wrapper, nn.Module)` is still `False`).
- **`torch._dynamo.reset()` warm-cache flush.** `reset()` cleared only the Python compile cache, leaving the C++ warm cache populated — a matching input profile still hit a stale runtime directly after reset, bypassing Dynamo. The reset wrapper now flushes the warm cache too.

## Related Issues / Tickets

* Related to: eager-mode correctness audit (no tracking issue yet — please link one if required).

## Type of Change

- [x] `fix` — Bug fix

## Affected Modules

- [x] `torch.compile`

## How to Test

1. `pytest test/rbln/test_torch_compile_patch.py`
2. A `CompiledFunctionWrapper` around an `nn.Module` exposes `state_dict()`/`eval()`/`parameters()`. As a class attribute: a compiled **function** binds `self`; a compiled `nn.Module` / bound method does **not** get the owner re-bound. `torch._dynamo.reset()` clears the C++ warm cache.

## Checklist

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to a corresponding issue
* [x] Linting passes
* [x] All CI tests pass
* [x] The test method is described, and the expected result is clearly stated

## Notes

Both fixes are scoped to the compile-lifecycle subsystem. `__get__` only affects class-attribute (method-decorator) use; standalone / instance-attribute wrappers are unchanged.
