### PR TITLE
fix(profiler): move torch.profiler bridge registration to Python init and gate it by device type

### DIFF
--- a/test/internal/test_device_arch.py
+++ b/test/internal/test_device_arch.py
@@ -6,7 +6,9 @@ import pytest
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import run_tests, TestCase
 
-from test.utils import _arch_from_npu_name, is_atom_device, is_rebel_device, xfail_atom, xfail_rebel
+from test.utils import xfail_atom, xfail_rebel
+
+from torch_rbln._internal.device_arch_utils import _arch_from_npu_name, is_atom_device, is_rebel_device
 
 
 @pytest.mark.test_set_ci
@@ -34,19 +36,19 @@ class TestArchPredicates(TestCase):
     """``is_rebel_device`` / ``is_atom_device`` reflect ``get_device_arch``."""
 
     def test_is_rebel_device_true_on_rebel(self):
-        with patch("test.utils.get_device_arch", return_value="rebel"):
+        with patch("torch_rbln._internal.device_arch_utils.get_device_arch", return_value="rebel"):
             self.assertTrue(is_rebel_device())
 
     def test_is_rebel_device_false_on_atom(self):
-        with patch("test.utils.get_device_arch", return_value="atom"):
+        with patch("torch_rbln._internal.device_arch_utils.get_device_arch", return_value="atom"):
             self.assertFalse(is_rebel_device())
 
     def test_is_atom_device_true_on_atom(self):
-        with patch("test.utils.get_device_arch", return_value="atom"):
+        with patch("torch_rbln._internal.device_arch_utils.get_device_arch", return_value="atom"):
             self.assertTrue(is_atom_device())
 
     def test_is_atom_device_false_on_rebel(self):
-        with patch("test.utils.get_device_arch", return_value="rebel"):
+        with patch("torch_rbln._internal.device_arch_utils.get_device_arch", return_value="rebel"):
             self.assertFalse(is_atom_device())
 
 
@@ -55,25 +57,25 @@ class TestArchXfailMarkers(TestCase):
     """xfail markers set ``condition`` per arch and ``strict=True``."""
 
     def test_xfail_rebel_active_on_rebel(self):
-        with patch("test.utils.get_device_arch", return_value="rebel"):
+        with patch("torch_rbln._internal.device_arch_utils.get_device_arch", return_value="rebel"):
             mark = xfail_rebel("REBEL: feature not yet supported")
         self.assertTrue(mark.mark.kwargs["condition"])
         self.assertTrue(mark.mark.kwargs["strict"])
         self.assertEqual(mark.mark.kwargs["reason"], "REBEL: feature not yet supported")
 
     def test_xfail_rebel_inert_on_atom(self):
-        with patch("test.utils.get_device_arch", return_value="atom"):
+        with patch("torch_rbln._internal.device_arch_utils.get_device_arch", return_value="atom"):
             mark = xfail_rebel("REBEL: feature not yet supported")
         self.assertFalse(mark.mark.kwargs["condition"])
 
     def test_xfail_atom_active_on_atom(self):
-        with patch("test.utils.get_device_arch", return_value="atom"):
+        with patch("torch_rbln._internal.device_arch_utils.get_device_arch", return_value="atom"):
             mark = xfail_atom("ATOM: feature not yet supported")
         self.assertTrue(mark.mark.kwargs["condition"])
         self.assertTrue(mark.mark.kwargs["strict"])
 
     def test_xfail_atom_inert_on_rebel(self):
-        with patch("test.utils.get_device_arch", return_value="rebel"):
+        with patch("torch_rbln._internal.device_arch_utils.get_device_arch", return_value="rebel"):
             mark = xfail_atom("ATOM: feature not yet supported")
         self.assertFalse(mark.mark.kwargs["condition"])
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,4 +1,3 @@
-import functools
 import multiprocessing
 import os
 import random
@@ -8,6 +7,7 @@ import numpy as np
 import pytest
 import torch
 
