### PR TITLE
fix(device): track per-process context so memory ops match CUDA's initialized() contract

### DIFF
--- a/c10/rbln/RBLNAllocator.cpp
+++ b/c10/rbln/RBLNAllocator.cpp
@@ -68,12 +68,13 @@ struct RBLNAllocator final : public c10::DeviceAllocator {
   }
 
   bool initialized() override {
-    // Gates torch.accelerator.empty_cache()/memory_stats(). Not noexcept upstream, but
-    // torch calls it as a predicate (incl. cleanup paths), so keep it total — a throw
-    // aborts the caller on a false alarm. Nothrow device count (cf. runtime_available());
-    // a malformed config still surfaces at real device use.
-    const bool is_initialized =
-        rbln_runtime_available() && (c10::rbln::is_dummy_device() || c10::rbln::get_device_count_nothrow() > 0);
+    // Gates torch.accelerator.empty_cache()/memory_stats(). CUDA parity: true only once
+    // THIS process has actually created allocator state (a successful device malloc),
+    // not merely because a device/mapping exists — so a process with the runtime but no
+    // live context (e.g. a vLLM EngineCore parent) reports false and those ops no-op
+    // instead of dispatching into a contextless runtime. Nothrow (torch calls this as a
+    // predicate, incl. cleanup paths, where a throw would abort the caller).
+    const bool is_initialized = c10::rbln::runtime_available() && c10::rbln::any_device_context_initialized();
     RBLN_LOG_DEBUG("is_initialized={}", is_initialized);
     return is_initialized;
   }

--- a/c10/rbln/RBLNAllocator.cpp
+++ b/c10/rbln/RBLNAllocator.cpp
@@ -68,11 +68,12 @@ struct RBLNAllocator final : public c10::DeviceAllocator {
   }
 
   bool initialized() override {
-    // Gates torch.accelerator.empty_cache()/memory_stats(). Runtime check first so a
-    // missing runtime is false (not a segfault); throwing get_device_count() keeps a
-    // malformed config loud when the runtime is present.
+    // Gates torch.accelerator.empty_cache()/memory_stats(). Not noexcept upstream, but
+    // torch calls it as a predicate (incl. cleanup paths), so keep it total — a throw
+    // aborts the caller on a false alarm. Nothrow device count (cf. runtime_available());
+    // a malformed config still surfaces at real device use.
     const bool is_initialized =
-        rbln_runtime_available() && (c10::rbln::is_dummy_device() || c10::rbln::get_device_count() > 0);
+        rbln_runtime_available() && (c10::rbln::is_dummy_device() || c10::rbln::get_device_count_nothrow() > 0);
     RBLN_LOG_DEBUG("is_initialized={}", is_initialized);
     return is_initialized;
   }

--- a/c10/rbln/RBLNAllocator.cpp
+++ b/c10/rbln/RBLNAllocator.cpp
@@ -74,7 +74,9 @@ struct RBLNAllocator final : public c10::DeviceAllocator {
     // live context (e.g. a vLLM EngineCore parent) reports false and those ops no-op
     // instead of dispatching into a contextless runtime. Nothrow (torch calls this as a
     // predicate, incl. cleanup paths, where a throw would abort the caller).
-    const bool is_initialized = c10::rbln::runtime_available() && c10::rbln::any_device_context_initialized();
+    // Context flag first: a cleanup predicate must not trigger device enumeration/registration
+    // as a side effect when this process has no context.
+    const bool is_initialized = c10::rbln::any_device_context_initialized() && c10::rbln::runtime_available();
     RBLN_LOG_DEBUG("is_initialized={}", is_initialized);
     return is_initialized;
   }

