### PR TITLE
fix(device): read TORCH_RBLN_EAGER_MALLOC live to prevent cross-test env leak

### DIFF
--- a/c10/rbln/RBLNFunctions.cpp
+++ b/c10/rbln/RBLNFunctions.cpp
@@ -340,7 +340,11 @@ c10::DeviceIndex get_torch_device_id(const void* data) {
 
 bool is_eager_malloc() {
   // Read live per call (not a process-lifetime static) so the value reflects the current
-  // environment. Safe: only malloc() consults it and free is mode-agnostic.
+  // environment. getenv is not thread-safe against a concurrent setenv/putenv, but this is
+  // safe here: only malloc() consults it, free is mode-agnostic (so an env change between an
+  // allocation and its free can't cause an alloc/free mismatch), and the env is not mutated
+  // concurrently with allocation (prod fixes it at startup; tests toggle it only at quiescent
+  // points, single-threaded per worker).
   const auto* env = std::getenv("TORCH_RBLN_EAGER_MALLOC");
   const bool eager_malloc = (env != nullptr) && (std::strcmp(env, "1") == 0);
   RBLN_LOG_DEBUG("eager_malloc={}", eager_malloc);

--- a/c10/rbln/RBLNFunctions.cpp
+++ b/c10/rbln/RBLNFunctions.cpp
@@ -339,11 +339,10 @@ c10::DeviceIndex get_torch_device_id(const void* data) {
 }
 
 bool is_eager_malloc() {
-  // Read live, not a process-lifetime static: enable_eager_malloc toggles this per-test
-  // (test/conftest.py); a static cache latches the first value into the whole xdist worker
-  // and leaks eager into later tests. Safe: only malloc() reads it, free is mode-agnostic.
+  // Read live per call (not a process-lifetime static) so the value reflects the current
+  // environment. Safe: only malloc() consults it and free is mode-agnostic.
   const auto* env = std::getenv("TORCH_RBLN_EAGER_MALLOC");
-  const bool eager_malloc = (env != nullptr) && (std::string(env) == "1");
+  const bool eager_malloc = (env != nullptr) && (std::strcmp(env, "1") == 0);
   RBLN_LOG_DEBUG("eager_malloc={}", eager_malloc);
   return eager_malloc;
 }

--- a/c10/rbln/RBLNFunctions.cpp
+++ b/c10/rbln/RBLNFunctions.cpp
@@ -339,10 +339,11 @@ c10::DeviceIndex get_torch_device_id(const void* data) {
 }
 
 bool is_eager_malloc() {
-  static const bool eager_malloc = []() {
-    const auto* env = std::getenv("TORCH_RBLN_EAGER_MALLOC");
-    return (env != nullptr) ? (std::string(env) == "1") : false;
-  }();
+  // Read live, not a process-lifetime static: enable_eager_malloc toggles this per-test
+  // (test/conftest.py); a static cache latches the first value into the whole xdist worker
+  // and leaks eager into later tests. Safe: only malloc() reads it, free is mode-agnostic.
+  const auto* env = std::getenv("TORCH_RBLN_EAGER_MALLOC");
+  const bool eager_malloc = (env != nullptr) && (std::string(env) == "1");
   RBLN_LOG_DEBUG("eager_malloc={}", eager_malloc);
   return eager_malloc;
 }

--- a/test/cpp/core/RBLNFunctionsTest.cpp
+++ b/test/cpp/core/RBLNFunctionsTest.cpp
@@ -3,7 +3,9 @@
 #include <gtest/gtest.h>
 
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
+#include <string>
 
 class RBLNFunctionsTest : public ::testing::Test {
  protected:
@@ -94,13 +96,26 @@ TEST_F(RBLNFunctionsTest, ExchangeInvalidDeviceIndex) {
 }
 
 TEST_F(RBLNFunctionsTest, IsEagerMalloc) {
-  const auto is_eager_malloc = c10::rbln::is_eager_malloc();
+  // is_eager_malloc() reads the env on every call, so toggling it is observed each time.
+  // A process-lifetime cache would latch the first value (the xdist cross-test leak this
+  // guards against), so assert set -> unset -> set flips the result live.
+  const char* saved = std::getenv("TORCH_RBLN_EAGER_MALLOC");
+  const bool had = saved != nullptr;
+  const std::string saved_str = had ? saved : "";
 
-  const auto* env = std::getenv("TORCH_RBLN_EAGER_MALLOC");
-  if ((env != nullptr) && (std::string(env) == "1")) {
-    EXPECT_TRUE(is_eager_malloc);
+  setenv("TORCH_RBLN_EAGER_MALLOC", "1", /*overwrite=*/1);
+  EXPECT_TRUE(c10::rbln::is_eager_malloc());
+  unsetenv("TORCH_RBLN_EAGER_MALLOC");
+  EXPECT_FALSE(c10::rbln::is_eager_malloc());
+  setenv("TORCH_RBLN_EAGER_MALLOC", "1", /*overwrite=*/1);
+  EXPECT_TRUE(c10::rbln::is_eager_malloc());
+  setenv("TORCH_RBLN_EAGER_MALLOC", "0", /*overwrite=*/1); // only exactly "1" is eager
+  EXPECT_FALSE(c10::rbln::is_eager_malloc());
+
+  if (had) {
+    setenv("TORCH_RBLN_EAGER_MALLOC", saved_str.c_str(), /*overwrite=*/1);
   } else {
-    EXPECT_FALSE(is_eager_malloc);
+    unsetenv("TORCH_RBLN_EAGER_MALLOC");
   }
 }
 

--- a/test/rbln/test_profiler.py
+++ b/test/rbln/test_profiler.py
@@ -29,6 +29,9 @@ carries the hidden-overhead signals plus the memory gauge, and EXCLUDES the
 out-of-scope dispatch/utilization counters.
 """
 
+import os
+from unittest import mock
+
 import pytest
 import torch
 from torch.testing._internal.common_utils import run_tests, TestCase
@@ -196,10 +199,50 @@ class TestProfilerTruthfulnessAndScope(TestCase):
         self.assertGreaterEqual(m["peak_bytes"], m["current_bytes"])
         self.assertGreater(m["peak_bytes"], 0)
 
-    # Removed test_runtime_hidden_d2h_is_cause_tagged: total_count>=1 is not a profiler
-    # invariant -- whether a copy_ incurs a runtime hidden d2h is a runtime/alloc-mode choice
-    # (eager-malloc -> device V2V, legitimately 0). Attribution (no unattributed bucket) is
-    # covered device-free by TestProfilerRuntimeContract.test_dump_maps_every_named_runtime_reason.
+    def test_runtime_hidden_d2h_is_cause_tagged(self):
+        # Deterministic witness for the runtime hidden-d2h path. Pin lazy allocation
+        # (delenv EAGER_MALLOC) so a freshly-created host-latest src forces the runtime's
+        # src_not_on_device v2v hidden d2h; under eager-malloc the copy completes on-device
+        # with 0 hidden d2h, so this must not depend on ambient env. Assert the profiler both
+        # counts the incident AND attributes every one to a named reason (no unattributed).
+        with mock.patch.dict(os.environ):
+            os.environ.pop("TORCH_RBLN_EAGER_MALLOC", None)
+            with torch.rbln.explain() as p:
+                x = torch.randn(256, 256, device=DEV, dtype=torch.float16)
+                y = torch.empty(256, 256, device=DEV, dtype=torch.float16)
+                y.copy_(x)
+        rr = p.dump()["runtime_residency"]
+        if not rr["available"]:
+            self.skipTest("runtime residency counter not exposed by the loaded librbln")
+        self.assertGreaterEqual(rr["total_count"], 1)
+        attributed = sum(v["count"] for v in rr["by_reason"].values())
+        self.assertEqual(attributed, rr["total_count"])  # every hidden d2h is cause-tagged
+        self.assertTrue(any(v["count"] > 0 for v in rr["by_reason"].values()))
+
+    def test_eager_malloc_env_is_live_not_process_latched(self):
+        # Regression for the xdist cross-test leak: is_eager_malloc() reads the env live, so
+        # toggling TORCH_RBLN_EAGER_MALLOC per-test cannot latch the whole worker into eager.
+        # Observable = the hidden-d2h witness (eager -> on-device copy, 0; lazy -> >= 1).
+        def hidden_total():
+            with torch.rbln.explain() as p:
+                x = torch.randn(256, 256, device=DEV, dtype=torch.float16)
+                y = torch.empty(256, 256, device=DEV, dtype=torch.float16)
+                y.copy_(x)
+            return p.dump()["runtime_residency"]
+
+        # set: an allocation under eager (this is what latched the worker on the buggy build)
+        with mock.patch.dict(os.environ, {"TORCH_RBLN_EAGER_MALLOC": "1"}):
+            rr = hidden_total()
+            if not rr["available"]:
+                self.skipTest("runtime residency counter not exposed by the loaded librbln")
+            self.assertEqual(rr["total_count"], 0)
+        # unset: flag is re-read live -> lazy behavior restored, NOT stuck eager
+        with mock.patch.dict(os.environ):
+            os.environ.pop("TORCH_RBLN_EAGER_MALLOC", None)
+            self.assertGreaterEqual(hidden_total()["total_count"], 1)
+        # set again: still tracks the env live
+        with mock.patch.dict(os.environ, {"TORCH_RBLN_EAGER_MALLOC": "1"}):
+            self.assertEqual(hidden_total()["total_count"], 0)
 
     def test_runtime_h2d_push_counted(self):
         # A device op (matmul) consuming host-latest inputs must push them to the

--- a/test/rbln/test_profiler.py
+++ b/test/rbln/test_profiler.py
@@ -196,22 +196,10 @@ class TestProfilerTruthfulnessAndScope(TestCase):
         self.assertGreaterEqual(m["peak_bytes"], m["current_bytes"])
         self.assertGreater(m["peak_bytes"], 0)
 
-    def test_runtime_hidden_d2h_is_cause_tagged(self):
-        # A plain contiguous copy_ of a freshly-created tensor bounces at the
-        # RUNTIME level (torch-side sees nothing). The profiler must not only
-        # count it but attribute the CAUSE — and every incident must map to a
-        # named reason (no unattributed/unknown).
-        with torch.rbln.explain() as p:
-            x = torch.randn(256, 256, device=DEV, dtype=torch.float16)
-            y = torch.empty(256, 256, device=DEV, dtype=torch.float16)
-            y.copy_(x)
-        rr = p.dump()["runtime_residency"]
-        if not rr["available"]:
-            self.skipTest("runtime residency counter not exposed by the loaded librbln")
-        self.assertGreaterEqual(rr["total_count"], 1)
-        attributed = sum(v["count"] for v in rr["by_reason"].values())
-        self.assertEqual(attributed, rr["total_count"])  # no unattributed hidden d2h
-        self.assertTrue(any(v["count"] > 0 for v in rr["by_reason"].values()))
+    # Removed test_runtime_hidden_d2h_is_cause_tagged: total_count>=1 is not a profiler
+    # invariant -- whether a copy_ incurs a runtime hidden d2h is a runtime/alloc-mode choice
+    # (eager-malloc -> device V2V, legitimately 0). Attribution (no unattributed bucket) is
+    # covered device-free by TestProfilerRuntimeContract.test_dump_maps_every_named_runtime_reason.
 
     def test_runtime_h2d_push_counted(self):
         # A device op (matmul) consuming host-latest inputs must push them to the

--- a/test/rbln/test_profiler.py
+++ b/test/rbln/test_profiler.py
@@ -219,31 +219,6 @@ class TestProfilerTruthfulnessAndScope(TestCase):
         self.assertEqual(attributed, rr["total_count"])  # every hidden d2h is cause-tagged
         self.assertTrue(any(v["count"] > 0 for v in rr["by_reason"].values()))
 
-    def test_eager_malloc_env_is_live_not_process_latched(self):
-        # Regression for the xdist cross-test leak: is_eager_malloc() reads the env live, so
-        # toggling TORCH_RBLN_EAGER_MALLOC per-test cannot latch the whole worker into eager.
-        # Observable = the hidden-d2h witness (eager -> on-device copy, 0; lazy -> >= 1).
-        def hidden_total():
-            with torch.rbln.explain() as p:
-                x = torch.randn(256, 256, device=DEV, dtype=torch.float16)
-                y = torch.empty(256, 256, device=DEV, dtype=torch.float16)
-                y.copy_(x)
-            return p.dump()["runtime_residency"]
-
-        # set: an allocation under eager (this is what latched the worker on the buggy build)
-        with mock.patch.dict(os.environ, {"TORCH_RBLN_EAGER_MALLOC": "1"}):
-            rr = hidden_total()
-            if not rr["available"]:
-                self.skipTest("runtime residency counter not exposed by the loaded librbln")
-            self.assertEqual(rr["total_count"], 0)
-        # unset: flag is re-read live -> lazy behavior restored, NOT stuck eager
-        with mock.patch.dict(os.environ):
-            os.environ.pop("TORCH_RBLN_EAGER_MALLOC", None)
-            self.assertGreaterEqual(hidden_total()["total_count"], 1)
-        # set again: still tracks the env live
-        with mock.patch.dict(os.environ, {"TORCH_RBLN_EAGER_MALLOC": "1"}):
-            self.assertEqual(hidden_total()["total_count"], 0)
-
     def test_runtime_h2d_push_counted(self):
         # A device op (matmul) consuming host-latest inputs must push them to the
         # device -> the manager-emitted real_host_sync_h2d counter fires. Symmetric


### PR DESCRIPTION
## Summary of Changes

`is_eager_malloc()` cached `TORCH_RBLN_EAGER_MALLOC` in a process-lifetime `static const bool`. The function-scoped `enable_eager_malloc` fixture toggles that env per-test, but the C++ cache latches the first-observed value for the whole process — so under pytest-xdist, the **first** test that allocates while the fixture is active pins the entire worker into eager mode, leaking it into every later, unrelated test on that worker.

This intermittently failed `test_runtime_hidden_d2h_is_cause_tagged` (`runtime_residency.total_count == 0` instead of `>= 1`: under eager, `y.copy_(x)` completes via device V2V with no hidden d2h). xdist shuffling the eager-latched worker per run is why it looked flaky.

- **Fix (`c10/rbln/RBLNFunctions.cpp`):** read the env live in `is_eager_malloc()` (drop the `static const bool`; compare with `strcmp(env, "1")`). Safe — only `malloc()` consults it and the free path (`rbln_free`) is mode-agnostic, so an alloc/free mode mismatch cannot occur; in production the env is fixed at startup so behavior is unchanged.
- **Make `test_runtime_hidden_d2h_is_cause_tagged` deterministic (not removed):** it now pins **lazy** allocation inside the test (`os.environ.pop("TORCH_RBLN_EAGER_MALLOC")` under `mock.patch.dict`) so the runtime always takes the `src_not_on_device` v2v hidden-d2h path, independent of the ambient/inherited env. The invariant it checks — the profiler counts the incident **and** attributes every hidden d2h to a named reason — is preserved.
- **C++ regression test (`test/cpp/core/RBLNFunctionsTest.cpp`):** `IsEagerMalloc` now actively asserts the live read: set → unset → set → `"0"` flips `is_eager_malloc()` on every call. A re-introduced process-lifetime cache would latch the first value and fail this, locking the fix against regression at the C++ level (no test-only wheel API needed).

## Related Issues / Tickets

* Related to # <!-- fill in: CI flake (test_runtime_hidden_d2h / pinned-unaligned) -->

## Type of Change

- [x] `core` — device layer / C++ extension
- [x] `fix` — Bug fix

## Affected Modules

- [x] Device
- [x] C++ extension (`c10/rbln`)
- [x] Memory

## How to Test

1. C++ GTest `RBLNFunctionsTest.IsEagerMalloc`: asserts `is_eager_malloc()` reflects `set → unset → set → "0"` live (only exactly `"1"` is eager). Pre-fix, the `static` cache latched the first value and this would fail after the first toggle.
2. `pytest test/rbln/test_profiler.py` → green. `test_runtime_hidden_d2h_is_cause_tagged` now pins lazy allocation, so it is deterministic regardless of ambient `TORCH_RBLN_EAGER_MALLOC` (previously flaked when an xdist worker was latched into eager).
3. `TORCH_RBLN_EAGER_MALLOC=1` at process start → still eager; unset → lazy (production opt-in preserved).

## Notes

- The same latent pattern exists for `TORCH_RBLN_DEPLOY` / `is_deploy_mode()` (used by many tests). Not touched here (larger blast radius); the same live-read follow-up is recommended.
- The correlated `test_pinned_roundtrip_unaligned` failure (8194-byte unaligned sync H2V) is a **separate runtime issue** merely exposed by the eager leak; not addressed in this PR.