+from torch_rbln._internal.device_arch_utils import is_atom_device, is_rebel_device
 from torch_rbln._internal.ops_utils import SupportedDtypes
 
 
@@ -87,42 +87,6 @@ def requires_physical_devices(num_devices):
         physical_device_count < num_devices,
         reason=f"Requires at least {num_devices} physical devices, found {physical_device_count}",
     )
-
-
-def _arch_from_npu_name(name: str) -> str:
-    """Map an RBLN NPU name to a device family: ``RBLN-CA*`` -> ``"atom"``,
-    ``RBLN-CR*`` -> ``"rebel"``, anything else -> ``"unknown"``.
-    """
-    name = name.upper()
-    if name.startswith("RBLN-CA"):
-        return "atom"
-    if name.startswith("RBLN-CR"):
-        return "rebel"
-    return "unknown"
-
-
-@functools.lru_cache(maxsize=1)
-def get_device_arch() -> str:
-    """Identify the current NPU family (``"atom"``/``"rebel"``/``"unknown"``) via
-    ``get_npu_name`` from ``rebel-compiler`` (cached). Returns ``"unknown"`` if the
-    NPU name can't be queried.
-    """
-    try:
-        from rebel.device_info import get_npu_name
-
-        return _arch_from_npu_name(get_npu_name(0) or "")
-    except Exception:
-        return "unknown"
-
-
-def is_atom_device() -> bool:
-    """True on the ATOM lineup (``RBLN-CA*``); thin wrapper over :func:`get_device_arch`."""
-    return get_device_arch() == "atom"
-
-
-def is_rebel_device() -> bool:
-    """True on the REBEL lineup (``RBLN-CR*``); thin wrapper over :func:`get_device_arch`."""
-    return get_device_arch() == "rebel"
 
 
 def xfail_atom(reason: str):

--- a/torch_rbln/__init__.py
+++ b/torch_rbln/__init__.py
@@ -194,14 +194,9 @@ def _create_process_group_rbln(dist_backend_opts, pg_options):
 
 def _initialize_kineto_profiler() -> None:
     """Register the rbln torch.profiler (kineto) bridge."""
-    try:
-        from rebel.device_info import get_npu_name
+    from torch_rbln._internal.device_arch_utils import is_atom_device
 
-        npu = (get_npu_name(0) or "").upper()
-    except Exception:
-        npu = ""
-
-    if npu.startswith("RBLN-CA"):  # ATOM
+    if is_atom_device():
         warnings.warn("rbln torch.profiler activities are not supported on ATOM and will be skipped", stacklevel=2)
         return
 

--- a/torch_rbln/__init__.py
+++ b/torch_rbln/__init__.py
@@ -195,6 +195,17 @@ def _create_process_group_rbln(dist_backend_opts, pg_options):
 def _initialize_kineto_profiler() -> None:
     """Register the rbln torch.profiler (kineto) bridge."""
     try:
+        from rebel.device_info import get_npu_name
+
+        npu = (get_npu_name(0) or "").upper()
+    except Exception:
+        npu = ""
+
+    if npu.startswith("RBLN-CA"):  # ATOM
+        warnings.warn("rbln torch.profiler activities are not supported on ATOM and will be skipped", stacklevel=2)
+        return
+
+    try:
         import torch_rbln._C
 
         torch_rbln._C._register_kineto_profiler()

--- a/torch_rbln/__init__.py
+++ b/torch_rbln/__init__.py
@@ -195,9 +195,10 @@ def _create_process_group_rbln(dist_backend_opts, pg_options):
 def _initialize_kineto_profiler() -> None:
     """Register the rbln torch.profiler (kineto) bridge."""
     from torch_rbln._internal.device_arch_utils import is_atom_device
+    from torch_rbln._internal.log_utils import rbln_log_info
 
     if is_atom_device():
-        warnings.warn("rbln torch.profiler activities are not supported on ATOM and will be skipped", stacklevel=2)
+        rbln_log_info("rbln torch.profiler activities are not supported on ATOM and will be skipped")
         return
 
     try:

