### PR TITLE
ci: add source linting

### DIFF
--- a/.github/workflows/_lint-source.yaml
+++ b/.github/workflows/_lint-source.yaml
@@ -1,0 +1,126 @@
+name: Lint source
+
+on:
+  workflow_call:
+    inputs:
+      torch_rbln_sha:
+        description: Git commit SHA
+        type: string
+        required: true
+      python_version:
+        description: Python version to lint under (3.10-3.13)
+        type: string
+        required: true
+      lint_all_files:
+        description: Lint every tracked file instead of only changed files
+        type: boolean
+        required: false
+        default: false
+    secrets:
+      GIT_PAT:
+        description: Personal access token
+        required: true
+      INTERNAL_INDEX_URL:
+        description: Internal package index URL
+        required: true
+      INTERNAL_INDEX_USERNAME:
+        description: Internal package index username
+        required: true
+      INTERNAL_INDEX_PASSWORD:
+        description: Internal package index password
+        required: true
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  lint_source:
+    name: Lint source (py${{ inputs.python_version }})
+    if: ${{ github.repository_owner == vars.TORCH_RBLN_REPO_OWNER }}
+    runs-on: ${{ vars.TORCH_RBLN_RUNNER_CPU_SMALL }}
+    env:
+      GIT_CONFIG_COUNT: '1'
+      GIT_CONFIG_KEY_0: safe.directory
+      GIT_CONFIG_VALUE_0: ${{ github.workspace }}
+    timeout-minutes: 60
+    container:
+      image: ghcr.io/rebellions-sw/rbln-build:0.11.0-ubi9-py${{ inputs.python_version }}  # zizmor: ignore[unpinned-images]
+      credentials:
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GIT_PAT }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          ref: ${{ inputs.torch_rbln_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
+
+      - name: Install dependencies
+        env:
+          UV_INDEX: rbln=${{ secrets.INTERNAL_INDEX_URL }}
+          UV_INDEX_RBLN_USERNAME: ${{ secrets.INTERNAL_INDEX_USERNAME }}
+          UV_INDEX_RBLN_PASSWORD: ${{ secrets.INTERNAL_INDEX_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          # clang-tidy needs the Rebel runtime headers, which ship only in the build-pinned rebel-compiler.
+          uv sync --no-install-project --no-install-package rebel-compiler
+          uv pip install --constraint constraints-build-dev.txt rebel-compiler
+
+      - name: Cache linter binaries
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+        with:
+          path: .lintbin
+          # The binaries are native tools, not Python-specific.
+          key: lintbin-${{ hashFiles('tools/linter/adapters/s3_init_config.json') }}
+
+      - name: Initialize linters
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4.0.0
+        with:
+          timeout_minutes: 15
+          max_attempts: 2
+          command: uv run --no-sync lintrunner init
+
+      - name: Configure CMake for clang-tidy
+        run: |
+          set -euo pipefail
+
+          [[ -f /etc/os-release ]] && . /etc/os-release
+          case "${ID:-}:${ID_LIKE:-}" in
+            *debian* | *ubuntu*) export CC=gcc-13 CXX=g++-13 ;;
+            *) source /opt/rh/gcc-toolset-13/enable ;;
+          esac
+
+          uv run --no-sync cmake -GNinja -B build -S . \
+            -DBUILD_SHARED_LIBS=ON \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=torch_rbln
+
+      - name: Run lintrunner
+        env:
+          LINT_ALL_FILES: ${{ inputs.lint_all_files }}
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+
+          if [ "${LINT_ALL_FILES}" = "true" ]; then
+            uv run --no-sync lintrunner --paths-cmd='git ls-files'
+          else
+            if [ "${EVENT_NAME}" = "pull_request" ]; then
+              git fetch --no-tags origin "${BASE_REF}"
+              diff_base="origin/${BASE_REF}"
+            else
+              diff_base="${BEFORE_SHA}"
+            fi
+            uv run --no-sync lintrunner -m "${diff_base}"
+          fi

--- a/.github/workflows/_lint-workflows.yaml
+++ b/.github/workflows/_lint-workflows.yaml
@@ -1,10 +1,16 @@
 name: Lint workflows
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-  push:
-    branches: [main, dev]
+  workflow_call:
+    inputs:
+      torch_rbln_sha:
+        description: Git commit SHA
+        type: string
+        required: true
+    secrets:
+      GIT_PAT:
+        description: Personal access token
+        required: true
 
 permissions:
   contents: read
@@ -12,10 +18,6 @@ permissions:
 defaults:
   run:
     shell: bash
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
   lint_workflows:
@@ -36,33 +38,33 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
+          ref: ${{ inputs.torch_rbln_sha }}
           persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
 
-      - name: Install workflow lint tools
+      - name: Install dependencies
         run: |
           set -euo pipefail
 
-          uv venv .venv-lint
-          uv pip install --group lint --python .venv-lint/bin/python
-          echo "${PWD}/.venv-lint/bin" >> "${GITHUB_PATH}"
+          uv venv
+          uv pip install --group lint
 
       - name: Run actionlint
         run: |
           set -euo pipefail
 
-          actionlint
+          uv run --no-sync actionlint
 
       - name: Run yamllint
         run: |
           set -euo pipefail
 
-          yamllint --strict .github/
+          uv run --no-sync yamllint --strict .github/
 
       - name: Run zizmor
         run: |
           set -euo pipefail
 
-          zizmor --offline .github/
+          uv run --no-sync zizmor --offline .github/

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,68 @@
+name: Lint
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main, dev]
+  push:
+    branches: [dev]
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  lint_source:
+    strategy:
+      fail-fast: false
+      matrix:
+        python_version: ${{ fromJSON(github.base_ref == 'main' && '["3.10", "3.11", "3.12", "3.13"]' || '["3.12"]') }}
+    uses: ./.github/workflows/_lint-source.yaml
+    with:
+      torch_rbln_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      python_version: ${{ matrix.python_version }}
+      lint_all_files: ${{ github.base_ref == 'main' }}
+    secrets:
+      GIT_PAT: ${{ secrets.GIT_PAT }}
+      INTERNAL_INDEX_URL: ${{ secrets.INTERNAL_INDEX_URL }}
+      INTERNAL_INDEX_USERNAME: ${{ secrets.INTERNAL_INDEX_USERNAME }}
+      INTERNAL_INDEX_PASSWORD: ${{ secrets.INTERNAL_INDEX_PASSWORD }}
+
+  lint_workflows:
+    uses: ./.github/workflows/_lint-workflows.yaml
+    with:
+      torch_rbln_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+    secrets:
+      GIT_PAT: ${{ secrets.GIT_PAT }}
+
+  lint_gate:
+    name: Lint
+    if: ${{ always() && github.repository_owner == vars.TORCH_RBLN_REPO_OWNER }}
+    needs: [lint_source, lint_workflows]
+    runs-on: ${{ vars.TORCH_RBLN_RUNNER_CPU_SMALL }}
+    timeout-minutes: 10
+    container:
+      image: ghcr.io/rebellions-sw/rbln-test:0.11.0-ubuntu22.04-py3.12
+      credentials:
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GIT_PAT }}
+    steps:
+      - name: Verify lint results
+        env:
+          SOURCE_RESULT: ${{ needs.lint_source.result }}
+          WORKFLOWS_RESULT: ${{ needs.lint_workflows.result }}
+        run: |
+          set -euo pipefail
+
+          if [ "${SOURCE_RESULT}" != "success" ] || [ "${WORKFLOWS_RESULT}" != "success" ]; then
+            echo "::error::Lint failed (source=${SOURCE_RESULT}, workflows=${WORKFLOWS_RESULT})"
+            exit 1
+          fi
+          echo "::notice::All lint checks passed"