--- a/c10/rbln/RBLNFunctions.cpp
+++ b/c10/rbln/RBLNFunctions.cpp
@@ -861,10 +861,15 @@ void empty_cache(const c10::Device& device) {
   check_device_index(device_index);
   const auto device_id = to_device_id(device_index);
   RBLN_LOG_DEBUG("Calling rbln_empty_cache: device_id={}", device_id);
-  RBLN_CHECK(
-      !rbln_empty_cache(device_id),
-      "rbln_empty_cache failed for rbln:{} (device may be busy or in a faulted state)",
-      static_cast<int>(device_index));
+  // Best-effort: a failed cache flush must not abort the caller (CUDA parity — empty_cache
+  // never raises). A process with no live context makes the runtime fail here, and
+  // cleanup/teardown paths call this; warn instead. A real fault resurfaces at the next
+  // mandatory op (malloc/copy/execute, all hard-checked).
+  if (rbln_empty_cache(device_id)) {
+    RBLN_WARN_NOTHROW(
+        "rbln_empty_cache failed for rbln:{} (device may be busy or in a faulted state); skipping cache flush",
+        static_cast<int>(device_index));
+  }
 }
 
 std::map<std::string, uint64_t> memory_stats(const c10::Device& device) {
@@ -894,10 +899,11 @@ void reset_accumulated_memory_stats(const c10::Device& device) {
   check_device_index(device_index);
   const auto device_id = to_device_id(device_index);
   RBLN_LOG_DEBUG("Calling rbln_reset_accumulated_memory_stats: device_id={}", device_id);
-  RBLN_CHECK(
-      !rbln_reset_accumulated_memory_stats(device_id),
-      "rbln_reset_accumulated_memory_stats failed for rbln:{}",
-      static_cast<int>(device_index));
+  // Best-effort (see empty_cache): a failed reset carries no correctness meaning; warn, don't throw.
+  if (rbln_reset_accumulated_memory_stats(device_id)) {
+    RBLN_WARN_NOTHROW(
+        "rbln_reset_accumulated_memory_stats failed for rbln:{}; skipping reset", static_cast<int>(device_index));
+  }
 }
 
 void reset_peak_memory_stats(const c10::Device& device) {
@@ -911,10 +917,11 @@ void reset_peak_memory_stats(const c10::Device& device) {
   check_device_index(device_index);
   const auto device_id = to_device_id(device_index);
   RBLN_LOG_DEBUG("Calling rbln_reset_peak_memory_stats: device_id={}", device_id);
-  RBLN_CHECK(
-      !rbln_reset_peak_memory_stats(device_id),
-      "rbln_reset_peak_memory_stats failed for rbln:{}",
-      static_cast<int>(device_index));
+  // Best-effort (see empty_cache): a failed reset carries no correctness meaning; warn, don't throw.
+  if (rbln_reset_peak_memory_stats(device_id)) {
+    RBLN_WARN_NOTHROW(
+        "rbln_reset_peak_memory_stats failed for rbln:{}; skipping reset", static_cast<int>(device_index));
+  }
 }
 
 void set_file_offloading_enabled(bool enabled) {

--- a/c10/rbln/RBLNFunctions.cpp
+++ b/c10/rbln/RBLNFunctions.cpp
@@ -410,6 +410,32 @@ bool runtime_available() noexcept {
       (is_dummy_device() || get_device_count_nothrow() > 0);
 }
 
+// --- Per-process device-context tracking ------------------------------------
+// A per-logical-device bit set on the first successful device malloc, mirroring CUDA's
+// device_allocator populated on first use. Backs initialized()/hasPrimaryContext() and
+// gates the best-effort memory ops, so a process with the runtime + a mapping but no live
+// context (e.g. a vLLM EngineCore parent) reports uninitialized. Set-once, lock-free.
+// Not reset across fork: RBLN-in-fork-child is unsupported (contexts don't survive fork).
+namespace {
+std::atomic<uint64_t> g_context_init_mask{0};
+constexpr c10::DeviceIndex kMaxTrackedDevices = 64; // one bit per logical device
+} // namespace
+
+void mark_device_context_initialized(c10::DeviceIndex device_index) noexcept {
+  if (device_index >= 0 && device_index < kMaxTrackedDevices) {
+    g_context_init_mask.fetch_or(uint64_t{1} << device_index, std::memory_order_relaxed);
+  }
+}
+
+bool device_context_initialized(c10::DeviceIndex device_index) noexcept {
+  return device_index >= 0 && device_index < kMaxTrackedDevices &&
+      ((g_context_init_mask.load(std::memory_order_relaxed) >> device_index) & 1U) != 0;
+}
+
+bool any_device_context_initialized() noexcept {
+  return g_context_init_mask.load(std::memory_order_relaxed) != 0;
+}
+
 void* malloc(c10::DeviceIndex device_index, size_t nbytes) {
   RBLN_LOG_DEBUG("logical device=rbln:{}, nbytes={}", static_cast<int>(device_index), nbytes);
   RBLN_CHECK(nbytes > 0, "nbytes must be positive, but got {}", nbytes);
@@ -449,6 +475,7 @@ void* malloc(c10::DeviceIndex device_index, size_t nbytes) {
   auto* data = reinterpret_cast<void*>(vaddr); // NOLINT(performance-no-int-to-ptr)
   RBLN_LOG_DEBUG("data={}", fmt::ptr(data));
   RBLN_CHECK(data != nullptr, "data cannot be nullptr");
+  mark_device_context_initialized(device_index); // this process now owns context on this device
   return data;
 }
 
@@ -800,8 +827,16 @@ c10::CachingDeviceAllocator::DeviceStats get_device_stats(const c10::Device& dev
   if (!runtime_available()) {
     return c10::CachingDeviceAllocator::DeviceStats{};
   }
+  // Two-level context gate (see empty_cache): empty stats when this process/device has no
+  // allocator state; an invalid index still throws once the allocator is in use.
+  if (!any_device_context_initialized()) {
+    return c10::CachingDeviceAllocator::DeviceStats{};
+  }
   const auto device_index = device.index();
   check_device_index(device_index);
+  if (!device_context_initialized(device_index)) {
+    return c10::CachingDeviceAllocator::DeviceStats{};
+  }
   const auto device_id = to_device_id(device_index);
   RBLN_LOG_DEBUG("Calling rbln_get_memory_stats: device_id={}", device_id);
   const auto memory_stats = rbln_get_memory_stats(device_id);
@@ -857,19 +892,27 @@ void empty_cache(const c10::Device& device) {
   if (!runtime_available()) {
     return;
   }
+  // Two-level context gate (CUDA parity): no allocator state anywhere → no-op (a no-context
+  // parent or malformed config; never dispatches); otherwise validate the index (invalid
+  // throws) and skip a device this process never used.
+  if (!any_device_context_initialized()) {
+    return;
+  }
   const auto device_index = device.index();
   check_device_index(device_index);
+  if (!device_context_initialized(device_index)) {
+    return;
+  }
   const auto device_id = to_device_id(device_index);
   RBLN_LOG_DEBUG("Calling rbln_empty_cache: device_id={}", device_id);
-  // Best-effort: a failed cache flush must not abort the caller (CUDA parity — empty_cache
-  // never raises). A process with no live context makes the runtime fail here, and
-  // cleanup/teardown paths call this; warn instead. A real fault resurfaces at the next
-  // mandatory op (malloc/copy/execute, all hard-checked).
-  if (rbln_empty_cache(device_id)) {
-    RBLN_WARN_NOTHROW(
-        "rbln_empty_cache failed for rbln:{} (device may be busy or in a faulted state); skipping cache flush",
-        static_cast<int>(device_index));
-  }
+  // Live context: surface a genuine failure (CUDA parity — an initialized allocator
+  // propagates real errors); rc included for diagnosis.
+  const auto rc = rbln_empty_cache(device_id);
+  RBLN_CHECK(
+      !rc,
+      "rbln_empty_cache failed for rbln:{} (rc={}); the device may be busy or in a faulted state",
+      static_cast<int>(device_index),
+      static_cast<int>(rc));
 }
 
 std::map<std::string, uint64_t> memory_stats(const c10::Device& device) {
@@ -878,8 +921,15 @@ std::map<std::string, uint64_t> memory_stats(const c10::Device& device) {
   if (!runtime_available()) {
     return {};
   }
+  // Two-level context gate (see empty_cache).
+  if (!any_device_context_initialized()) {
+    return {};
+  }
   const auto device_index = device.index();
   check_device_index(device_index);
+  if (!device_context_initialized(device_index)) {
+    return {};
+  }
   const auto device_id = to_device_id(device_index);
   RBLN_LOG_DEBUG("Calling rbln_get_memory_stats: rbln:{}, device_id={}", static_cast<int>(device_index), device_id);
   const auto stats = rbln_get_memory_stats(device_id);
@@ -895,15 +945,24 @@ void reset_accumulated_memory_stats(const c10::Device& device) {
   if (!runtime_available()) {
     return;
   }
+  // Two-level context gate (see empty_cache).
+  if (!any_device_context_initialized()) {
+    return;
+  }
   const auto device_index = device.index();
   check_device_index(device_index);
+  if (!device_context_initialized(device_index)) {
+    return;
+  }
   const auto device_id = to_device_id(device_index);
   RBLN_LOG_DEBUG("Calling rbln_reset_accumulated_memory_stats: device_id={}", device_id);
-  // Best-effort (see empty_cache): a failed reset carries no correctness meaning; warn, don't throw.
-  if (rbln_reset_accumulated_memory_stats(device_id)) {
-    RBLN_WARN_NOTHROW(
-        "rbln_reset_accumulated_memory_stats failed for rbln:{}; skipping reset", static_cast<int>(device_index));
-  }
+  // Live context: surface a genuine failure (a silent success would mislead the caller).
+  const auto rc = rbln_reset_accumulated_memory_stats(device_id);
+  RBLN_CHECK(
+      !rc,
+      "rbln_reset_accumulated_memory_stats failed for rbln:{} (rc={})",
+      static_cast<int>(device_index),
+      static_cast<int>(rc));
 }
 
 void reset_peak_memory_stats(const c10::Device& device) {
@@ -913,15 +972,25 @@ void reset_peak_memory_stats(const c10::Device& device) {
   if (!runtime_available()) {
     return;
   }
+  // Two-level context gate (see empty_cache). This is also the only guard for the generic
+  // torch.accelerator.reset_peak path (no Python init-guard upstream).
+  if (!any_device_context_initialized()) {
+    return;
+  }
   const auto device_index = device.index();
   check_device_index(device_index);
+  if (!device_context_initialized(device_index)) {
+    return;
+  }
   const auto device_id = to_device_id(device_index);
   RBLN_LOG_DEBUG("Calling rbln_reset_peak_memory_stats: device_id={}", device_id);
-  // Best-effort (see empty_cache): a failed reset carries no correctness meaning; warn, don't throw.
-  if (rbln_reset_peak_memory_stats(device_id)) {
-    RBLN_WARN_NOTHROW(
-        "rbln_reset_peak_memory_stats failed for rbln:{}; skipping reset", static_cast<int>(device_index));
-  }
+  // Live context: surface a genuine failure.
+  const auto rc = rbln_reset_peak_memory_stats(device_id);
+  RBLN_CHECK(
+      !rc,
+      "rbln_reset_peak_memory_stats failed for rbln:{} (rc={})",
+      static_cast<int>(device_index),
+      static_cast<int>(rc));
 }
 
 void set_file_offloading_enabled(bool enabled) {

--- a/c10/rbln/RBLNFunctions.cpp
+++ b/c10/rbln/RBLNFunctions.cpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <limits>
 #include <map>
 #include <mutex>
 #include <vector>
@@ -415,25 +416,31 @@ bool runtime_available() noexcept {
 // device_allocator populated on first use. Backs initialized()/hasPrimaryContext() and
 // gates the best-effort memory ops, so a process with the runtime + a mapping but no live
 // context (e.g. a vLLM EngineCore parent) reports uninitialized. Set-once, lock-free.
-// Not reset across fork: RBLN-in-fork-child is unsupported (contexts don't survive fork).
+// RBLN device use after fork is unsupported; bad-fork detection is not implemented yet
+// (the mask is inherited stale in a fork child).
 namespace {
-std::atomic<uint64_t> g_context_init_mask{0};
-constexpr c10::DeviceIndex kMaxTrackedDevices = 64; // one bit per logical device
+// Two 64-bit words cover the full valid DeviceIndex range. DeviceMappingManager caps
+// logical devices at numeric_limits<DeviceIndex>::max(), so valid indices are
+// [0, max) = [0, 126] and index 127 is never a device — no valid device is silently
+// untracked (the earlier single-word tracker dropped indices 64+).
+constexpr c10::DeviceIndex kMaxTrackedDevices = std::numeric_limits<c10::DeviceIndex>::max(); // 127
+std::array<std::atomic<uint64_t>, 2> g_context_init_mask{}; // 128 bits
 } // namespace
 
 void mark_device_context_initialized(c10::DeviceIndex device_index) noexcept {
   if (device_index >= 0 && device_index < kMaxTrackedDevices) {
-    g_context_init_mask.fetch_or(uint64_t{1} << device_index, std::memory_order_relaxed);
+    g_context_init_mask[device_index >> 6].fetch_or(uint64_t{1} << (device_index & 63), std::memory_order_relaxed);
   }
 }
 
 bool device_context_initialized(c10::DeviceIndex device_index) noexcept {
   return device_index >= 0 && device_index < kMaxTrackedDevices &&
-      ((g_context_init_mask.load(std::memory_order_relaxed) >> device_index) & 1U) != 0;
+      ((g_context_init_mask[device_index >> 6].load(std::memory_order_relaxed) >> (device_index & 63)) & 1U) != 0;
 }
 
 bool any_device_context_initialized() noexcept {
-  return g_context_init_mask.load(std::memory_order_relaxed) != 0;
+  return (g_context_init_mask[0].load(std::memory_order_relaxed) |
+          g_context_init_mask[1].load(std::memory_order_relaxed)) != 0;
 }
 
 void* malloc(c10::DeviceIndex device_index, size_t nbytes) {
@@ -827,16 +834,8 @@ c10::CachingDeviceAllocator::DeviceStats get_device_stats(const c10::Device& dev
   if (!runtime_available()) {
     return c10::CachingDeviceAllocator::DeviceStats{};
   }
-  // Two-level context gate (see empty_cache): empty stats when this process/device has no
-  // allocator state; an invalid index still throws once the allocator is in use.
-  if (!any_device_context_initialized()) {
-    return c10::CachingDeviceAllocator::DeviceStats{};
-  }
   const auto device_index = device.index();
   check_device_index(device_index);
-  if (!device_context_initialized(device_index)) {
-    return c10::CachingDeviceAllocator::DeviceStats{};
-  }
   const auto device_id = to_device_id(device_index);
   RBLN_LOG_DEBUG("Calling rbln_get_memory_stats: device_id={}", device_id);
   const auto memory_stats = rbln_get_memory_stats(device_id);
@@ -888,14 +887,11 @@ c10::CachingDeviceAllocator::DeviceStats get_device_stats(const c10::Device& dev
 
 void empty_cache(const c10::Device& device) {
   RBLN_LOG_DEBUG("logical device={}", c10::str(device));
-  // Best-effort: nothing to flush when the runtime is unavailable.
-  if (!runtime_available()) {
-    return;
-  }
-  // Two-level context gate (CUDA parity): no allocator state anywhere → no-op (a no-context
-  // parent or malformed config; never dispatches); otherwise validate the index (invalid
-  // throws) and skip a device this process never used.
-  if (!any_device_context_initialized()) {
+  // Two-level context gate (CUDA parity). Check the context flag FIRST: no allocator state
+  // anywhere → no-op (a no-context parent or malformed config; never dispatches, and this
+  // avoids runtime_available()/device enumeration triggering device registration as a side
+  // effect). Otherwise validate the index (invalid throws) and skip a device never used here.
+  if (!any_device_context_initialized() || !runtime_available()) {
     return;
   }
   const auto device_index = device.index();
@@ -921,15 +917,8 @@ std::map<std::string, uint64_t> memory_stats(const c10::Device& device) {
   if (!runtime_available()) {
     return {};
   }
-  // Two-level context gate (see empty_cache).
-  if (!any_device_context_initialized()) {
-    return {};
-  }
   const auto device_index = device.index();
   check_device_index(device_index);
-  if (!device_context_initialized(device_index)) {
-    return {};
-  }
   const auto device_id = to_device_id(device_index);
   RBLN_LOG_DEBUG("Calling rbln_get_memory_stats: rbln:{}, device_id={}", static_cast<int>(device_index), device_id);
   const auto stats = rbln_get_memory_stats(device_id);
@@ -941,12 +930,8 @@ std::map<std::string, uint64_t> memory_stats(const c10::Device& device) {
 
 void reset_accumulated_memory_stats(const c10::Device& device) {
   RBLN_LOG_DEBUG("logical device={}", c10::str(device));
-  // Best-effort: nothing to reset when the runtime is unavailable.
-  if (!runtime_available()) {
-    return;
-  }
-  // Two-level context gate (see empty_cache).
-  if (!any_device_context_initialized()) {
+  // Two-level context gate (see empty_cache); context flag first.
+  if (!any_device_context_initialized() || !runtime_available()) {
     return;
   }
   const auto device_index = device.index();
@@ -967,14 +952,9 @@ void reset_accumulated_memory_stats(const c10::Device& device) {
 
 void reset_peak_memory_stats(const c10::Device& device) {
   RBLN_LOG_DEBUG("logical device={}", c10::str(device));
-  // Best-effort no-op when unavailable (torch.accelerator.reset_peak has no Python
-  // init-guard, so the leaf gate is the only protection).
-  if (!runtime_available()) {
-    return;
-  }
-  // Two-level context gate (see empty_cache). This is also the only guard for the generic
-  // torch.accelerator.reset_peak path (no Python init-guard upstream).
-  if (!any_device_context_initialized()) {
+  // Two-level context gate (see empty_cache); context flag first. This is also the only
+  // guard for the generic torch.accelerator.reset_peak path (no Python init-guard upstream).
+  if (!any_device_context_initialized() || !runtime_available()) {
     return;
   }
   const auto device_index = device.index();

--- a/c10/rbln/RBLNFunctions.h
+++ b/c10/rbln/RBLNFunctions.h
@@ -161,6 +161,20 @@ C10_RBLN_API bool runtime_available() noexcept;
 C10_RBLN_API void set_runtime_shutting_down(bool value) noexcept;
 
 /**
+ * @brief Per-process device-context tracking (CUDA parity with device_allocator).
+ *
+ * mark_device_context_initialized() records that THIS process has successfully
+ * allocated device memory on a logical device; the query functions report whether
+ * such allocator/context state exists. They gate the best-effort memory ops and back
+ * initialized()/hasPrimaryContext(), so a process with the runtime + a device mapping
+ * but no live context (e.g. a vLLM EngineCore parent) is correctly reported as
+ * uninitialized. Set-once, monotonic, nothrow. Not reset across fork.
+ */
+C10_RBLN_API void mark_device_context_initialized(c10::DeviceIndex device_index) noexcept;
+C10_RBLN_API bool device_context_initialized(c10::DeviceIndex device_index) noexcept;
+C10_RBLN_API bool any_device_context_initialized() noexcept;
+
+/**
  * @brief Allocates memory on the specified RBLN device.
  *
  * This function allocates a contiguous block of memory on the given RBLN

--- a/c10/rbln/RBLNFunctions.h
+++ b/c10/rbln/RBLNFunctions.h
@@ -168,7 +168,8 @@ C10_RBLN_API void set_runtime_shutting_down(bool value) noexcept;
  * such allocator/context state exists. They gate the best-effort memory ops and back
  * initialized()/hasPrimaryContext(), so a process with the runtime + a device mapping
  * but no live context (e.g. a vLLM EngineCore parent) is correctly reported as
- * uninitialized. Set-once, monotonic, nothrow. Not reset across fork.
+ * uninitialized. Set-once, monotonic, nothrow. RBLN device use after fork is
+ * unsupported; bad-fork detection is not implemented yet.
  */
 C10_RBLN_API void mark_device_context_initialized(c10::DeviceIndex device_index) noexcept;
 C10_RBLN_API bool device_context_initialized(c10::DeviceIndex device_index) noexcept;

--- a/c10/rbln/RBLNHooksInterface.cpp
+++ b/c10/rbln/RBLNHooksInterface.cpp
@@ -49,10 +49,12 @@ c10::Device RBLNHooksInterface::getDeviceFromPtr(void* data) const {
 bool RBLNHooksInterface::hasPrimaryContext(c10::DeviceIndex device_index) const {
   RBLN_LOG_DEBUG("device_index={}", static_cast<int>(device_index));
 
-  // Runtime check first so a missing runtime is a clean false (no segfault); throwing
-  // get_device_count() keeps a malformed config loud when the runtime is present.
+  // Keep total (not noexcept upstream, but torch calls it from cleanup/selection paths
+  // where a throw aborts the caller on a false alarm). Runtime check first so a missing
+  // runtime is a clean false; nothrow device count instead of the throwing
+  // get_device_count() — a malformed config still surfaces at real device use.
   const bool has_context =
-      device_index >= 0 && rbln_runtime_available() && device_index < c10::rbln::get_device_count();
+      device_index >= 0 && rbln_runtime_available() && device_index < c10::rbln::get_device_count_nothrow();
   RBLN_LOG_DEBUG("has_context={}", has_context);
   return has_context;
 }

--- a/c10/rbln/RBLNHooksInterface.cpp
+++ b/c10/rbln/RBLNHooksInterface.cpp
@@ -49,12 +49,12 @@ c10::Device RBLNHooksInterface::getDeviceFromPtr(void* data) const {
 bool RBLNHooksInterface::hasPrimaryContext(c10::DeviceIndex device_index) const {
   RBLN_LOG_DEBUG("device_index={}", static_cast<int>(device_index));
 
-  // CUDA parity: a primary context exists for a device only once THIS process has used
-  // it (a successful allocation), not merely because the device exists. Per-device and
-  // nothrow (torch consults this from cleanup/autograd paths, where a throw would abort
-  // the caller). A device-present-but-unused process — or one that is shutting down —
-  // reports false (runtime_available() folds in the shutdown/liveness check).
-  const bool has_context = c10::rbln::runtime_available() && c10::rbln::device_context_initialized(device_index);
+  // CUDA parity: a primary context exists for a device only once THIS process has used it
+  // (a successful allocation), not merely because the device exists. Per-device and nothrow
+  // (torch consults this from cleanup/autograd paths, where a throw would abort the caller).
+  // Context flag first so an unused device doesn't trigger device enumeration/registration;
+  // runtime_available() then folds in the shutdown/liveness check.
+  const bool has_context = c10::rbln::device_context_initialized(device_index) && c10::rbln::runtime_available();
   RBLN_LOG_DEBUG("has_context={}", has_context);
   return has_context;
 }

--- a/c10/rbln/RBLNHooksInterface.cpp
+++ b/c10/rbln/RBLNHooksInterface.cpp
@@ -49,12 +49,12 @@ c10::Device RBLNHooksInterface::getDeviceFromPtr(void* data) const {
 bool RBLNHooksInterface::hasPrimaryContext(c10::DeviceIndex device_index) const {
   RBLN_LOG_DEBUG("device_index={}", static_cast<int>(device_index));
 
-  // Keep total (not noexcept upstream, but torch calls it from cleanup/selection paths
-  // where a throw aborts the caller on a false alarm). Runtime check first so a missing
-  // runtime is a clean false; nothrow device count instead of the throwing
-  // get_device_count() — a malformed config still surfaces at real device use.
-  const bool has_context =
-      device_index >= 0 && rbln_runtime_available() && device_index < c10::rbln::get_device_count_nothrow();
+  // CUDA parity: a primary context exists for a device only once THIS process has used
+  // it (a successful allocation), not merely because the device exists. Per-device and
+  // nothrow (torch consults this from cleanup/autograd paths, where a throw would abort
+  // the caller). A device-present-but-unused process — or one that is shutting down —
+  // reports false (runtime_available() folds in the shutdown/liveness check).
+  const bool has_context = c10::rbln::runtime_available() && c10::rbln::device_context_initialized(device_index);
   RBLN_LOG_DEBUG("has_context={}", has_context);
   return has_context;
 }

--- a/test/cpp/core/RBLNAllocatorTest.cpp
+++ b/test/cpp/core/RBLNAllocatorTest.cpp
@@ -103,9 +103,7 @@ TEST_F(RBLNAllocatorTest, Initialized) {
 // set on the first successful allocation on a device. (The uninitialized case — false
 // before any allocation — needs a fresh process; see test_runtime_unavailable.py.)
 TEST_F(RBLNAllocatorTest, DeviceContextTracksAllocation) {
-  // Out-of-range / negative indices are always false (bounded bitmask, nothrow).
-  EXPECT_FALSE(c10::rbln::device_context_initialized(-1));
-  EXPECT_FALSE(c10::rbln::device_context_initialized(64));
+  EXPECT_FALSE(c10::rbln::device_context_initialized(-1)); // negative → always false, nothrow
 
   const auto idx = c10::rbln::get_device_index();
   const auto data = c10::GetAllocator(c10::kPrivateUse1)->allocate(1024);
@@ -117,7 +115,22 @@ TEST_F(RBLNAllocatorTest, DeviceContextTracksAllocation) {
   auto* hooks = c10::rbln::get_rbln_hooks();
   EXPECT_TRUE(hooks->hasPrimaryContext(idx));
   EXPECT_FALSE(hooks->hasPrimaryContext(-1));
-  EXPECT_FALSE(hooks->hasPrimaryContext(64));
+}
+
+// The tracker spans the full valid DeviceIndex range across both mask words (63 = word 0,
+// 64/126 = word 1); the max value (127) is out of range, and negatives are false. This
+// guards against the earlier single-word tracker that silently dropped indices 64+. Marks
+// are process-global/sticky, so this only touches high, otherwise-unused indices.
+TEST_F(RBLNAllocatorTest, DeviceContextTrackerBounds) {
+  EXPECT_FALSE(c10::rbln::device_context_initialized(-1));
+  for (const c10::DeviceIndex i : {c10::DeviceIndex{63}, c10::DeviceIndex{64}, c10::DeviceIndex{126}}) {
+    EXPECT_FALSE(c10::rbln::device_context_initialized(i)); // unset before mark
+    c10::rbln::mark_device_context_initialized(i);
+    EXPECT_TRUE(c10::rbln::device_context_initialized(i));
+  }
+  // 127 == numeric_limits<DeviceIndex>::max() is never a valid device index → ignored.
+  c10::rbln::mark_device_context_initialized(127);
+  EXPECT_FALSE(c10::rbln::device_context_initialized(127));
 }
 
 // A shutting-down runtime has no usable context, so hasPrimaryContext() must report
@@ -137,6 +150,10 @@ TEST_F(RBLNAllocatorTest, HasPrimaryContextFalseDuringShutdown) {
 
 TEST_F(RBLNAllocatorTest, EmptyCache) {
   auto* device_allocator = GetDeviceAllocator();
+  // Allocate first so this exercises a real flush, not the uninitialized no-op path
+  // (keeps the test independent of allocations done by earlier tests).
+  const auto data = c10::GetAllocator(c10::kPrivateUse1)->allocate(1024);
+  EXPECT_NE(data.get(), nullptr);
   EXPECT_NO_THROW(device_allocator->emptyCache());
 }
 
@@ -182,9 +199,6 @@ TEST_F(RBLNAllocatorTest, GetDeviceStats) {
 TEST_F(RBLNAllocatorTest, GetDeviceStatsInvalidIndex) {
   auto* device_allocator = GetDeviceAllocator();
   const auto device_count = c10::rbln::get_device_count();
-  // Once the allocator is in use, an invalid device index is a real error (CUDA parity).
-  const auto data = c10::GetAllocator(c10::kPrivateUse1)->allocate(1024);
-  EXPECT_NE(data.get(), nullptr);
 
   // Negative index should throw.
   EXPECT_THROW(device_allocator->getDeviceStats(-1), c10::Error);
@@ -194,6 +208,9 @@ TEST_F(RBLNAllocatorTest, GetDeviceStatsInvalidIndex) {
 
 TEST_F(RBLNAllocatorTest, ResetAccumulatedStats) {
   auto* device_allocator = GetDeviceAllocator();
+  // Allocate first so this exercises a real reset, not the uninitialized no-op path.
+  const auto data = c10::GetAllocator(c10::kPrivateUse1)->allocate(1024);
+  EXPECT_NE(data.get(), nullptr);
   EXPECT_NO_THROW(device_allocator->resetAccumulatedStats(initial_device_index_));
 }
 
@@ -210,6 +227,9 @@ TEST_F(RBLNAllocatorTest, ResetAccumulatedStatsInvalidIndex) {
 
 TEST_F(RBLNAllocatorTest, ResetPeakStats) {
   auto* device_allocator = GetDeviceAllocator();
+  // Allocate first so this exercises a real reset, not the uninitialized no-op path.
+  const auto data = c10::GetAllocator(c10::kPrivateUse1)->allocate(1024);
+  EXPECT_NE(data.get(), nullptr);
   EXPECT_NO_THROW(device_allocator->resetPeakStats(initial_device_index_));
 }
 

--- a/test/cpp/core/RBLNAllocatorTest.cpp
+++ b/test/cpp/core/RBLNAllocatorTest.cpp
@@ -1,6 +1,7 @@
 #include <c10/core/Allocator.h>
 #include <c10/core/CachingDeviceAllocator.h>
 #include <c10/rbln/RBLNFunctions.h>
+#include <c10/rbln/RBLNHooksInterface.h>
 #include <gtest/gtest.h>
 
 class RBLNAllocatorTest : public ::testing::Test {
@@ -88,8 +89,50 @@ TEST_F(RBLNAllocatorTest, IsDeviceAllocator) {
 }
 
 TEST_F(RBLNAllocatorTest, Initialized) {
+  // CUDA parity: initialized() reflects per-process allocator state, so it is true only
+  // after this process has actually allocated (a device/mapping existing is not enough).
+  // The uninitialized-process case (false before any allocation) is covered in a fresh
+  // subprocess by test/rbln/test_runtime_unavailable.py.
   auto* device_allocator = GetDeviceAllocator();
+  const auto data = c10::GetAllocator(c10::kPrivateUse1)->allocate(1024);
+  EXPECT_NE(data.get(), nullptr);
   EXPECT_TRUE(device_allocator->initialized());
+}
+
+// The per-process context flag backs initialized() and hasPrimaryContext(): a bit is
+// set on the first successful allocation on a device. (The uninitialized case — false
+// before any allocation — needs a fresh process; see test_runtime_unavailable.py.)
+TEST_F(RBLNAllocatorTest, DeviceContextTracksAllocation) {
+  // Out-of-range / negative indices are always false (bounded bitmask, nothrow).
+  EXPECT_FALSE(c10::rbln::device_context_initialized(-1));
+  EXPECT_FALSE(c10::rbln::device_context_initialized(64));
+
+  const auto idx = c10::rbln::get_device_index();
+  const auto data = c10::GetAllocator(c10::kPrivateUse1)->allocate(1024);
+  EXPECT_NE(data.get(), nullptr);
+  EXPECT_TRUE(c10::rbln::device_context_initialized(idx));
+  EXPECT_TRUE(c10::rbln::any_device_context_initialized());
+
+  // hasPrimaryContext() is per-device and mirrors the flag (CUDA parity).
+  auto* hooks = c10::rbln::get_rbln_hooks();
+  EXPECT_TRUE(hooks->hasPrimaryContext(idx));
+  EXPECT_FALSE(hooks->hasPrimaryContext(-1));
+  EXPECT_FALSE(hooks->hasPrimaryContext(64));
+}
+
+// A shutting-down runtime has no usable context, so hasPrimaryContext() must report
+// false even for a device this process allocated on (folds in the liveness check).
+TEST_F(RBLNAllocatorTest, HasPrimaryContextFalseDuringShutdown) {
+  const auto idx = c10::rbln::get_device_index();
+  const auto data = c10::GetAllocator(c10::kPrivateUse1)->allocate(1024);
+  EXPECT_NE(data.get(), nullptr);
+  auto* hooks = c10::rbln::get_rbln_hooks();
+  EXPECT_TRUE(hooks->hasPrimaryContext(idx));
+
+  c10::rbln::set_runtime_shutting_down(true);
+  EXPECT_FALSE(hooks->hasPrimaryContext(idx));
+  c10::rbln::set_runtime_shutting_down(false); // restore (process-global flag)
+  EXPECT_TRUE(hooks->hasPrimaryContext(idx));
 }
 
 TEST_F(RBLNAllocatorTest, EmptyCache) {
@@ -139,6 +182,9 @@ TEST_F(RBLNAllocatorTest, GetDeviceStats) {
 TEST_F(RBLNAllocatorTest, GetDeviceStatsInvalidIndex) {
   auto* device_allocator = GetDeviceAllocator();
   const auto device_count = c10::rbln::get_device_count();
+  // Once the allocator is in use, an invalid device index is a real error (CUDA parity).
+  const auto data = c10::GetAllocator(c10::kPrivateUse1)->allocate(1024);
+  EXPECT_NE(data.get(), nullptr);
 
   // Negative index should throw.
   EXPECT_THROW(device_allocator->getDeviceStats(-1), c10::Error);
@@ -154,6 +200,9 @@ TEST_F(RBLNAllocatorTest, ResetAccumulatedStats) {
 TEST_F(RBLNAllocatorTest, ResetAccumulatedStatsInvalidIndex) {
   auto* device_allocator = GetDeviceAllocator();
   const auto device_count = c10::rbln::get_device_count();
+  // Once the allocator is in use, an invalid device index is a real error (CUDA parity).
+  const auto data = c10::GetAllocator(c10::kPrivateUse1)->allocate(1024);
+  EXPECT_NE(data.get(), nullptr);
 
   EXPECT_THROW(device_allocator->resetAccumulatedStats(-1), c10::Error);
   EXPECT_THROW(device_allocator->resetAccumulatedStats(device_count), c10::Error);
@@ -167,6 +216,9 @@ TEST_F(RBLNAllocatorTest, ResetPeakStats) {
 TEST_F(RBLNAllocatorTest, ResetPeakStatsInvalidIndex) {
   auto* device_allocator = GetDeviceAllocator();
   const auto device_count = c10::rbln::get_device_count();
+  // Once the allocator is in use, an invalid device index is a real error (CUDA parity).
+  const auto data = c10::GetAllocator(c10::kPrivateUse1)->allocate(1024);
+  EXPECT_NE(data.get(), nullptr);
 
   EXPECT_THROW(device_allocator->resetPeakStats(-1), c10::Error);
   EXPECT_THROW(device_allocator->resetPeakStats(device_count), c10::Error);

--- a/test/internal/test_memory_stats.py
+++ b/test/internal/test_memory_stats.py
@@ -641,6 +641,14 @@ class TestAcceleratorMemoryAPI(TestCase):
         if torch.accelerator.current_accelerator().type != "rbln":
             self.skipTest("Current accelerator is not RBLN")
 
+        # Establish allocator state so the torch.accelerator memory APIs report full stats.
+        # Before the first allocation the allocator is uninitialized, and upstream's
+        # torch.accelerator.memory_stats() returns an empty dict via its init guard — so
+        # without this warmup these tests would be order-dependent (only passing when an
+        # earlier test in the process happened to allocate first).
+        warmup = torch.empty(1, device="rbln:0")
+        del warmup
+
         # Ensure a clean stats baseline before each test.
         torch.accelerator.empty_cache()
         torch.accelerator.reset_accumulated_memory_stats()

--- a/test/rbln/test_runtime_unavailable.py
+++ b/test/rbln/test_runtime_unavailable.py
@@ -266,12 +266,15 @@ class TestRuntimeUnavailable(TestCase):
         Proven with a shim that records whether rbln_empty_cache is actually invoked."""
         with tempfile.TemporaryDirectory() as tmp:
             marker = os.path.join(tmp, "called")
-            # Shim records an invocation; if the gate works, it is never called.
+            # Shim records an invocation of any of the gated ops; if the gate works, none
+            # are ever called (the marker file is never created).
             so = _build_ld_preload_shim(
                 tmp,
                 "#include <stdio.h>\n#include <stdlib.h>\n"
-                'int rbln_empty_cache(int d){(void)d; const char*p=getenv("SHIM_MARKER");'
-                ' if(p){FILE*f=fopen(p,"w"); if(f)fclose(f);} return 0;}\n',
+                'static void mark(void){const char*p=getenv("SHIM_MARKER"); if(p){FILE*f=fopen(p,"a"); if(f)fclose(f);}}\n'
+                "int rbln_empty_cache(int d){(void)d; mark(); return 0;}\n"
+                "int rbln_reset_peak_memory_stats(int d){(void)d; mark(); return 0;}\n"
+                "int rbln_reset_accumulated_memory_stats(int d){(void)d; mark(); return 0;}\n",
             )
             if so is None:
                 self.skipTest("needs a C compiler to build the LD_PRELOAD shim")
@@ -280,9 +283,10 @@ class TestRuntimeUnavailable(TestCase):
                 assert torch.rbln.device_count() > 0 and C.runtime_available() is True
                 assert torch._C._accelerator_isAllocatorInitialized() is False, "no allocation yet -> not initialized"
                 d = torch.device("rbln", 0)
-                torch.accelerator.empty_cache()          # generic accelerator path (vLLM shutdown)
+                torch.accelerator.empty_cache()               # generic accelerator path (vLLM shutdown)
                 torch.accelerator.reset_peak_memory_stats()
-                C.empty_cache(d); C.reset_peak_memory_stats(d)   # direct C API too
+                torch.accelerator.reset_accumulated_memory_stats(0)
+                C.empty_cache(d); C.reset_peak_memory_stats(d); C.reset_accumulated_memory_stats(d)  # direct C API too
                 print("NOCTX_OK")
                 """,
                 env_extra={"LD_PRELOAD": so, "SHIM_MARKER": marker},
@@ -290,7 +294,7 @@ class TestRuntimeUnavailable(TestCase):
             _assert_ok(self, result, "NOCTX_OK")
             self.assertFalse(
                 os.path.exists(marker),
-                "rbln_empty_cache was dispatched despite no live context — the context gate failed",
+                "a best-effort runtime op was dispatched despite no live context — the context gate failed",
             )
 
     @requires_physical_devices(1)
@@ -320,13 +324,15 @@ class TestRuntimeUnavailable(TestCase):
                     "C.reset_peak": lambda: C.reset_peak_memory_stats(d),
                     "C.reset_accum": lambda: C.reset_accumulated_memory_stats(d),
                 }
-                swallowed = []
+                swallowed, bad_msg = [], []
                 for name, fn in ops.items():
                     try:
                         fn(); swallowed.append(name)
-                    except RuntimeError:
-                        pass
+                    except RuntimeError as exc:
+                        if "rc=1" not in str(exc):  # the injected non-zero rc must be reported
+                            bad_msg.append(name + ": " + str(exc)[:60])
                 assert not swallowed, "runtime failure silently swallowed on a live context: " + ",".join(swallowed)
+                assert not bad_msg, "error missing injected rc=1: " + "; ".join(bad_msg)
                 print("PROPAGATE_OK")
                 """,
                 env_extra={"LD_PRELOAD": so},
@@ -386,20 +392,39 @@ class TestRuntimeUnavailable(TestCase):
 
     @requires_physical_devices(1)
     def test_runtime_available_true_on_healthy_host(self):
-        """With a device present and the runtime loaded, runtime_available() is True and
+        """With a device present, the runtime loaded, and this process having allocated,
         best-effort ops actually run (not gated off)."""
         result = _run_subprocess(
             """
             assert torch.rbln.device_count() > 0
             assert C.runtime_available() is True, "healthy host with a device must be available"
             assert torch.rbln.is_available() is True
+            t = torch.ones(64, device="rbln:0"); _ = (t + t).sum().item()   # establish a live context
             d = torch.device("rbln", 0)
             C.empty_cache(d)  # real flush, must not raise
-            assert isinstance(C.memory_stats(d), dict)
+            assert isinstance(C.memory_stats(d), dict) and len(C.memory_stats(d)) > 0
             print("HEALTHY_OK")
             """
         )
         _assert_ok(self, result, "HEALTHY_OK")
+
+    @requires_physical_devices(1)
+    def test_lazy_allocation_initializes_context(self):
+        """Invariant confirmed on real hardware: in default lazy-malloc mode, a single
+        torch.empty() marks the process initialized and the best-effort ops then run
+        (the runtime pool/context is created at registration, before malloc)."""
+        result = _run_subprocess(
+            """
+            t = torch.empty(1, device="rbln:0")   # default lazy VMemory entry (no eager malloc)
+            assert torch._C._accelerator_isAllocatorInitialized() is True, "lazy alloc must initialize the context"
+            torch.accelerator.empty_cache()
+            torch.accelerator.reset_peak_memory_stats()
+            assert len(torch.accelerator.memory.memory_stats(0)) > 0
+            print("LAZY_OK")
+            """,
+            env_extra={"TORCH_RBLN_EAGER_MALLOC": None},  # ensure lazy mode
+        )
+        _assert_ok(self, result, "LAZY_OK")
 
 
 if __name__ == "__main__":

--- a/test/rbln/test_runtime_unavailable.py
+++ b/test/rbln/test_runtime_unavailable.py
@@ -62,6 +62,21 @@ def _assert_ok(self, result: subprocess.CompletedProcess, marker: str) -> None:
     )
 
 
+def _build_ld_preload_shim(tmp_dir: str, c_source: str):
+    """Compile a tiny LD_PRELOAD shim that interposes librbln's C-linkage entry points
+    (used to force / observe the runtime calls). Returns the .so path, or None if no C
+    compiler is available (test skips)."""
+    cc = shutil.which("cc") or shutil.which("gcc")
+    if cc is None:
+        return None
+    src = os.path.join(tmp_dir, "shim.c")
+    so = os.path.join(tmp_dir, "shim.so")
+    with open(src, "w") as handle:
+        handle.write(c_source)
+    build = subprocess.run([cc, "-shared", "-fPIC", "-o", so, src], capture_output=True, text=True)
+    return so if build.returncode == 0 else None
+
+
 @pytest.mark.test_set_ci
 class TestRuntimeUnavailable(TestCase):
     """``runtime_available()`` gates every runtime-touching leaf (torch.cuda parity)."""
@@ -243,78 +258,131 @@ class TestRuntimeUnavailable(TestCase):
         _assert_ok(self, result, "MALLOC_OK")
 
     @requires_physical_devices(1)
-    def test_best_effort_ops_degrade_when_runtime_call_fails(self):
-        """With the runtime AVAILABLE, a best-effort runtime call that returns non-zero
-        (the reported crash: a no-context process makes the runtime fail rbln_empty_cache)
-        must degrade to a warning, not abort the caller (torch.cuda parity). An LD_PRELOAD
-        shim forces the non-zero rc so the contract is testable on healthy hardware;
-        reset_peak / reset_accumulated share the leaf and are covered too."""
-        cc = shutil.which("cc") or shutil.which("gcc")
-        if cc is None:
-            self.skipTest("needs a C compiler to build the failure-injection shim")
+    def test_best_effort_ops_noop_without_live_context(self):
+        """The reported regression: a process with the runtime + a device mapping but NO
+        live context (no allocation yet — the vLLM EngineCore parent) must NOT dispatch
+        the runtime call. empty_cache/reset_* are gated by the per-process context flag
+        (initialized()/hasPrimaryContext()), so they no-op without fabricating a context.
+        Proven with a shim that records whether rbln_empty_cache is actually invoked."""
         with tempfile.TemporaryDirectory() as tmp:
-            src = os.path.join(tmp, "fail_shim.c")
-            so = os.path.join(tmp, "fail_shim.so")
-            # librbln exports these with C linkage; LD_PRELOAD interposes them so the
-            # best-effort leaves see rc != 0 without any real fault.
-            with open(src, "w") as handle:
-                handle.write(
-                    "int rbln_empty_cache(int d){(void)d;return 1;}\n"
-                    "int rbln_reset_peak_memory_stats(int d){(void)d;return 1;}\n"
-                    "int rbln_reset_accumulated_memory_stats(int d){(void)d;return 1;}\n"
-                )
-            build = subprocess.run([cc, "-shared", "-fPIC", "-o", so, src], capture_output=True, text=True)
-            if build.returncode != 0:
-                self.skipTest(f"could not build failure-injection shim: {build.stderr}")
+            marker = os.path.join(tmp, "called")
+            # Shim records an invocation; if the gate works, it is never called.
+            so = _build_ld_preload_shim(
+                tmp,
+                "#include <stdio.h>\n#include <stdlib.h>\n"
+                'int rbln_empty_cache(int d){(void)d; const char*p=getenv("SHIM_MARKER");'
+                ' if(p){FILE*f=fopen(p,"w"); if(f)fclose(f);} return 0;}\n',
+            )
+            if so is None:
+                self.skipTest("needs a C compiler to build the LD_PRELOAD shim")
             result = _run_subprocess(
                 """
                 assert torch.rbln.device_count() > 0 and C.runtime_available() is True
-                t = torch.ones(64, device="rbln:0"); _ = (t + t).sum().item()  # establish a real context
-                # rbln_empty_cache / rbln_reset_* now return non-zero (LD_PRELOAD shim);
-                # every entry point must degrade to a warning, not raise.
-                torch.accelerator.empty_cache()                      # generic accelerator path (vLLM shutdown)
-                torch.accelerator.reset_peak_memory_stats()          # no Python init-guard: leaf gate is the only protection
-                torch.accelerator.reset_accumulated_memory_stats(0)
+                assert torch._C._accelerator_isAllocatorInitialized() is False, "no allocation yet -> not initialized"
                 d = torch.device("rbln", 0)
-                C.empty_cache(d); C.reset_peak_memory_stats(d); C.reset_accumulated_memory_stats(d)
-                print("DEGRADE_OK")
+                torch.accelerator.empty_cache()          # generic accelerator path (vLLM shutdown)
+                torch.accelerator.reset_peak_memory_stats()
+                C.empty_cache(d); C.reset_peak_memory_stats(d)   # direct C API too
+                print("NOCTX_OK")
                 """,
-                env_extra={"LD_PRELOAD": so},
+                env_extra={"LD_PRELOAD": so, "SHIM_MARKER": marker},
             )
-            _assert_ok(self, result, "DEGRADE_OK")
-            # Non-vacuous: prove the failure path was actually taken (the leaf warned)
-            # rather than the shim silently not interposing.
-            self.assertIn(
-                "skipping cache flush",
-                result.stderr,
-                f"expected the degraded-empty_cache warning (failure path not exercised?)\n--- stderr ---\n{result.stderr}",
+            _assert_ok(self, result, "NOCTX_OK")
+            self.assertFalse(
+                os.path.exists(marker),
+                "rbln_empty_cache was dispatched despite no live context — the context gate failed",
             )
 
     @requires_physical_devices(1)
+    def test_best_effort_ops_propagate_live_context_failure(self):
+        """Once this process has a live context (after an allocation), a genuine runtime
+        failure in a best-effort op IS surfaced (CUDA parity — cudaFree failures in an
+        initialized allocator propagate), not silently swallowed. Injected with an
+        LD_PRELOAD shim forcing the C entry points to return non-zero."""
+        with tempfile.TemporaryDirectory() as tmp:
+            so = _build_ld_preload_shim(
+                tmp,
+                "int rbln_empty_cache(int d){(void)d;return 1;}\n"
+                "int rbln_reset_peak_memory_stats(int d){(void)d;return 1;}\n"
+                "int rbln_reset_accumulated_memory_stats(int d){(void)d;return 1;}\n",
+            )
+            if so is None:
+                self.skipTest("needs a C compiler to build the LD_PRELOAD shim")
+            result = _run_subprocess(
+                """
+                t = torch.ones(64, device="rbln:0"); _ = (t + t).sum().item()   # establish a live context
+                d = torch.device("rbln", 0)
+                ops = {
+                    "empty_cache": lambda: torch.accelerator.empty_cache(),
+                    "reset_peak": lambda: torch.accelerator.reset_peak_memory_stats(),
+                    "reset_accum": lambda: torch.accelerator.reset_accumulated_memory_stats(0),
+                    "C.empty_cache": lambda: C.empty_cache(d),
+                    "C.reset_peak": lambda: C.reset_peak_memory_stats(d),
+                    "C.reset_accum": lambda: C.reset_accumulated_memory_stats(d),
+                }
+                swallowed = []
+                for name, fn in ops.items():
+                    try:
+                        fn(); swallowed.append(name)
+                    except RuntimeError:
+                        pass
+                assert not swallowed, "runtime failure silently swallowed on a live context: " + ",".join(swallowed)
+                print("PROPAGATE_OK")
+                """,
+                env_extra={"LD_PRELOAD": so},
+            )
+            _assert_ok(self, result, "PROPAGATE_OK")
+
+    @requires_physical_devices(1)
     def test_memory_ops_nothrow_on_malformed_config(self):
-        """The allocator's initialized() predicate (which gates torch.accelerator memory
-        ops) must stay total. A malformed RBLN_NPUS_PER_DEVICE makes the internal
-        device-count lookup throw; the predicate must swallow it and report
-        not-initialized so empty_cache no-ops instead of aborting the caller. The
-        misconfig still surfaces at real device use."""
+        """The initialized()/hasPrimaryContext() predicates that gate torch.accelerator
+        memory ops must stay total. A malformed RBLN_NPUS_PER_DEVICE makes the internal
+        device-count lookup throw; the predicate swallows it and reports not-initialized,
+        so empty_cache no-ops instead of aborting the caller. The misconfig still surfaces
+        at real device use."""
         result = _run_subprocess(
             """
-            # Malformed config: the device-count lookup throws internally. The nothrow
-            # predicate must NOT propagate that -- it reports not-initialized.
             assert torch._C._accelerator_isAllocatorInitialized() is False, "predicate must be nothrow + not-initialized"
             torch.accelerator.empty_cache()               # gated off -> no-op, must not raise
             torch.accelerator.reset_peak_memory_stats()
-            # The misconfig is still surfaced when a device is actually used.
             try:
                 torch.ones(4, device="rbln:0")
+            except RuntimeError as exc:
+                assert "valid sizes" in str(exc), str(exc)   # misconfig surfaces at real device use
+            else:
                 raise AssertionError("malformed config must raise at the point of real device use")
-            except Exception:
-                pass
             print("MALFORMED_OK")
             """,
             env_extra={"RBLN_NPUS_PER_DEVICE": "3", "RBLN_DEVICE_MAP": None},
         )
         _assert_ok(self, result, "MALFORMED_OK")
+
+    @requires_physical_devices(1)
+    def test_dummy_malformed_config_memory_ops_noop(self):
+        """Dummy mode must not short-circuit the context gate: with a malformed config and
+        no allocation, the memory ops still no-op (not-initialized), and the misconfig
+        surfaces only at real device use. Covered for both malformed-config env vars
+        (RBLN_NPUS_PER_DEVICE and RBLN_DEVICE_MAP — same validateDeviceGroups path)."""
+        script = """
+            assert C.is_dummy_device() is True
+            assert torch._C._accelerator_isAllocatorInitialized() is False
+            torch.accelerator.empty_cache()               # no live context -> no-op, must not raise
+            torch.accelerator.reset_peak_memory_stats()
+            try:
+                torch.zeros(4, device="rbln:0")
+            except RuntimeError:
+                pass
+            else:
+                raise AssertionError("dummy + malformed config must raise at real device use")
+            print("DUMMY_MALFORMED_OK")
+            """
+        # A bad group size (3) via each of the two mapping env vars.
+        for env_extra in (
+            {"RBLN_DUMMY_DEVICE": "1", "RBLN_NPUS_PER_DEVICE": "3", "RBLN_DEVICE_MAP": None},
+            {"RBLN_DUMMY_DEVICE": "1", "RBLN_DEVICE_MAP": "[0,1,2]", "RBLN_NPUS_PER_DEVICE": None},
+        ):
+            result = _run_subprocess(script, env_extra=env_extra)
+            _assert_ok(self, result, "DUMMY_MALFORMED_OK")
 
     @requires_physical_devices(1)
     def test_runtime_available_true_on_healthy_host(self):

--- a/test/rbln/test_runtime_unavailable.py
+++ b/test/rbln/test_runtime_unavailable.py
@@ -19,8 +19,10 @@ flag never leaks into other tests.
 """
 
 import os
+import shutil
 import subprocess
 import sys
+import tempfile
 import textwrap
 
 import pytest
@@ -239,6 +241,80 @@ class TestRuntimeUnavailable(TestCase):
             """
         )
         _assert_ok(self, result, "MALLOC_OK")
+
+    @requires_physical_devices(1)
+    def test_best_effort_ops_degrade_when_runtime_call_fails(self):
+        """With the runtime AVAILABLE, a best-effort runtime call that returns non-zero
+        (the reported crash: a no-context process makes the runtime fail rbln_empty_cache)
+        must degrade to a warning, not abort the caller (torch.cuda parity). An LD_PRELOAD
+        shim forces the non-zero rc so the contract is testable on healthy hardware;
+        reset_peak / reset_accumulated share the leaf and are covered too."""
+        cc = shutil.which("cc") or shutil.which("gcc")
+        if cc is None:
+            self.skipTest("needs a C compiler to build the failure-injection shim")
+        with tempfile.TemporaryDirectory() as tmp:
+            src = os.path.join(tmp, "fail_shim.c")
+            so = os.path.join(tmp, "fail_shim.so")
+            # librbln exports these with C linkage; LD_PRELOAD interposes them so the
+            # best-effort leaves see rc != 0 without any real fault.
+            with open(src, "w") as handle:
+                handle.write(
+                    "int rbln_empty_cache(int d){(void)d;return 1;}\n"
+                    "int rbln_reset_peak_memory_stats(int d){(void)d;return 1;}\n"
+                    "int rbln_reset_accumulated_memory_stats(int d){(void)d;return 1;}\n"
+                )
+            build = subprocess.run([cc, "-shared", "-fPIC", "-o", so, src], capture_output=True, text=True)
+            if build.returncode != 0:
+                self.skipTest(f"could not build failure-injection shim: {build.stderr}")
+            result = _run_subprocess(
+                """
+                assert torch.rbln.device_count() > 0 and C.runtime_available() is True
+                t = torch.ones(64, device="rbln:0"); _ = (t + t).sum().item()  # establish a real context
+                # rbln_empty_cache / rbln_reset_* now return non-zero (LD_PRELOAD shim);
+                # every entry point must degrade to a warning, not raise.
+                torch.accelerator.empty_cache()                      # generic accelerator path (vLLM shutdown)
+                torch.accelerator.reset_peak_memory_stats()          # no Python init-guard: leaf gate is the only protection
+                torch.accelerator.reset_accumulated_memory_stats(0)
+                d = torch.device("rbln", 0)
+                C.empty_cache(d); C.reset_peak_memory_stats(d); C.reset_accumulated_memory_stats(d)
+                print("DEGRADE_OK")
+                """,
+                env_extra={"LD_PRELOAD": so},
+            )
+            _assert_ok(self, result, "DEGRADE_OK")
+            # Non-vacuous: prove the failure path was actually taken (the leaf warned)
+            # rather than the shim silently not interposing.
+            self.assertIn(
+                "skipping cache flush",
+                result.stderr,
+                f"expected the degraded-empty_cache warning (failure path not exercised?)\n--- stderr ---\n{result.stderr}",
+            )
+
+    @requires_physical_devices(1)
+    def test_memory_ops_nothrow_on_malformed_config(self):
+        """The allocator's initialized() predicate (which gates torch.accelerator memory
+        ops) must stay total. A malformed RBLN_NPUS_PER_DEVICE makes the internal
+        device-count lookup throw; the predicate must swallow it and report
+        not-initialized so empty_cache no-ops instead of aborting the caller. The
+        misconfig still surfaces at real device use."""
+        result = _run_subprocess(
+            """
+            # Malformed config: the device-count lookup throws internally. The nothrow
+            # predicate must NOT propagate that -- it reports not-initialized.
+            assert torch._C._accelerator_isAllocatorInitialized() is False, "predicate must be nothrow + not-initialized"
+            torch.accelerator.empty_cache()               # gated off -> no-op, must not raise
+            torch.accelerator.reset_peak_memory_stats()
+            # The misconfig is still surfaced when a device is actually used.
+            try:
+                torch.ones(4, device="rbln:0")
+                raise AssertionError("malformed config must raise at the point of real device use")
+            except Exception:
+                pass
+            print("MALFORMED_OK")
+            """,
+            env_extra={"RBLN_NPUS_PER_DEVICE": "3", "RBLN_DEVICE_MAP": None},
+        )
+        _assert_ok(self, result, "MALFORMED_OK")
 
     @requires_physical_devices(1)
     def test_runtime_available_true_on_healthy_host(self):


### PR DESCRIPTION
## Problem

`torch.accelerator.empty_cache()` aborted the caller with a `RuntimeError` at vLLM shutdown, crashing every DP `EngineCore`:

```
RuntimeError: rbln_empty_cache failed for rbln:0 (device may be busy or in a faulted state)
  cleanup_dist_env_and_memory() -> torch.accelerator.empty_cache() -> c10::rbln::empty_cache
```

Root cause: `RBLNAllocator::initialized()` reported *"a device/mapping exists"* (`runtime_available() && device_count>0`) instead of CUDA's *"this process has initialized the allocator."* torch guards the accelerator memory ops on this predicate (`_accelerator_isAllocatorInitialized`), so in the `EngineCore` parent — which has the runtime and a device mapping but **no live context** (its Worker child owns the device) — the guard passed and `empty_cache` dispatched into a contextless runtime, which fabricated a throwaway/dummy context and failed. The compile artifact was produced fine; the crash is at teardown, but it makes every DP process exit non-zero.

## Change

Track per-process context directly (CUDA parity with `device_allocator`): a per-logical-device bit is set on the first successful device `malloc` (the single allocation funnel; a two-word mask covers the full `DeviceIndex` range). It backs:

- `RBLNAllocator::initialized()` = `any_device_context_initialized() && runtime_available()`
- `RBLNHooksInterface::hasPrimaryContext(idx)` = `device_context_initialized(idx) && runtime_available()` — now **per-device** and shutdown-aware

The context flag is checked **first**, so a cleanup predicate on a no-context process never triggers device enumeration/registration as a side effect.

The **throwing** best-effort leaves (`empty_cache` / `reset_peak` / `reset_accumulated`) use a two-level gate, matching CUDA:

1. no allocator state anywhere in this process → no-op (never dispatches; covers the no-context parent **and** a malformed-config process),
2. allocator in use → `check_device_index` (an invalid index is a real error, throws),
3. this device unused → nothing to do,
4. otherwise run the runtime call and **propagate** a genuine failure (rc included) rather than swallowing it — an initialized allocator surfaces real errors.

The query leaves (`memory_stats` / `get_device_stats`) are left unchanged (they never throw); their pre-init empty result for `torch.accelerator.memory_stats()` comes from the same Python init guard via `initialized()`, so the existing `torch.rbln.memory_stats()` full-key contract is preserved.

This is *not* "CUDA `empty_cache` never raises": CUDA skips via its init guard **before** the allocator is used, but an initialized allocator propagates real errors — this matches that. Mandatory ops (malloc/free/copy/synchronize/…) are unchanged. RBLN device use after fork is unsupported (contexts don't survive fork); bad-fork detection is a follow-up.

## Tests

`test/rbln/test_runtime_unavailable.py` (subprocess-isolated, run on real NPU in CI):
- **no live context** → the ops never dispatch the runtime call (an `LD_PRELOAD` shim records non-invocation of empty_cache / reset_peak / reset_accumulated);
- **live-context failure** → propagates, per op, generic + direct C API, asserting the injected `rc=1` is reported;
- **malformed config** (real and dummy, `RBLN_NPUS_PER_DEVICE` and `RBLN_DEVICE_MAP`) → the predicate stays total and no-ops; the misconfig surfaces only at real device use;
- **lazy-malloc invariant** → a default-mode `torch.empty()` initializes the context and the ops then run.

`test/cpp/core/RBLNAllocatorTest.cpp`: `initialized()` / `hasPrimaryContext()` track allocation (per-device, invalid index, shutdown state); a tracker-bounds test (63/64/126 tracked, 127 invalid); the `*InvalidIndex` tests assert the throw; success tests allocate first so they exercise the real path independent of run order. Reset before/after effect is covered by `test_internal/test_memory_stats.py::test_reset_operations`.

The new subprocess tests fail on the pre-fix binary. Verified against the real runtime: gtest `RBLNAllocatorTest` 18/18 + `RBLNFunctionsTest` 32/33, Python suites green (incl. `test_memory_stats.py` in isolation).

Not included (cost): an end-to-end DP>1 vLLM `EngineCore` shutdown integration test — recommended as a required regression in downstream vLLM CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