--- a/torch_rbln/__init__.py
+++ b/torch_rbln/__init__.py
@@ -82,6 +82,9 @@ def torch_backends_entry_point() -> None:
 
         # Note: torch.compile monkey patch is applied in apply_all_patches() above
 
+        # Register torch.profiler (kineto) bridge ##############################
+        _initialize_kineto_profiler()
+
         # Initialize distributed support #######################################
         _initialize_distributed_bindings()
     except Exception:
@@ -187,6 +190,16 @@ def _create_process_group_rbln(dist_backend_opts, pg_options):
     return torch_rbln._C._distributed_c10d.ProcessGroupRBLN(
         store, group_rank, group_size, group_id, global_ranks_in_group, timeout, gloo_backend=gloo_backend
     )
+
+
+def _initialize_kineto_profiler() -> None:
+    """Register the rbln torch.profiler (kineto) bridge."""
+    try:
+        import torch_rbln._C
+
+        torch_rbln._C._register_kineto_profiler()
+    except Exception as e:
+        warnings.warn(f"Failed to register rbln kineto profiler: {e}", stacklevel=2)
 
 
 def _initialize_distributed_bindings() -> None:

--- a/torch_rbln/_internal/device_arch_utils.py
+++ b/torch_rbln/_internal/device_arch_utils.py
@@ -1,0 +1,42 @@
+"""Device architecture detection via RBLN NPU name."""
+
+import functools
+
+
+__all__ = ["get_device_arch", "is_atom_device", "is_rebel_device"]
+
+
+def _arch_from_npu_name(name: str) -> str:
+    """Map an RBLN NPU name to a device family: ``RBLN-CA*`` -> ``"atom"``,
+    ``RBLN-CR*`` -> ``"rebel"``, anything else -> ``"unknown"``.
+    """
+    name = name.upper()
+    if name.startswith("RBLN-CA"):
+        return "atom"
+    if name.startswith("RBLN-CR"):
+        return "rebel"
+    return "unknown"
+
+
+@functools.lru_cache(maxsize=1)
+def get_device_arch() -> str:
+    """Identify the current NPU family (``"atom"``/``"rebel"``/``"unknown"``) via
+    ``get_npu_name`` from ``rebel-compiler`` (cached). Returns ``"unknown"`` if the
+    NPU name can't be queried.
+    """
+    try:
+        from rebel.device_info import get_npu_name
+
+        return _arch_from_npu_name(get_npu_name(0) or "")
+    except Exception:
+        return "unknown"
+
+
+def is_atom_device() -> bool:
+    """True on the ATOM lineup (``RBLN-CA*``); thin wrapper over :func:`get_device_arch`."""
+    return get_device_arch() == "atom"
+
+
+def is_rebel_device() -> bool:
+    """True on the REBEL lineup (``RBLN-CR*``); thin wrapper over :func:`get_device_arch`."""
+    return get_device_arch() == "rebel"

--- a/torch_rbln/csrc/rbln/Module.cpp
+++ b/torch_rbln/csrc/rbln/Module.cpp
@@ -309,6 +309,12 @@ void register_internal_api(py::module_& module) {
       "_set_file_offloading_enabled",
       &c10::rbln::set_file_offloading_enabled,
       "Internal: enable or disable process-wide RBLN vmemory file offloading.");