--- a/docs/LINTING.md
+++ b/docs/LINTING.md
@@ -1,26 +1,47 @@
 # Linting
 
-A Git `pre-commit` hook runs linting automatically on commit. Initialize `lintrunner` once:
+## Source linting
+
+[Source linting](WORKFLOWS.md#lint-workflow) runs `lintrunner` over the source tree.
+
+Install dependencies and initialize `lintrunner` once:
 
 ```bash
-source .venv/bin/activate
-lintrunner init
+uv sync --no-install-project
+uv run --no-sync lintrunner init
 ```
 
-After initialization, linting runs on every `git commit`. To manually lint and auto-fix:
+For C++ changes, `clang-tidy` needs the Rebel runtime headers and a compile database. Install the build-pinned rebel-compiler, then configure CMake:
 
 ```bash
-lintrunner -m main -a
+uv pip install --constraint constraints-build-dev.txt rebel-compiler
+uv run --no-sync cmake -GNinja -B build -S . \
+  -DBUILD_SHARED_LIBS=ON \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX=torch_rbln
+```
+
+To lint and auto-fix changed files:
+
+```bash
+uv run --no-sync lintrunner -m origin/main -a
 ```
 
 ## Workflow linting
 
-[Workflow linting](WORKFLOWS.md#lint-workflows) runs [`actionlint`](https://github.com/rhysd/actionlint), [`yamllint`](https://github.com/adrienverge/yamllint), and [`zizmor`](https://github.com/zizmorcore/zizmor) on the workflow files. To run them locally:
+[Workflow linting](WORKFLOWS.md#lint-workflow) runs [`actionlint`](https://github.com/rhysd/actionlint), [`yamllint`](https://github.com/adrienverge/yamllint), and [`zizmor`](https://github.com/zizmorcore/zizmor) on the workflow files.
+
+Install dependencies once:
 
 ```bash
+uv venv
 uv pip install --group lint
+```
 
-actionlint
-yamllint --strict .github/
-zizmor --offline .github/
+To run them locally:
+
+```bash
+uv run --no-sync actionlint
+uv run --no-sync yamllint --strict .github/
+uv run --no-sync zizmor --offline .github/
 ```

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -11,7 +11,7 @@ This document describes the GitHub Actions workflows that power the automated te
 | CD (`cd.yaml`)                         | Version tags (`v*`)           | Build and publish release artifacts | Deployment pipeline                                                |
 | Build (`build.yaml`)                   | PRs; manual dispatch          | Build and publish the wheel         | —                                                                  |
 | Check PR Title (`check-pr-title.yaml`) | PR opened, edited, or updated | Enforce Conventional Commits format | —                                                                  |
-| Lint workflows (`lint-workflows.yaml`) | PRs; pushes to `main`/`dev`   | Lint the workflow files             | —                                                                  |
+| Lint (`lint.yaml`)                     | PRs; pushes to `dev`          | Lint the source tree and workflows  | —                                                                  |
 
 CI, Release, and CD workflows delegate to a shared [Event Dispatch](#event-dispatch-mechanism) mechanism that sends events to infrastructure with physical RBLN NPU devices.
 
@@ -26,9 +26,9 @@ CI, Release, and CD workflows delegate to a shared [Event Dispatch](#event-dispa
 | CD             | —                               | Tags matching `v*` | **No**              |
 | Build          | All PRs                         | —                  | PRs only            |
 | Check PR Title | On open, edit, sync, reopen     | —                  | Yes                 |
-| Lint workflows | All PRs                         | To `main`/`dev`    | Yes                 |
+| Lint           | To `main` or `dev`              | To `dev`           | Yes                 |
 
-CI and Release runs are grouped by PR number (or SHA for pushes); a new push cancels the in-progress run. CD runs are never cancelled — once a deployment starts, it runs to completion. Check PR Title runs are grouped by PR number and always cancel the in-progress run. Build also runs on manual `workflow_dispatch`; its PR runs are grouped by PR number and cancel superseded commits, while dispatch runs are grouped by run ID and always complete.
+CI, Release, and Lint runs are grouped by PR number (or SHA for pushes); a new push cancels the in-progress run. CD runs are never cancelled — once a deployment starts, it runs to completion. Check PR Title runs are grouped by PR number and always cancel the in-progress run. Build also runs on manual `workflow_dispatch`; its PR runs are grouped by PR number and cancel superseded commits, while dispatch runs are grouped by run ID and always complete.
 
 ---
 
@@ -107,11 +107,16 @@ If the title is invalid, the workflow uses [`marocchino/sticky-pull-request-comm
 
 ---
 
-## Lint Workflows
+## Lint Workflow
 
-**File:** [`.github/workflows/lint-workflows.yaml`](../.github/workflows/lint-workflows.yaml)
+**File:** [`.github/workflows/lint.yaml`](../.github/workflows/lint.yaml)
 
-This workflow runs `actionlint`, `yamllint`, and `zizmor` on the workflow files (see [Linting](LINTING.md)).
+The Lint workflow runs on pull requests to `main` or `dev` and on pushes to `dev`, fanning out to two reusable workflows:
+
+- [`_lint-source.yaml`](../.github/workflows/_lint-source.yaml) runs `lintrunner` over the source tree (see [Linting](LINTING.md)). A pull request to `main` (release validation) lints every tracked file across Python 3.10–3.13; pull requests and pushes to `dev` lint only the changed files on 3.12, for fast feedback.
+- [`_lint-workflows.yaml`](../.github/workflows/_lint-workflows.yaml) runs `actionlint`, `yamllint`, and `zizmor` on the workflow files.
+
+A final `Lint` job aggregates both, so branch protection has one stable check even as the source matrix varies by branch.
 
 ---
 
@@ -150,4 +155,4 @@ It can also be run manually via `workflow_dispatch`, optionally pinning a specif
 - [Release Process](RELEASE_PROCESS.md) — Branch model, versioning, tagging, and publication
 - [Contributing Guide](CONTRIBUTING.md) — PR requirements and merge policy
 - [Test Guide](TEST_GUIDE.md) — Test infrastructure, markers, and `run_tests.py` usage
-- [Linting](LINTING.md) — Code style and pre-commit hooks
+- [Linting](LINTING.md) — `lintrunner` and the workflow linters


### PR DESCRIPTION
## Summary of Changes

Adds `lint.yaml`, which runs `lintrunner` over the source tree alongside the existing workflow linting, aggregating both into a single `Lint` check. The source lint uses a Python 3.10–3.13 matrix because `mypy` is interpreter-specific.

The existing workflow linting also becomes a reusable workflow, using `uv` like the source lint.

---

## Type of Change

- [x] `other` — Other (describe below)

CI infrastructure change only.

---

## Affected Modules

- [x] Build/Tools
- [x] Docs

---

## Checklist

* [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
* [x] Linting passes — see [Linting](docs/LINTING.md)
* [x] All CI tests pass — see [CI/CD Workflows](docs/WORKFLOWS.md)
* [x] Relevant documentation has been updated (if applicable)

---
