### PR TITLE
ci: inline container image references

### DIFF
--- a/.github/workflows/_build-wheel.yaml
+++ b/.github/workflows/_build-wheel.yaml
@@ -47,7 +47,7 @@ jobs:
       GIT_CONFIG_VALUE_0: ${{ github.workspace }}
     timeout-minutes: 60
     container:
-      image: ${{ vars.TORCH_RBLN_IMAGE_BUILD_NAME }}:${{ vars.TORCH_RBLN_IMAGE_BUILD_TAG }}-py${{ inputs.python_version }}  # zizmor: ignore[unpinned-images] internal mutable tag, no digest to pin
+      image: ghcr.io/rebellions-sw/rbln-build:0.11.0-ubi9-py${{ inputs.python_version }}  # zizmor: ignore[unpinned-images]
       credentials:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GIT_PAT }}
@@ -145,7 +145,7 @@ jobs:
           INTERNAL_INDEX_URL: ${{ secrets.INTERNAL_INDEX_URL }}
           UV_PUBLISH_USERNAME: ${{ secrets.INTERNAL_INDEX_USERNAME }}
           UV_PUBLISH_PASSWORD: ${{ secrets.INTERNAL_INDEX_PASSWORD }}
-        run: |  # zizmor: ignore[use-trusted-publishing] internal index uses username/password auth, not OIDC
+        run: |  # zizmor: ignore[use-trusted-publishing]
           set -euo pipefail
 
           # curl authenticates its index query via ~/.netrc.

--- a/.github/workflows/_dispatch-event.yaml
+++ b/.github/workflows/_dispatch-event.yaml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ${{ vars.TORCH_RBLN_RUNNER_CPU_SMALL }}
     timeout-minutes: 60
     container:
-      image: ${{ vars.TORCH_RBLN_IMAGE_NAME }}:${{ vars.TORCH_RBLN_IMAGE_TAG }}-py3.12
+      image: ghcr.io/rebellions-sw/rbln-test:0.11.0-ubuntu22.04-py3.12
       credentials:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GIT_PAT }}

--- a/.github/workflows/check-pr-title.yaml
+++ b/.github/workflows/check-pr-title.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ vars.TORCH_RBLN_RUNNER_CPU_SMALL }}
     timeout-minutes: 10
     container:
-      image: ${{ vars.TORCH_RBLN_IMAGE_NAME }}:${{ vars.TORCH_RBLN_IMAGE_TAG }}-py3.12
+      image: ghcr.io/rebellions-sw/rbln-test:0.11.0-ubuntu22.04-py3.12
       credentials:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GIT_PAT }}

--- a/.github/workflows/lint-workflows.yaml
+++ b/.github/workflows/lint-workflows.yaml
@@ -28,7 +28,7 @@ jobs:
       GIT_CONFIG_VALUE_0: ${{ github.workspace }}
     timeout-minutes: 15
     container:
-      image: ${{ vars.TORCH_RBLN_IMAGE_NAME }}:${{ vars.TORCH_RBLN_IMAGE_TAG }}-py3.12
+      image: ghcr.io/rebellions-sw/rbln-test:0.11.0-ubuntu22.04-py3.12
       credentials:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GIT_PAT }}


### PR DESCRIPTION
## Summary of Changes

Replaces the configuration-variable indirection for the CI container images with literal references. The image each job runs in is now recorded in the workflow itself, so updating it is a reviewable code change rather than an out-of-band variable edit.

---

## Type of Change

- [x] `other` — Other (describe below)

CI infrastructure change only.

---

## Affected Modules

- [x] Build/Tools

---

## Checklist

* [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
* [x] Linting passes — see [Linting](docs/LINTING.md)
* [x] All CI tests pass — see [CI/CD Workflows](docs/WORKFLOWS.md)
* [x] Relevant documentation has been updated (if applicable)

---