+
+  // torch.profiler (kineto) integration
+  module.def(
+      "_register_kineto_profiler",
+      &rbln::profiler::kineto::register_rbln_kineto_profiler,
+      "Internal: register the rbln torch.profiler (kineto) bridge");
 }
 
 py::tuple supported_dtypes_to_tuple(c10::ArrayRef<c10::ScalarType> scalar_types) {
@@ -413,7 +419,6 @@ extern "C" PyObject* initModule() {
   register_public_device_api(python_module);
   register_internal_api(python_module);
   register_supported_dtypes_api(python_module);
-  rbln::profiler::kineto::register_rbln_kineto_profiler();
 
   c10::rbln::register_rbln_device_mapping_initialized_callback([]() {
     py::gil_scoped_acquire gil;

--- a/torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_adapter.cc
+++ b/torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_adapter.cc
@@ -168,8 +168,11 @@ class RblnActivityProfiler : public ::libkineto::IActivityProfiler {
           "rbln_kineto_is_active failed with error code: {}; not creating a profiling session", static_cast<int>(ret));
       return nullptr;
     }
-    if (!active)
+    if (!active) {
+      RBLN_LOG_INFO("rbln profiling is not active; skipping rbln activities for this torch.profiler session");
       return nullptr;
+    }
+    RBLN_LOG_DEBUG("rbln profiling is active; creating a profiling session");
     return std::make_unique<RblnActivityProfilerSession>();
   }
 

--- a/torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_adapter.h
+++ b/torch_rbln/csrc/rbln/profiler/kineto/rbln_kineto_adapter.h
@@ -3,9 +3,8 @@
 
 namespace rbln::profiler::kineto {
 
-// Registers the rbln IActivityProfiler factory with libkineto; call once at _C
-// module init. Explicit (not static-init) -- static-init in a pybind module can
-// be dead-stripped.
+// Registers the rbln IActivityProfiler factory with libkineto. Explicit (not
+// static-init) -- static-init in a pybind module can be dead-stripped.
 void register_rbln_kineto_profiler();
 
 } // namespace rbln::profiler::kineto


### PR DESCRIPTION
<!--
Thank you for contributing to torch-rbln!
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: docs/CONTRIBUTING.md
-->

## Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format.
see: https://www.conventionalcommits.org/en/v1.0.0/
-->

<!-- Describe your changes in detail -->

- Move the torch.profiler (kineto) bridge registration from C++ module init to Python init.
- Gate the registration by device type, enabling it only on supported devices.
- Log when rbln profiling is inactive so a skipped torch.profiler session is visible.


---

## Related Issues / Tickets

<!--
All pull requests must have a corresponding issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
see: docs/CONTRIBUTING.md#pull-request-guidelines
-->

* Related to # https://github.com/rebellions-sw/rebel_compiler/pull/12079

---

## Type of Change

<!--
Select the type that best describes your PR. This should match the issue label.
see: docs/CONTRIBUTING.md#development-related-issue
-->

- [ ] `feature` — New capability or functionality
- [ ] `core` — Changes to RBLN backend, device layer, C++ extension, op registration, or `torch.compile` integration
- [ ] `fix` — Bug fix
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code improvement without behavior change
- [ ] `docs` — Documentation only
- [ ] `other` — Other (describe below)

---

## Affected Modules

<!--
Check all modules affected by this change.
-->

- [ ] Backend
- [ ] Device
- [ ] Ops/Kernels
- [ ] `torch.compile`
- [x] C++ extension (`torch_rbln/csrc`)
- [ ] Memory
- [ ] Build/Tools
- [ ] Docs

---

## How to Test (if applicable)

<!--
Describe the steps to verify your changes. Include expected results.
see: docs/TEST_GUIDE.md
-->

- On a supported device: run a model under `torch.profiler.profile(...)` and confirm rbln activities appear in the exported trace.
- On an unsupported device type: registration is skipped and a warning is logged at import; `import torch_rbln` and `torch.profiler` still run without error (no rbln activities in the trace).

---

## Screenshots / Logs (if applicable)

<!-- Add before/after screenshots, terminal output, or logs -->

---

## Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
* [ ] This PR is linked to a corresponding issue — see [Contributing to torch-rbln](docs/CONTRIBUTING.md)
* [x] Linting passes — see [Linting](docs/LINTING.md)
* [x] All CI tests pass — see [CI/CD Workflows](docs/WORKFLOWS.md)
* [ ] The test method is described, and the expected result is clearly stated (if applicable)
* [ ] Relevant documentation has been updated (if applicable)

---

## Notes

<!-- Anything reviewers should pay extra attention to? -->

---
