### PR TITLE
feat(rbln): torch.Stream / torch.Event support

### DIFF
--- a/c10/rbln/RBLNAllocator.cpp
+++ b/c10/rbln/RBLNAllocator.cpp
@@ -108,7 +108,10 @@ struct RBLNAllocator final : public c10::DeviceAllocator {
    * @param stream The stream to associate with the data pointer.
    */
   void recordStream(const c10::DataPtr& /*ptr*/, c10::Stream /*stream*/) override {
-    RBLN_LOG_DEBUG("recordStream is no-op because RBLN does not support stream-based asynchronous execution");
+    // No-op on purpose: the runtime tags a freed block with the (stream, seq) still in
+    // flight at its free and folds foreign seqs into the reusing stream as cross-deps,
+    // so cross-stream lifetime is already safe without the hint torch passes here.
+    RBLN_LOG_DEBUG("recordStream is a no-op; the runtime tags freed blocks with their in-flight stream");
   }
 
   /**

--- a/c10/rbln/RBLNFunctions.cpp
+++ b/c10/rbln/RBLNFunctions.cpp
@@ -757,10 +757,21 @@ c10::DeviceIndex resolve_device_index(c10::DeviceIndex device_index) {
   return device_index < 0 ? get_device_index() : device_index;
 }
 
-// Fixed per-device pool backing getStreamFromGlobalPool. RBLN has no stream
-// priorities, so one pool suffices; streams are created lazily and live for the
-// process (matching CUDA's global pool).
-constexpr int kStreamPoolSize = 32;
+// Fixed per-device pool behind every stream torch hands out. RBLN has no stream
+// priorities, so one pool suffices. Torch has no destroy hook for a stream, so
+// creating one per request would leak it and lengthen every runtime drain-all;
+// CUDA answers getNewStream from its pool for the same reason.
+constexpr size_t kStreamPoolSize = 32;
+
+c10::StreamId create_stream_local_id(c10::DeviceIndex device_index) {
+  const auto torch_device_id = static_cast<uint32_t>(to_device_id(device_index));
+  uint64_t handle = 0;
+  RBLN_CHECK(
+      !::rbln::rbln_stream_create(torch_device_id, &handle),
+      "rbln_stream_create failed for rbln:{}",
+      static_cast<int>(device_index));
+  return static_cast<c10::StreamId>(static_cast<uint32_t>(handle & 0xFFFFFFFFULL));
+}
 
 } // namespace
 
@@ -783,18 +794,6 @@ c10::Stream get_default_stream(c10::DeviceIndex device_index) {
   return c10::Stream(c10::Stream::DEFAULT, c10::Device(c10::kPrivateUse1, device_index));
 }
 
-c10::Stream new_stream(c10::DeviceIndex device_index) {
-  device_index = resolve_device_index(device_index);
-  check_device_index(device_index);
-  const auto torch_device_id = static_cast<uint32_t>(to_device_id(device_index));
-  uint64_t handle = 0;
-  RBLN_CHECK(
-      !::rbln::rbln_stream_create(torch_device_id, &handle),
-      "rbln_stream_create failed for rbln:{}",
-      static_cast<int>(device_index));
-  return stream_from_handle(device_index, handle);
-}
-
 c10::Stream get_stream_from_pool(c10::DeviceIndex device_index) {
   device_index = resolve_device_index(device_index);
   check_device_index(device_index);
@@ -806,20 +805,13 @@ c10::Stream get_stream_from_pool(c10::DeviceIndex device_index) {
   static std::map<c10::DeviceIndex, Pool> pools;
   std::lock_guard<std::mutex> lock(pool_mutex);
   auto& pool = pools[device_index];
-  if (pool.local_ids.empty()) {
-    const auto torch_device_id = static_cast<uint32_t>(to_device_id(device_index));
-    pool.local_ids.reserve(kStreamPoolSize);
-    for (int i = 0; i < kStreamPoolSize; ++i) {
-      uint64_t handle = 0;
-      RBLN_CHECK(
-          !::rbln::rbln_stream_create(torch_device_id, &handle),
-          "rbln_stream_create (pool) failed for rbln:{}",
-          static_cast<int>(device_index));
-      pool.local_ids.push_back(static_cast<c10::StreamId>(static_cast<uint32_t>(handle & 0xFFFFFFFFULL)));
-    }
+  // next <= size holds, so next == size means this slot has not been filled yet:
+  // one stream is created per new slot, then the pool cycles.
+  if (pool.next == pool.local_ids.size()) {
+    pool.local_ids.push_back(create_stream_local_id(device_index));
   }
   const auto local_id = pool.local_ids[pool.next];
-  pool.next = (pool.next + 1) % pool.local_ids.size();
+  pool.next = (pool.next + 1) % kStreamPoolSize;
   return c10::Stream(c10::Stream::UNSAFE, c10::Device(c10::kPrivateUse1, device_index), local_id);
 }
 

--- a/c10/rbln/RBLNFunctions.cpp
+++ b/c10/rbln/RBLNFunctions.cpp
@@ -829,6 +829,9 @@ void set_current_stream(c10::Stream stream) {
 }
 
 bool query_stream(c10::Stream stream) {
+  if (runtime_shutting_down_.load(std::memory_order_relaxed)) {
+    return true; // nothing left to wait for; matches synchronize_stream's no-op
+  }
   bool done = false;
   RBLN_CHECK(
       !::rbln::rbln_stream_query(stream_to_handle(stream), &done),
@@ -857,6 +860,9 @@ uint64_t event_create(c10::DeviceIndex device_index) {
       !::rbln::rbln_event_create(torch_device_id, &handle),
       "rbln_event_create failed for rbln:{}",
       static_cast<int>(device_index));
+  // torch's "not created yet" sentinel is a null handle, so handle 0 would make
+  // every record allocate anew and every query answer "complete".
+  RBLN_CHECK(handle != 0, "rbln_event_create returned handle 0, which aliases the not-created sentinel");
   return handle;
 }
 
@@ -872,6 +878,9 @@ void event_destroy(uint64_t event) noexcept {
 }
 
 void event_record(uint64_t event, c10::Stream stream) {
+  if (runtime_shutting_down_.load(std::memory_order_relaxed)) {
+    return;
+  }
   RBLN_CHECK(
       !::rbln::rbln_event_record(event, stream_to_handle(stream)), "rbln_event_record failed (event={:#x})", event);
 }
@@ -896,6 +905,9 @@ void event_block(c10::Stream stream, uint64_t event) {
 }
 
 bool event_query(uint64_t event) {
+  if (runtime_shutting_down_.load(std::memory_order_relaxed)) {
+    return true; // nothing left to wait for; matches event_synchronize's no-op
+  }
   bool done = false;
   RBLN_CHECK(!::rbln::rbln_event_query(event, &done), "rbln_event_query failed (event={:#x})", event);
   return done;

--- a/c10/rbln/RBLNFunctions.cpp
+++ b/c10/rbln/RBLNFunctions.cpp
@@ -770,6 +770,9 @@ c10::StreamId create_stream_local_id(c10::DeviceIndex device_index) {
       !::rbln::rbln_stream_create(torch_device_id, &handle),
       "rbln_stream_create failed for rbln:{}",
       static_cast<int>(device_index));
+  // A stream exists only on a live context, so this process owns one on this device.
+  // Keeps getStream's "no context -> default stream" shortcut honest.
+  mark_device_context_initialized(device_index);
   return static_cast<c10::StreamId>(static_cast<uint32_t>(handle & 0xFFFFFFFFULL));
 }
 

--- a/c10/rbln/RBLNFunctions.cpp
+++ b/c10/rbln/RBLNFunctions.cpp
@@ -735,6 +735,184 @@ void synchronize(c10::DeviceIndex device_index) {
       static_cast<int>(device_index));
 }
 
+namespace {
+
+// Pack a c10::Stream into its C-ABI handle. StreamId carries the per-device stream id.
+uint64_t stream_to_handle(const c10::Stream& stream) {
+  const auto torch_device_id = static_cast<uint32_t>(to_device_id(stream.device_index()));
+  const auto local_id = static_cast<uint32_t>(stream.id());
+  return (static_cast<uint64_t>(torch_device_id) << 32) | local_id;
+}
+
+// Rebuild a c10::Stream on `device_index` from its C-ABI handle. StreamId holds the
+// per-device stream id; the device travels in the Stream itself.
+c10::Stream stream_from_handle(c10::DeviceIndex device_index, uint64_t handle) {
+  const auto local_id = static_cast<c10::StreamId>(static_cast<uint32_t>(handle & 0xFFFFFFFFULL));
+  return c10::Stream(c10::Stream::UNSAFE, c10::Device(c10::kPrivateUse1, device_index), local_id);
+}
+
+// A device index of -1 means "current device" (torch passes it for an index-less
+// device like `torch.Stream(device="rbln")`); resolve it up front.
+c10::DeviceIndex resolve_device_index(c10::DeviceIndex device_index) {
+  return device_index < 0 ? get_device_index() : device_index;
+}
+
+// Fixed per-device pool backing getStreamFromGlobalPool. RBLN has no stream
+// priorities, so one pool suffices; streams are created lazily and live for the
+// process (matching CUDA's global pool).
+constexpr int kStreamPoolSize = 32;
+
+} // namespace
+
+c10::Stream get_current_stream(c10::DeviceIndex device_index) {
+  device_index = resolve_device_index(device_index);
+  check_device_index(device_index);
+  const auto torch_device_id = static_cast<uint32_t>(to_device_id(device_index));
+  uint64_t handle = 0;
+  RBLN_CHECK(
+      !::rbln::rbln_get_current_stream(torch_device_id, &handle),
+      "rbln_get_current_stream failed for rbln:{}",
+      static_cast<int>(device_index));
+  return stream_from_handle(device_index, handle);
+}
+
+c10::Stream get_default_stream(c10::DeviceIndex device_index) {
+  device_index = resolve_device_index(device_index);
+  check_device_index(device_index);
+  // StreamId 0 is the default stream; no C-ABI call needed.
+  return c10::Stream(c10::Stream::DEFAULT, c10::Device(c10::kPrivateUse1, device_index));
+}
+
+c10::Stream new_stream(c10::DeviceIndex device_index) {
+  device_index = resolve_device_index(device_index);
+  check_device_index(device_index);
+  const auto torch_device_id = static_cast<uint32_t>(to_device_id(device_index));
+  uint64_t handle = 0;
+  RBLN_CHECK(
+      !::rbln::rbln_stream_create(torch_device_id, &handle),
+      "rbln_stream_create failed for rbln:{}",
+      static_cast<int>(device_index));
+  return stream_from_handle(device_index, handle);
+}
+
+c10::Stream get_stream_from_pool(c10::DeviceIndex device_index) {
+  device_index = resolve_device_index(device_index);
+  check_device_index(device_index);
+  struct Pool {
+    std::vector<c10::StreamId> local_ids;
+    size_t next = 0;
+  };
+  static std::mutex pool_mutex;
+  static std::map<c10::DeviceIndex, Pool> pools;
+  std::lock_guard<std::mutex> lock(pool_mutex);
+  auto& pool = pools[device_index];
+  if (pool.local_ids.empty()) {
+    const auto torch_device_id = static_cast<uint32_t>(to_device_id(device_index));
+    pool.local_ids.reserve(kStreamPoolSize);
+    for (int i = 0; i < kStreamPoolSize; ++i) {
+      uint64_t handle = 0;
+      RBLN_CHECK(
+          !::rbln::rbln_stream_create(torch_device_id, &handle),
+          "rbln_stream_create (pool) failed for rbln:{}",
+          static_cast<int>(device_index));
+      pool.local_ids.push_back(static_cast<c10::StreamId>(static_cast<uint32_t>(handle & 0xFFFFFFFFULL)));
+    }
+  }
+  const auto local_id = pool.local_ids[pool.next];
+  pool.next = (pool.next + 1) % pool.local_ids.size();
+  return c10::Stream(c10::Stream::UNSAFE, c10::Device(c10::kPrivateUse1, device_index), local_id);
+}
+
+void set_current_stream(c10::Stream stream) {
+  const auto device_index = stream.device_index();
+  check_device_index(device_index);
+  const auto torch_device_id = static_cast<uint32_t>(to_device_id(device_index));
+  RBLN_CHECK(
+      !::rbln::rbln_set_current_stream(torch_device_id, stream_to_handle(stream)),
+      "rbln_set_current_stream failed for rbln:{}",
+      static_cast<int>(device_index));
+}
+
+bool query_stream(c10::Stream stream) {
+  bool done = false;
+  RBLN_CHECK(
+      !::rbln::rbln_stream_query(stream_to_handle(stream), &done),
+      "rbln_stream_query failed for rbln:{}",
+      static_cast<int>(stream.device_index()));
+  return done;
+}
+
+void synchronize_stream(c10::Stream stream) {
+  // Teardown-safe: skip during interpreter shutdown.
+  if (runtime_shutting_down_.load(std::memory_order_relaxed)) {
+    return;
+  }
+  RBLN_CHECK(
+      !::rbln::rbln_stream_synchronize(stream_to_handle(stream)),
+      "rbln_stream_synchronize failed for rbln:{}",
+      static_cast<int>(stream.device_index()));
+}
+
+uint64_t event_create(c10::DeviceIndex device_index) {
+  device_index = resolve_device_index(device_index);
+  check_device_index(device_index);
+  const auto torch_device_id = static_cast<uint32_t>(to_device_id(device_index));
+  uint64_t handle = 0;
+  RBLN_CHECK(
+      !::rbln::rbln_event_create(torch_device_id, &handle),
+      "rbln_event_create failed for rbln:{}",
+      static_cast<int>(device_index));
+  return handle;
+}
+
+void event_destroy(uint64_t event) noexcept {
+  // noexcept: called from ~Event, possibly during interpreter teardown. Never throw.
+  if (event == 0 || runtime_shutting_down_.load(std::memory_order_relaxed)) {
+    return;
+  }
+  const int rc = ::rbln::rbln_event_destroy(event);
+  if (rc != 0) {
+    RBLN_WARN_NOTHROW("rbln_event_destroy failed (handle={:#x}, rc={})", event, rc);
+  }
+}
+
+void event_record(uint64_t event, c10::Stream stream) {
+  RBLN_CHECK(
+      !::rbln::rbln_event_record(event, stream_to_handle(stream)), "rbln_event_record failed (event={:#x})", event);
+}
+
+void event_block(c10::Stream stream, uint64_t event) {
+  const auto stream_handle = stream_to_handle(stream);
+  if ((event >> 32) == (stream_handle >> 32)) {
+    // Same device: does not block the host.
+    RBLN_CHECK(
+        !::rbln::rbln_stream_wait_event(stream_handle, event),
+        "rbln_stream_wait_event failed (stream={:#x}, event={:#x})",
+        stream_handle,
+        event);
+  } else {
+    // Cross-device waits are not supported; degrade to a host-side wait on the event
+    // -- correct ordering, at the cost of serializing the host.
+    RBLN_CHECK(
+        !::rbln::rbln_event_synchronize(event),
+        "cross-device wait_event fallback (event_synchronize) failed (event={:#x})",
+        event);
+  }
+}
+
+bool event_query(uint64_t event) {
+  bool done = false;
+  RBLN_CHECK(!::rbln::rbln_event_query(event, &done), "rbln_event_query failed (event={:#x})", event);
+  return done;
+}
+
+void event_synchronize(uint64_t event) {
+  if (runtime_shutting_down_.load(std::memory_order_relaxed)) {
+    return;
+  }
+  RBLN_CHECK(!::rbln::rbln_event_synchronize(event), "rbln_event_synchronize failed (event={:#x})", event);
+}
+
 void memcpy_v2v_multi(const std::vector<V2VCopyOp>& copies) {
   if (copies.empty()) {
     return;

--- a/c10/rbln/RBLNFunctions.cpp
+++ b/c10/rbln/RBLNFunctions.cpp
@@ -757,10 +757,8 @@ c10::DeviceIndex resolve_device_index(c10::DeviceIndex device_index) {
   return device_index < 0 ? get_device_index() : device_index;
 }
 
-// Fixed per-device pool behind every stream torch hands out. RBLN has no stream
-// priorities, so one pool suffices. Torch has no destroy hook for a stream, so
-// creating one per request would leak it and lengthen every runtime drain-all;
-// CUDA answers getNewStream from its pool for the same reason.
+// Every stream torch hands out comes from this per-device pool: there is no destroy
+// hook, so an unbounded create would leak and lengthen every runtime drain-all.
 constexpr size_t kStreamPoolSize = 32;
 
 c10::StreamId create_stream_local_id(c10::DeviceIndex device_index) {
@@ -770,9 +768,7 @@ c10::StreamId create_stream_local_id(c10::DeviceIndex device_index) {
       !::rbln::rbln_stream_create(torch_device_id, &handle),
       "rbln_stream_create failed for rbln:{}",
       static_cast<int>(device_index));
-  // A stream exists only on a live context, so this process owns one on this device.
-  // Keeps getStream's "no context -> default stream" shortcut honest.
-  mark_device_context_initialized(device_index);
+  mark_device_context_initialized(device_index); // a stream implies a live context here
   return static_cast<c10::StreamId>(static_cast<uint32_t>(handle & 0xFFFFFFFFULL));
 }
 
@@ -808,8 +804,7 @@ c10::Stream get_stream_from_pool(c10::DeviceIndex device_index) {
   static std::map<c10::DeviceIndex, Pool> pools;
   std::lock_guard<std::mutex> lock(pool_mutex);
   auto& pool = pools[device_index];
-  // next <= size holds, so next == size means this slot has not been filled yet:
-  // one stream is created per new slot, then the pool cycles.
+  // next <= size, so next == size means this slot is still empty.
   if (pool.next == pool.local_ids.size()) {
     pool.local_ids.push_back(create_stream_local_id(device_index));
   }
@@ -830,7 +825,7 @@ void set_current_stream(c10::Stream stream) {
 
 bool query_stream(c10::Stream stream) {
   if (runtime_shutting_down_.load(std::memory_order_relaxed)) {
-    return true; // nothing left to wait for; matches synchronize_stream's no-op
+    return true; // nothing left to wait for
   }
   bool done = false;
   RBLN_CHECK(
@@ -841,7 +836,6 @@ bool query_stream(c10::Stream stream) {
 }
 
 void synchronize_stream(c10::Stream stream) {
-  // Teardown-safe: skip during interpreter shutdown.
   if (runtime_shutting_down_.load(std::memory_order_relaxed)) {
     return;
   }
@@ -860,14 +854,13 @@ uint64_t event_create(c10::DeviceIndex device_index) {
       !::rbln::rbln_event_create(torch_device_id, &handle),
       "rbln_event_create failed for rbln:{}",
       static_cast<int>(device_index));
-  // torch's "not created yet" sentinel is a null handle, so handle 0 would make
-  // every record allocate anew and every query answer "complete".
+  // A null handle is torch's "not created yet" sentinel, so 0 must never be a handle.
   RBLN_CHECK(handle != 0, "rbln_event_create returned handle 0, which aliases the not-created sentinel");
   return handle;
 }
 
 void event_destroy(uint64_t event) noexcept {
-  // noexcept: called from ~Event, possibly during interpreter teardown. Never throw.
+  // Called from ~Event, possibly during interpreter teardown, so it must never throw.
   if (event == 0 || runtime_shutting_down_.load(std::memory_order_relaxed)) {
     return;
   }
@@ -906,7 +899,7 @@ void event_block(c10::Stream stream, uint64_t event) {
 
 bool event_query(uint64_t event) {
   if (runtime_shutting_down_.load(std::memory_order_relaxed)) {
-    return true; // nothing left to wait for; matches event_synchronize's no-op
+    return true; // nothing left to wait for
   }
   bool done = false;
   RBLN_CHECK(!::rbln::rbln_event_query(event, &done), "rbln_event_query failed (event={:#x})", event);

--- a/c10/rbln/RBLNFunctions.cpp
+++ b/c10/rbln/RBLNFunctions.cpp
@@ -739,6 +739,11 @@ namespace {
 
 // Pack a c10::Stream into its C-ABI handle. StreamId carries the per-device stream id.
 uint64_t stream_to_handle(const c10::Stream& stream) {
+  // The handle holds the stream id in 32 bits, so a wider id would alias another stream.
+  RBLN_CHECK(
+      stream.id() >= 0 && stream.id() <= std::numeric_limits<uint32_t>::max(),
+      "rbln stream id {} is out of range for a stream handle",
+      stream.id());
   const auto torch_device_id = static_cast<uint32_t>(to_device_id(stream.device_index()));
   const auto local_id = static_cast<uint32_t>(stream.id());
   return (static_cast<uint64_t>(torch_device_id) << 32) | local_id;

--- a/c10/rbln/RBLNFunctions.cpp
+++ b/c10/rbln/RBLNFunctions.cpp
@@ -952,6 +952,9 @@ void event_record(uint64_t event, c10::Stream stream) {
 }
 
 void event_block(c10::Stream stream, uint64_t event) {
+  if (runtime_shutting_down_.load(std::memory_order_relaxed)) {
+    return;
+  }
   const auto stream_handle = stream_to_handle(stream);
   if ((event >> 32) == (stream_handle >> 32)) {
     // Same device: does not block the host.

--- a/c10/rbln/RBLNFunctions.h
+++ b/c10/rbln/RBLNFunctions.h
@@ -328,14 +328,11 @@ C10_RBLN_API c10::Stream get_current_stream(c10::DeviceIndex device_index);
 C10_RBLN_API c10::Stream get_default_stream(c10::DeviceIndex device_index);
 
 /**
- * @brief Creates a fresh stream on the device. `priority` has no analogue on RBLN
- * and is intentionally not part of this API (the guard impl ignores it).
- */
-C10_RBLN_API c10::Stream new_stream(c10::DeviceIndex device_index);
-
-/**
- * @brief Returns a stream from a fixed, lazily-created per-device round-robin pool
- * (backs getStreamFromGlobalPool). Pooled streams live for the process.
+ * @brief Returns a stream from a fixed per-device round-robin pool, creating one
+ * runtime stream per pool slot on first use. Backs both getNewStream and
+ * getStreamFromGlobalPool: torch never destroys a stream, so the pool is what keeps
+ * repeated requests from leaking. Past the pool size, requests reuse earlier streams.
+ * `priority` has no analogue on RBLN and is not part of this API.
  */
 C10_RBLN_API c10::Stream get_stream_from_pool(c10::DeviceIndex device_index);
 

--- a/c10/rbln/RBLNFunctions.h
+++ b/c10/rbln/RBLNFunctions.h
@@ -328,11 +328,9 @@ C10_RBLN_API c10::Stream get_current_stream(c10::DeviceIndex device_index);
 C10_RBLN_API c10::Stream get_default_stream(c10::DeviceIndex device_index);
 
 /**
- * @brief Returns a stream from a fixed per-device round-robin pool, creating one
- * runtime stream per pool slot on first use. Backs both getNewStream and
- * getStreamFromGlobalPool: torch never destroys a stream, so the pool is what keeps
- * repeated requests from leaking. Past the pool size, requests reuse earlier streams.
- * `priority` has no analogue on RBLN and is not part of this API.
+ * @brief Returns a stream from a fixed per-device round-robin pool, filled one slot at
+ * a time. Past the pool size, requests reuse earlier streams. Priorities do not exist
+ * on RBLN and are not part of this API.
  */
 C10_RBLN_API c10::Stream get_stream_from_pool(c10::DeviceIndex device_index);
 

--- a/c10/rbln/RBLNFunctions.h
+++ b/c10/rbln/RBLNFunctions.h
@@ -3,6 +3,7 @@
 #include <c10/core/CachingDeviceAllocator.h>
 #include <c10/core/Device.h>
 #include <c10/core/ScalarType.h>
+#include <c10/core/Stream.h>
 #include <c10/rbln/RBLNMacros.h>
 #include <rebel/runtime/api/rbln_runtime_api.h>
 
@@ -311,6 +312,79 @@ C10_RBLN_API void memcpy_v2v_async(void* rbln_dst_data, const void* rbln_src_dat
  * @param device_index The RBLN device to synchronize.
  */
 C10_RBLN_API void synchronize(c10::DeviceIndex device_index);
+
+// Streams / events (torch.Stream / torch.Event). A c10::Stream carries the per-device
+// stream id as its StreamId (StreamId 0 is the default stream). An event surfaces as
+// its opaque handle, which is non-zero for a valid event (so it never aliases nullptr).
+
+/**
+ * @brief Returns the current stream for the device (default stream if none set).
+ */
+C10_RBLN_API c10::Stream get_current_stream(c10::DeviceIndex device_index);
+
+/**
+ * @brief Returns the device's default stream (StreamId 0).
+ */
+C10_RBLN_API c10::Stream get_default_stream(c10::DeviceIndex device_index);
+
+/**
+ * @brief Creates a fresh stream on the device. `priority` has no analogue on RBLN
+ * and is intentionally not part of this API (the guard impl ignores it).
+ */
+C10_RBLN_API c10::Stream new_stream(c10::DeviceIndex device_index);
+
+/**
+ * @brief Returns a stream from a fixed, lazily-created per-device round-robin pool
+ * (backs getStreamFromGlobalPool). Pooled streams live for the process.
+ */
+C10_RBLN_API c10::Stream get_stream_from_pool(c10::DeviceIndex device_index);
+
+/**
+ * @brief Makes `stream` the current stream on its device (thread-local).
+ */
+C10_RBLN_API void set_current_stream(c10::Stream stream);
+
+/**
+ * @brief Non-blocking: true iff all work submitted to `stream` has completed.
+ */
+C10_RBLN_API bool query_stream(c10::Stream stream);
+
+/**
+ * @brief Blocks the host until all work on `stream` has completed.
+ */
+C10_RBLN_API void synchronize_stream(c10::Stream stream);
+
+/**
+ * @brief Creates an event on the device and returns its opaque uint64 handle.
+ */
+C10_RBLN_API uint64_t event_create(c10::DeviceIndex device_index);
+
+/**
+ * @brief Destroys an event. Never throws (called from destructors); no-op on 0.
+ */
+C10_RBLN_API void event_destroy(uint64_t event) noexcept;
+
+/**
+ * @brief Snapshots `stream`'s current position into the event (re-record overwrites).
+ */
+C10_RBLN_API void event_record(uint64_t event, c10::Stream stream);
+
+/**
+ * @brief Makes `stream` wait for `event`. Same-device: does not block the host.
+ * Cross-device waits are not supported and degrade to a host-side wait on the event
+ * (correct, but serializes the host).
+ */
+C10_RBLN_API void event_block(c10::Stream stream, uint64_t event);
+
+/**
+ * @brief Non-blocking: true iff the work recorded into the event has completed.
+ */
+C10_RBLN_API bool event_query(uint64_t event);
+
+/**
+ * @brief Blocks the host until the work recorded into the event has completed.
+ */
+C10_RBLN_API void event_synchronize(uint64_t event);
 
 /**
  * @brief Descriptor for one device-to-device slab copy used by memcpy_v2v_multi.

--- a/c10/rbln/impl/RBLNGuardImpl.cpp
+++ b/c10/rbln/impl/RBLNGuardImpl.cpp
@@ -125,68 +125,96 @@ c10::DeviceCapability RBLNGuardImpl::getDeviceCapability(c10::Device device) con
 }
 
 c10::Stream RBLNGuardImpl::getStream(c10::Device device) const {
-  const auto current_stream = c10::Stream(c10::Stream::Default::DEFAULT, device);
-  RBLN_LOG_DEBUG("current_stream={}", c10::str(current_stream));
-  return current_stream;
+  // Called on hot paths (every StreamGuard). If the current stream can't be resolved
+  // (e.g. the device isn't initialized yet), fall back to the default stream instead
+  // of surfacing an error here.
+  try {
+    return c10::rbln::get_current_stream(device.index());
+  } catch (const std::exception& e) {
+    RBLN_LOG_DEBUG("getStream falling back to default stream: {}", e.what());
+    return c10::rbln::get_default_stream(device.index());
+  }
+}
+
+c10::Stream RBLNGuardImpl::getDefaultStream(c10::Device device) const {
+  return c10::rbln::get_default_stream(device.index());
+}
+
+c10::Stream RBLNGuardImpl::getNewStream(c10::Device device, int priority) const {
+  (void)priority; // RBLN has no stream priorities.
+  return c10::rbln::new_stream(device.index());
+}
+
+c10::Stream RBLNGuardImpl::getStreamFromGlobalPool(c10::Device device, bool isHighPriority) const {
+  (void)isHighPriority; // RBLN has no stream priorities.
+  return c10::rbln::get_stream_from_pool(device.index());
 }
 
 c10::Stream RBLNGuardImpl::exchangeStream(c10::Stream stream) const {
-  const auto current_device_index = c10::rbln::get_device_index();
-  const auto current_device = c10::Device(c10::kPrivateUse1, current_device_index);
-  const auto original_stream = c10::Stream(c10::Stream::Default::DEFAULT, current_device);
+  const auto original_stream = getStream(stream.device());
+  c10::rbln::set_current_stream(stream);
   RBLN_LOG_DEBUG("Setting current stream: {} -> {}", c10::str(original_stream), c10::str(stream));
   return original_stream;
 }
 
+bool RBLNGuardImpl::queryStream(const c10::Stream& stream) const {
+  return c10::rbln::query_stream(stream);
+}
+
+void RBLNGuardImpl::synchronizeStream(const c10::Stream& stream) const {
+  c10::rbln::synchronize_stream(stream);
+}
+
 namespace {
 
-// Opaque payload behind the void* handles in the event API: the device the
-// event was last recorded on, or -1 while never recorded.
-struct RBLNEvent {
-  c10::DeviceIndex device_index = -1;
+// The void* event handle IS the opaque event handle (see RBLNGuardImpl.h). Route the
+// int<->ptr casts through uintptr_t and keep them in one place.
+void* to_event_ptr(uint64_t handle) {
+  return reinterpret_cast<void*>(static_cast<uintptr_t>(handle)); // NOLINT(performance-no-int-to-ptr)
+}
 
-  bool recorded() const {
-    return device_index >= 0;
-  }
-};
-
-void drain_if_recorded(void* event) {
-  const auto* rbln_event = static_cast<const RBLNEvent*>(event);
-  if (rbln_event != nullptr && rbln_event->recorded()) {
-    c10::rbln::synchronize(rbln_event->device_index);
-  }
+uint64_t to_event_handle(void* event) {
+  return static_cast<uint64_t>(reinterpret_cast<uintptr_t>(event));
 }
 
 } // namespace
 
 void RBLNGuardImpl::record(void** event, const c10::Stream& stream, c10::DeviceIndex device_index, c10::EventFlag flag)
     const {
-  (void)flag; // RBLN events carry no timing.
+  (void)flag; // Event timing is not supported (elapsedTime is unimplemented).
+  const auto event_device = device_index >= 0 ? device_index : stream.device_index();
   if (*event == nullptr) {
-    *event = new RBLNEvent();
+    // A valid event handle is non-zero, so it never aliases the "not yet created"
+    // nullptr sentinel torch checks here.
+    *event = to_event_ptr(c10::rbln::event_create(event_device));
   }
-  auto* rbln_event = static_cast<RBLNEvent*>(*event);
-  rbln_event->device_index = device_index >= 0 ? device_index : stream.device_index();
-  RBLN_LOG_DEBUG("Recorded event on device {}", static_cast<int>(rbln_event->device_index));
+  c10::rbln::event_record(to_event_handle(*event), stream);
 }
 
 void RBLNGuardImpl::block(void* event, const c10::Stream& stream) const {
-  (void)stream; // Single in-order queue: a host-side drain orders everything.
-  drain_if_recorded(event);
+  if (event == nullptr) {
+    return; // never recorded -> nothing to wait for
+  }
+  c10::rbln::event_block(stream, to_event_handle(event));
 }
 
 bool RBLNGuardImpl::queryEvent(void* event) const {
-  drain_if_recorded(event);
-  return true;
+  if (event == nullptr) {
+    return true; // never recorded -> complete
+  }
+  return c10::rbln::event_query(to_event_handle(event));
 }
 
 void RBLNGuardImpl::synchronizeEvent(void* event) const {
-  drain_if_recorded(event);
+  if (event == nullptr) {
+    return; // never recorded -> no-op
+  }
+  c10::rbln::event_synchronize(to_event_handle(event));
 }
 
 void RBLNGuardImpl::destroyEvent(void* event, c10::DeviceIndex device_index) const noexcept {
   (void)device_index;
-  delete static_cast<RBLNEvent*>(event);
+  c10::rbln::event_destroy(to_event_handle(event)); // noexcept; no-op on null (handle 0)
 }
 
 void RBLNGuardImpl::synchronizeDevice(c10::DeviceIndex device_index) const {

--- a/c10/rbln/impl/RBLNGuardImpl.cpp
+++ b/c10/rbln/impl/RBLNGuardImpl.cpp
@@ -178,6 +178,13 @@ uint64_t to_event_handle(void* event) {
 void RBLNGuardImpl::record(void** event, const c10::Stream& stream, c10::DeviceIndex device_index, c10::EventFlag flag)
     const {
   (void)flag; // Event timing is not supported (elapsedTime is unimplemented).
+  TORCH_CHECK(
+      device_index == -1 || device_index == stream.device_index(),
+      "Event device index ",
+      device_index,
+      " does not match recording stream's device index ",
+      stream.device_index(),
+      ".");
   const auto event_device = device_index >= 0 ? device_index : stream.device_index();
   if (*event == nullptr) {
     *event = to_event_ptr(c10::rbln::event_create(event_device));

--- a/c10/rbln/impl/RBLNGuardImpl.cpp
+++ b/c10/rbln/impl/RBLNGuardImpl.cpp
@@ -142,7 +142,9 @@ c10::Stream RBLNGuardImpl::getDefaultStream(c10::Device device) const {
 
 c10::Stream RBLNGuardImpl::getNewStream(c10::Device device, int priority) const {
   (void)priority; // RBLN has no stream priorities.
-  return c10::rbln::new_stream(device.index());
+  // Pooled, like CUDA's getNewStream: torch has no destroy hook for a stream, so
+  // handing out a freshly created one per call would leak it.
+  return c10::rbln::get_stream_from_pool(device.index());
 }
 
 c10::Stream RBLNGuardImpl::getStreamFromGlobalPool(c10::Device device, bool isHighPriority) const {

--- a/c10/rbln/impl/RBLNGuardImpl.cpp
+++ b/c10/rbln/impl/RBLNGuardImpl.cpp
@@ -125,10 +125,8 @@ c10::DeviceCapability RBLNGuardImpl::getDeviceCapability(c10::Device device) con
 }
 
 c10::Stream RBLNGuardImpl::getStream(c10::Device device) const {
-  // No context yet means there is no current stream to read, and nothing has been
-  // selected: the default stream is the answer, without a runtime call. A failure
-  // once the context exists is real -- swallowing it would silently move work off
-  // the stream the caller selected.
+  // With no context there is nothing to read and nothing can have been selected, so
+  // the default stream is the answer. Past that point a failure is real.
   const auto index = device.has_index() ? device.index() : c10::rbln::get_device_index();
   if (!c10::rbln::device_context_initialized(index)) {
     return c10::rbln::get_default_stream(index);
@@ -142,8 +140,6 @@ c10::Stream RBLNGuardImpl::getDefaultStream(c10::Device device) const {
 
 c10::Stream RBLNGuardImpl::getNewStream(c10::Device device, int priority) const {
   (void)priority; // RBLN has no stream priorities.
-  // Pooled, like CUDA's getNewStream: torch has no destroy hook for a stream, so
-  // handing out a freshly created one per call would leak it.
   return c10::rbln::get_stream_from_pool(device.index());
 }
 
@@ -155,7 +151,6 @@ c10::Stream RBLNGuardImpl::getStreamFromGlobalPool(c10::Device device, bool isHi
 c10::Stream RBLNGuardImpl::exchangeStream(c10::Stream stream) const {
   const auto original_stream = getStream(stream.device());
   c10::rbln::set_current_stream(stream);
-  RBLN_LOG_DEBUG("Setting current stream: {} -> {}", c10::str(original_stream), c10::str(stream));
   return original_stream;
 }
 
@@ -169,8 +164,7 @@ void RBLNGuardImpl::synchronizeStream(const c10::Stream& stream) const {
 
 namespace {
 
-// The void* event handle IS the opaque event handle (see RBLNGuardImpl.h). Route the
-// int<->ptr casts through uintptr_t and keep them in one place.
+// The void* handle IS the opaque event handle; the casts live here only.
 void* to_event_ptr(uint64_t handle) {
   return reinterpret_cast<void*>(static_cast<uintptr_t>(handle)); // NOLINT(performance-no-int-to-ptr)
 }
@@ -186,8 +180,6 @@ void RBLNGuardImpl::record(void** event, const c10::Stream& stream, c10::DeviceI
   (void)flag; // Event timing is not supported (elapsedTime is unimplemented).
   const auto event_device = device_index >= 0 ? device_index : stream.device_index();
   if (*event == nullptr) {
-    // A valid event handle is non-zero, so it never aliases the "not yet created"
-    // nullptr sentinel torch checks here.
     *event = to_event_ptr(c10::rbln::event_create(event_device));
   }
   c10::rbln::event_record(to_event_handle(*event), stream);

--- a/c10/rbln/impl/RBLNGuardImpl.cpp
+++ b/c10/rbln/impl/RBLNGuardImpl.cpp
@@ -125,15 +125,15 @@ c10::DeviceCapability RBLNGuardImpl::getDeviceCapability(c10::Device device) con
 }
 
 c10::Stream RBLNGuardImpl::getStream(c10::Device device) const {
-  // Called on hot paths (every StreamGuard). If the current stream can't be resolved
-  // (e.g. the device isn't initialized yet), fall back to the default stream instead
-  // of surfacing an error here.
-  try {
-    return c10::rbln::get_current_stream(device.index());
-  } catch (const std::exception& e) {
-    RBLN_LOG_DEBUG("getStream falling back to default stream: {}", e.what());
-    return c10::rbln::get_default_stream(device.index());
+  // No context yet means there is no current stream to read, and nothing has been
+  // selected: the default stream is the answer, without a runtime call. A failure
+  // once the context exists is real -- swallowing it would silently move work off
+  // the stream the caller selected.
+  const auto index = device.has_index() ? device.index() : c10::rbln::get_device_index();
+  if (!c10::rbln::device_context_initialized(index)) {
+    return c10::rbln::get_default_stream(index);
   }
+  return c10::rbln::get_current_stream(index);
 }
 
 c10::Stream RBLNGuardImpl::getDefaultStream(c10::Device device) const {

--- a/c10/rbln/impl/RBLNGuardImpl.h
+++ b/c10/rbln/impl/RBLNGuardImpl.h
@@ -65,12 +65,38 @@ struct RBLNGuardImpl final : public c10::impl::DeviceGuardImplInterface {
   c10::DeviceCapability getDeviceCapability(c10::Device device) const override;
 
   /**
-   * @brief Returns the current stream for the input device.
+   * @brief Returns the current stream for the input device (default if none set).
    *
    * @param device The input device.
    * @return The current stream.
    */
   c10::Stream getStream(c10::Device device) const override;
+
+  /**
+   * @brief Returns the device's default stream (StreamId 0).
+   *
+   * @param device The input device.
+   * @return The default stream.
+   */
+  c10::Stream getDefaultStream(c10::Device device) const override;
+
+  /**
+   * @brief Creates and returns a fresh stream on the input device.
+   *
+   * @param device The input device.
+   * @param priority Ignored. RBLN has no stream priorities.
+   * @return A new stream.
+   */
+  c10::Stream getNewStream(c10::Device device, int priority = 0) const override;
+
+  /**
+   * @brief Returns a stream from the device's fixed round-robin pool.
+   *
+   * @param device The input device.
+   * @param isHighPriority Ignored. RBLN has no stream priorities.
+   * @return A pooled stream.
+   */
+  c10::Stream getStreamFromGlobalPool(c10::Device device, bool isHighPriority = false) const override;
 
   /**
    * @brief Sets the current stream to the input stream, and returns the previous stream.
@@ -80,52 +106,65 @@ struct RBLNGuardImpl final : public c10::impl::DeviceGuardImplInterface {
    */
   c10::Stream exchangeStream(c10::Stream stream) const override;
 
-  // Events (torch.Event). RBLN has a single in-order copy queue per device and
-  // the UMD exposes only a whole-device drain, so an event records the device
-  // it was captured on and every wait maps to synchronize(device). This
-  // over-synchronizes relative to CUDA's per-event waits but is correct: the
-  // queue is in-order, so draining it covers everything recorded before.
+  /**
+   * @brief Non-blocking: true iff all work submitted to the stream has completed.
+   *
+   * @param stream The stream to query.
+   */
+  bool queryStream(const c10::Stream& stream) const override;
 
   /**
-   * @brief Marks the event as recorded on the device of the input stream.
-   * Allocates the event on first record.
+   * @brief Blocks the host until all work on the stream has completed.
+   *
+   * @param stream The stream to synchronize.
+   */
+  void synchronizeStream(const c10::Stream& stream) const override;
+
+  // Events (torch.Event). elapsedTime is intentionally left unimplemented (event
+  // timing is not supported; the base throws "Backend doesn't support elapsedTime.").
+  // Cross-device waits are not supported and degrade to a host-side wait (see
+  // block()). The opaque void* handle is non-zero for a valid event, so it never
+  // aliases nullptr.
+
+  /**
+   * @brief Records the event at the stream's current position (allocates on first
+   * record; re-record overwrites the snapshot).
    *
    * @param event In/out opaque event handle.
-   * @param stream The stream to record on (only its device is used).
+   * @param stream The stream to record on.
    * @param device_index The device index, or -1 for the stream's device.
-   * @param flag Ignored (RBLN events carry no timing).
+   * @param flag Ignored (event timing is not supported).
    */
   void record(void** event, const c10::Stream& stream, c10::DeviceIndex device_index, c10::EventFlag flag)
       const override;
 
   /**
-   * @brief Makes the stream wait for the event. Host-blocks on the recorded
-   * device's queue (stronger than a device-side wait, hence correct).
+   * @brief Makes the stream wait for the event. Same-device: does not block the
+   * host. Cross-device waits are not supported and degrade to a host-side wait on
+   * the event.
    *
-   * @param event An opaque event handle. May be null (never recorded).
-   * @param stream Unused.
+   * @param event An opaque event handle. May be null (never recorded -> no-op).
+   * @param stream The stream that must wait.
    */
   void block(void* event, const c10::Stream& stream) const override;
 
   /**
-   * @brief Returns true once the recorded work has completed. Drains the
-   * recorded device's queue first, so unlike CUDA this may block; it never
-   * returns false for a recorded event.
+   * @brief Non-blocking: true iff the work recorded into the event has completed
+   * (true for a null / never-recorded event).
    *
    * @param event An opaque event handle. May be null (never recorded).
-   * @return True.
    */
   bool queryEvent(void* event) const override;
 
   /**
    * @brief Blocks the host until the recorded work has completed.
    *
-   * @param event An opaque event handle. May be null (never recorded).
+   * @param event An opaque event handle. May be null (never recorded -> no-op).
    */
   void synchronizeEvent(void* event) const override;
 
   /**
-   * @brief Frees the event.
+   * @brief Frees the event. Never throws.
    *
    * @param event An opaque event handle. May be null.
    * @param device_index Unused.

--- a/c10/rbln/impl/RBLNGuardImpl.h
+++ b/c10/rbln/impl/RBLNGuardImpl.h
@@ -81,11 +81,12 @@ struct RBLNGuardImpl final : public c10::impl::DeviceGuardImplInterface {
   c10::Stream getDefaultStream(c10::Device device) const override;
 
   /**
-   * @brief Creates and returns a fresh stream on the input device.
+   * @brief Returns a stream from the input device's pool (as CUDA does; torch has no
+   * destroy hook for a stream, so creating one per call would leak it).
    *
    * @param device The input device.
    * @param priority Ignored. RBLN has no stream priorities.
-   * @return A new stream.
+   * @return A pooled stream.
    */
   c10::Stream getNewStream(c10::Device device, int priority = 0) const override;
 

--- a/c10/rbln/impl/RBLNGuardImpl.h
+++ b/c10/rbln/impl/RBLNGuardImpl.h
@@ -81,8 +81,7 @@ struct RBLNGuardImpl final : public c10::impl::DeviceGuardImplInterface {
   c10::Stream getDefaultStream(c10::Device device) const override;
 
   /**
-   * @brief Returns a stream from the input device's pool (as CUDA does; torch has no
-   * destroy hook for a stream, so creating one per call would leak it).
+   * @brief Returns a stream from the input device's pool.
    *
    * @param device The input device.
    * @param priority Ignored. RBLN has no stream priorities.
@@ -121,11 +120,9 @@ struct RBLNGuardImpl final : public c10::impl::DeviceGuardImplInterface {
    */
   void synchronizeStream(const c10::Stream& stream) const override;
 
-  // Events (torch.Event). elapsedTime is intentionally left unimplemented (event
-  // timing is not supported; the base throws "Backend doesn't support elapsedTime.").
-  // Cross-device waits are not supported and degrade to a host-side wait (see
-  // block()). The opaque void* handle is non-zero for a valid event, so it never
-  // aliases nullptr.
+  // Events (torch.Event). elapsedTime stays unimplemented -- event timing is not
+  // supported, so the base throws. The opaque void* handle is non-zero for a valid
+  // event, so it never aliases nullptr.
 
   /**
    * @brief Records the event at the stream's current position (allocates on first

--- a/constraints-build-dev.txt
+++ b/constraints-build-dev.txt
@@ -1,2 +1,3 @@
 # Build/dev dependency constraints (single source of truth).
-rebel-compiler==0.11.2.dev256+gc5eaca9d.prod
+# Multi-stream/event runtime build required by torch.Stream/torch.Event support.
+rebel-compiler==0.11.2.dev374+g0179acfc

--- a/constraints-build-dev.txt
+++ b/constraints-build-dev.txt
@@ -1,3 +1,2 @@
 # Build/dev dependency constraints (single source of truth).
-# Multi-stream/event runtime build required by torch.Stream/torch.Event support.
 rebel-compiler==0.11.2.dev374+g0179acfc

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -6,6 +6,7 @@ set(sources
   core/RBLNNoDeviceTest.cpp
   core/RBLNDummyDeviceTest.cpp
   core/RBLNEventTest.cpp
+  core/RBLNStreamTest.cpp
   core/RBLNFunctionsTest.cpp
   core/RBLNLoggingTest.cpp
   core/RBLNPinnedAllocatorTest.cpp

--- a/test/cpp/core/RBLNEventTest.cpp
+++ b/test/cpp/core/RBLNEventTest.cpp
@@ -2,9 +2,13 @@
 #include <c10/rbln/RBLNFunctions.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <cstdint>
 #include <vector>
 
+// Exercises the event half of RBLNGuardImpl through VirtualGuardImpl (the same path
+// torch.Event takes): record, block, query, synchronize, destroy. Host-observable
+// data assertions use synchronizeDevice.
 class RBLNEventTest : public ::testing::Test {
  protected:
   static void SetUpTestSuite() {
@@ -21,11 +25,12 @@ TEST_F(RBLNEventTest, NeverRecordedEventIsComplete) {
   const c10::impl::VirtualGuardImpl impl(c10::kPrivateUse1);
   void* event = nullptr;
   EXPECT_TRUE(impl.queryEvent(event));
-  impl.synchronizeEvent(event); // must be a no-op, not a crash
+  impl.synchronizeEvent(event); // no-op, not a crash
+  impl.block(event, impl.getStream(c10::Device(c10::kPrivateUse1, 0))); // no-op
   impl.destroyEvent(event, 0);
 }
 
-TEST_F(RBLNEventTest, RecordSynchronizeOrdersAsyncCopy) {
+TEST_F(RBLNEventTest, RecordSynchronizeCompletesAsyncCopy) {
   const c10::impl::VirtualGuardImpl impl(c10::kPrivateUse1);
   constexpr c10::DeviceIndex device_index = 0;
   constexpr size_t nbytes = 4096;
@@ -44,15 +49,48 @@ TEST_F(RBLNEventTest, RecordSynchronizeOrdersAsyncCopy) {
   void* event = nullptr;
   const auto stream = impl.getStream(c10::Device(c10::kPrivateUse1, device_index));
   impl.record(&event, stream, device_index, c10::EventFlag::PYTORCH_DEFAULT);
-  impl.synchronizeEvent(event);
+  impl.synchronizeEvent(event); // the recorded work has completed
+  EXPECT_TRUE(impl.queryEvent(event)); // ... and query agrees
+  impl.synchronizeDevice(device_index); // finalize the pending D2H transfer
   EXPECT_EQ(dst_cpu, src_cpu);
-  EXPECT_TRUE(impl.queryEvent(event));
 
-  // Recording again must reuse the handle, and block() must drain too.
+  // Re-record reuses the handle and snapshots the newer copy.
+  std::fill(dst_cpu.begin(), dst_cpu.end(), int8_t{0});
   c10::rbln::memcpy_v2h_async(dst_cpu.data(), rbln_data, nbytes);
   impl.record(&event, stream, device_index, c10::EventFlag::PYTORCH_DEFAULT);
-  impl.block(event, stream);
+  impl.synchronizeEvent(event);
+  impl.synchronizeDevice(device_index);
   EXPECT_EQ(dst_cpu, src_cpu);
+
+  impl.destroyEvent(event, device_index);
+  c10::rbln::free(rbln_data);
+}
+
+TEST_F(RBLNEventTest, WaitEventAcrossStreamsDoesNotError) {
+  // stream B waits on an event recorded on stream A. Asserts the plumbing works end
+  // to end and completion is observable.
+  const c10::impl::VirtualGuardImpl impl(c10::kPrivateUse1);
+  constexpr c10::DeviceIndex device_index = 0;
+  constexpr size_t nbytes = 4096;
+  const auto device = c10::Device(c10::kPrivateUse1, device_index);
+
+  std::vector<int8_t> src_cpu(nbytes, 7);
+  auto* rbln_data = c10::rbln::malloc(device_index, nbytes); // also materializes the context
+  ASSERT_NE(rbln_data, nullptr);
+
+  const auto stream_a = impl.getNewStream(device, 0);
+  const auto stream_b = impl.getNewStream(device, 0);
+
+  const auto prev = impl.exchangeStream(stream_a);
+  c10::rbln::memcpy_h2v_async(rbln_data, src_cpu.data(), nbytes);
+  void* event = nullptr;
+  impl.record(&event, stream_a, device_index, c10::EventFlag::PYTORCH_DEFAULT);
+  impl.block(event, stream_b); // B waits for A's event; must not error
+  impl.exchangeStream(prev);
+
+  impl.synchronizeStream(stream_a);
+  impl.synchronizeStream(stream_b);
+  EXPECT_TRUE(impl.queryEvent(event));
 
   impl.destroyEvent(event, device_index);
   c10::rbln::free(rbln_data);

--- a/test/cpp/core/RBLNStreamTest.cpp
+++ b/test/cpp/core/RBLNStreamTest.cpp
@@ -1,0 +1,119 @@
+#include <c10/core/impl/VirtualGuardImpl.h>
+#include <c10/rbln/RBLNFunctions.h>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <set>
+
+// Exercises the stream half of RBLNGuardImpl through VirtualGuardImpl (the same
+// path torch.Stream takes). Stream creation needs the device initialized, so each
+// test forces it with a scratch allocation.
+class RBLNStreamTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    c10::register_privateuse1_backend("rbln");
+    ASSERT_TRUE(c10::is_privateuse1_backend_registered());
+  }
+
+  void SetUp() override {
+    c10::rbln::set_device_index(0);
+    scratch_ = c10::rbln::malloc(0, 4096); // initialize the device
+    ASSERT_NE(scratch_, nullptr);
+    reset_to_default();
+  }
+
+  void TearDown() override {
+    reset_to_default();
+    if (scratch_ != nullptr) {
+      c10::rbln::free(scratch_);
+      scratch_ = nullptr;
+    }
+  }
+
+  // Leave the thread's current stream at the default so tests don't leak state.
+  void reset_to_default() {
+    const c10::impl::VirtualGuardImpl impl(c10::kPrivateUse1);
+    impl.exchangeStream(impl.getDefaultStream(device_));
+  }
+
+  void* scratch_ = nullptr;
+  const c10::Device device_{c10::kPrivateUse1, 0};
+};
+
+TEST_F(RBLNStreamTest, DefaultStreamIsZero) {
+  const c10::impl::VirtualGuardImpl impl(c10::kPrivateUse1);
+  EXPECT_EQ(impl.getDefaultStream(device_).id(), 0);
+  EXPECT_EQ(impl.getDefaultStream(device_).device(), device_);
+}
+
+TEST_F(RBLNStreamTest, CurrentDefaultsToDefault) {
+  const c10::impl::VirtualGuardImpl impl(c10::kPrivateUse1);
+  EXPECT_EQ(impl.getStream(device_), impl.getDefaultStream(device_));
+}
+
+TEST_F(RBLNStreamTest, NewStreamsAreDistinct) {
+  const c10::impl::VirtualGuardImpl impl(c10::kPrivateUse1);
+  const auto s1 = impl.getNewStream(device_, 0);
+  const auto s2 = impl.getNewStream(device_, 0);
+  EXPECT_NE(s1.id(), 0);
+  EXPECT_NE(s2.id(), 0);
+  EXPECT_NE(s1, s2);
+  EXPECT_EQ(s1.device(), device_);
+}
+
+TEST_F(RBLNStreamTest, ExchangeStreamSetsAndRestores) {
+  const c10::impl::VirtualGuardImpl impl(c10::kPrivateUse1);
+  const auto s = impl.getNewStream(device_, 0);
+  const auto def = impl.getDefaultStream(device_);
+  const auto prev = impl.exchangeStream(s);
+  EXPECT_EQ(prev, def);
+  EXPECT_EQ(impl.getStream(device_), s);
+  const auto back = impl.exchangeStream(def);
+  EXPECT_EQ(back, s);
+  EXPECT_EQ(impl.getStream(device_), def);
+}
+
+TEST_F(RBLNStreamTest, PriorityIsAcceptedButIgnored) {
+  const c10::impl::VirtualGuardImpl impl(c10::kPrivateUse1);
+  // RBLN has no stream priorities; any value is accepted and yields a usable stream.
+  const auto high = impl.getNewStream(device_, -1);
+  const auto low = impl.getNewStream(device_, 1);
+  EXPECT_NE(high.id(), 0);
+  EXPECT_NE(low.id(), 0);
+}
+
+TEST_F(RBLNStreamTest, IdleStreamQueryIsTrue) {
+  const c10::impl::VirtualGuardImpl impl(c10::kPrivateUse1);
+  const auto s = impl.getNewStream(device_, 0);
+  EXPECT_TRUE(impl.queryStream(s));
+  impl.synchronizeStream(s); // idle -> no-op, must not crash
+  EXPECT_TRUE(impl.queryStream(s));
+}
+
+TEST_F(RBLNStreamTest, GlobalPoolRoundRobins) {
+  const c10::impl::VirtualGuardImpl impl(c10::kPrivateUse1);
+  const auto first = impl.getStreamFromGlobalPool(device_, false);
+  std::set<c10::StreamId> seen{first.id()};
+  bool cycled = false;
+  for (int i = 0; i < 128; ++i) {
+    const auto s = impl.getStreamFromGlobalPool(device_, false);
+    EXPECT_NE(s.id(), 0);
+    if (s.id() == first.id()) {
+      cycled = true;
+      break;
+    }
+    seen.insert(s.id());
+  }
+  EXPECT_TRUE(cycled); // a fixed-size pool cycles back to the first stream
+  EXPECT_GT(seen.size(), 1u); // and holds more than one stream
+}
+
+TEST_F(RBLNStreamTest, StreamIdRoundTrips) {
+  const c10::impl::VirtualGuardImpl impl(c10::kPrivateUse1);
+  const auto s = impl.getNewStream(device_, 0);
+  const auto data = s.pack3();
+  const auto rebuilt = c10::Stream::unpack3(data.stream_id, data.device_index, data.device_type);
+  EXPECT_EQ(rebuilt, s);
+  EXPECT_EQ(rebuilt.id(), s.id());
+  EXPECT_EQ(rebuilt.device(), device_);
+}

--- a/test/rbln/test_accelerator_stream.py
+++ b/test/rbln/test_accelerator_stream.py
@@ -1,0 +1,135 @@
+# Owner(s): ["module: PrivateUse1"]
+
+"""torch.accelerator stream/event conformance for the RBLN backend.
+
+Ported from PyTorch's own accelerator test suite (pytorch v2.11.0
+``test/test_accelerator.py``). These cases are device-agnostic — they drive the
+generic ``torch.accelerator`` / ``torch.Stream`` / ``torch.Event`` API, which
+routes to whichever backend is the current accelerator. On an RBLN host that is
+``rbln``, so running them here exercises the RBLN DeviceGuard stream/event
+implementation exactly the way upstream exercises CUDA/XPU/MPS.
+
+Kept as close to the upstream bodies as possible so divergences are easy to spot.
+"""
+
+import pytest
+import torch
+from torch.testing._internal.common_utils import run_tests, TEST_ACCELERATOR, TEST_MULTIACCELERATOR, TestCase
+
+
+@pytest.mark.test_set_ci
+@pytest.mark.skipif(not TEST_ACCELERATOR, reason="no accelerator (rbln) detected")
+class TestAcceleratorStream(TestCase):
+    def test_generic_stream_behavior(self):
+        s1 = torch.Stream()
+        s2 = torch.Stream()
+        torch.accelerator.set_stream(s1)
+        self.assertEqual(torch.accelerator.current_stream(), s1)
+        event = torch.Event()
+        a = torch.randn(1000)
+        b = torch.randn(1000)
+        c = a + b
+        torch.accelerator.set_stream(s2)
+        self.assertEqual(torch.accelerator.current_stream(), s2)
+        a_acc = a.to(torch.accelerator.current_accelerator(), non_blocking=True)
+        b_acc = b.to(torch.accelerator.current_accelerator(), non_blocking=True)
+        torch.accelerator.set_stream(s1)
+        self.assertEqual(torch.accelerator.current_stream(), s1)
+        event.record(s2)
+        event.synchronize()
+        c_acc = a_acc + b_acc
+        event.record(s2)
+        torch.accelerator.synchronize()
+        self.assertTrue(event.query())
+        self.assertEqual(c_acc.cpu(), c)
+
+    def test_current_stream_query(self):
+        s = torch.accelerator.current_stream()
+        self.assertEqual(torch.accelerator.current_stream(s.device), s)
+        self.assertEqual(torch.accelerator.current_stream(s.device.index), s)
+        self.assertEqual(torch.accelerator.current_stream(str(s.device)), s)
+        other_device = torch.device("cpu")
+        with self.assertRaisesRegex(ValueError, "doesn't match the current accelerator"):
+            torch.accelerator.current_stream(other_device)
+
+    def test_stream_context_manager(self):
+        prev_stream = torch.accelerator.current_stream()
+        with torch.Stream() as s:
+            self.assertEqual(torch.accelerator.current_stream(), s)
+        self.assertEqual(torch.accelerator.current_stream(), prev_stream)
+
+    def test_stream_context_manager_reentrance(self):
+        prev_stream = torch.accelerator.current_stream()
+        s0 = torch.Stream()
+        with s0, s0:
+            self.assertEqual(torch.accelerator.current_stream(), s0)
+        self.assertEqual(torch.accelerator.current_stream(), prev_stream)
+        s1 = torch.Stream()
+        with s0:
+            self.assertEqual(torch.accelerator.current_stream(), s0)
+            with s1:
+                self.assertEqual(torch.accelerator.current_stream(), s1)
+                with s0:
+                    self.assertEqual(torch.accelerator.current_stream(), s0)
+        self.assertEqual(torch.accelerator.current_stream(), prev_stream)
+
+    def test_generic_event_behavior(self):
+        event1 = torch.Event(enable_timing=False)
+        event2 = torch.Event(enable_timing=False)
+        with self.assertRaisesRegex(
+            ValueError,
+            "Both events must be created with argument 'enable_timing=True'",
+        ):
+            event1.elapsed_time(event2)
+
+        event1 = torch.Event(enable_timing=True)
+        event2 = torch.Event(enable_timing=True)
+        with self.assertRaisesRegex(
+            ValueError,
+            "Both events must be recorded before calculating elapsed time",
+        ):
+            event1.elapsed_time(event2)
+
+        # check default value of enable_timing: False
+        event1 = torch.Event()
+        event2 = torch.Event()
+        with self.assertRaisesRegex(
+            ValueError,
+            "Both events must be created with argument 'enable_timing=True'",
+        ):
+            event1.elapsed_time(event2)
+
+    @pytest.mark.skipif(not TEST_MULTIACCELERATOR, reason="only one accelerator detected")
+    def test_generic_multi_device_behavior(self):
+        orig_device = torch.accelerator.current_device_index()
+        target_device = (orig_device + 1) % torch.accelerator.device_count()
+
+        torch.accelerator.set_device_index(target_device)
+        self.assertEqual(target_device, torch.accelerator.current_device_index())
+        torch.accelerator.set_device_index(orig_device)
+        self.assertEqual(orig_device, torch.accelerator.current_device_index())
+
+        s1 = torch.Stream(target_device)
+        torch.accelerator.set_stream(s1)
+        self.assertEqual(target_device, torch.accelerator.current_device_index())
+        torch.accelerator.synchronize(orig_device)
+        self.assertEqual(target_device, torch.accelerator.current_device_index())
+
+    @pytest.mark.skipif(not TEST_MULTIACCELERATOR, reason="only one accelerator detected")
+    def test_multi_device_stream_context_manager(self):
+        src_device = 0
+        dst_device = 1
+        torch.accelerator.set_device_index(src_device)
+        src_prev_stream = torch.accelerator.current_stream()
+        dst_prev_stream = torch.accelerator.current_stream(dst_device)
+        with torch.Stream(dst_device) as dst_stream:
+            self.assertEqual(torch.accelerator.current_device_index(), dst_device)
+            self.assertEqual(torch.accelerator.current_stream(), dst_stream)
+            self.assertEqual(torch.accelerator.current_stream(src_device), src_prev_stream)
+        self.assertEqual(torch.accelerator.current_device_index(), src_device)
+        self.assertEqual(torch.accelerator.current_stream(), src_prev_stream)
+        self.assertEqual(torch.accelerator.current_stream(dst_device), dst_prev_stream)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/rbln/test_event.py
+++ b/test/rbln/test_event.py
@@ -1,13 +1,13 @@
 # Owner(s): ["module: PrivateUse1"]
 
-"""
-Test suite for torch.Event with the RBLN backend.
+"""Test suite for torch.Event with the RBLN backend.
 
-RBLN has a single in-order copy queue per device, so an event records the
-device it was captured on and every wait drains that device's queue. This
-gives `torch.Event` the CUDA usage pattern (record after a `non_blocking`
-copy, synchronize before reading the host buffer) without per-event fences.
+Covers the torch.Event usage pattern (record after a non_blocking copy, synchronize
+before reading the host buffer), reuse, cross-stream and cross-device waits, and the
+unsupported elapsed_time path.
 """
+
+import unittest
 
 import pytest
 import torch
@@ -64,6 +64,51 @@ class TestEvent(TestCase):
         end.record()
         with self.assertRaisesRegex(RuntimeError, "elapsedTime"):
             start.elapsed_time(end)
+
+    def test_rbln_event_namespace(self):
+        # torch.rbln.Event mirrors torch.cuda.Event and binds to the rbln device.
+        event = torch.rbln.Event()
+        self.assertEqual(event.device.type, "rbln")
+        self.assertTrue(event.query())  # never recorded -> complete
+
+    def test_rbln_event_elapsed_time_unsupported(self):
+        start, end = torch.rbln.Event(enable_timing=True), torch.rbln.Event(enable_timing=True)
+        start.record()
+        end.record()
+        with self.assertRaisesRegex(RuntimeError, "elapsed_time"):
+            start.elapsed_time(end)
+
+    def test_wait_event_across_streams(self):
+        # A consumer stream waits on an event recorded on a producer stream (a real
+        # device-side fence), then a host sync makes the pinned D2H visible.
+        src = torch.arange(512, dtype=torch.int32).reshape(-1, 1)
+        dev = src.to("rbln")
+        pinned = torch.empty_like(src, pin_memory=True)
+        producer, consumer = torch.rbln.Stream(), torch.rbln.Stream()
+        done = torch.rbln.Event()
+        with torch.rbln.stream(producer):
+            pinned.copy_(dev, non_blocking=True)
+            done.record()
+        consumer.wait_event(done)
+        consumer.synchronize()
+        self.assertEqual(pinned.flatten().tolist(), list(range(512)))
+
+    @unittest.skipIf(torch.rbln.device_count() < 2, "needs >= 2 RBLN devices")
+    def test_cross_device_event_wait_degrades_to_host_sync(self):
+        # Cross-device waits are not supported and must degrade to a host-side
+        # synchronize (correct, serializing) rather than erroring.
+        src = torch.randn(128, 128)
+        dev0 = src.to("rbln:0")
+        pinned = torch.empty_like(src, pin_memory=True)
+        _warm = torch.zeros(1, device="rbln:1")  # materialize device 1's context  # noqa: F841
+        event = torch.rbln.Event()
+        with torch.rbln.stream(torch.rbln.Stream(device=0)):
+            pinned.copy_(dev0, non_blocking=True)
+            event.record()
+        stream1 = torch.rbln.Stream(device=1)
+        stream1.wait_event(event)  # device 1 waits on device 0's event
+        stream1.synchronize()
+        self.assertEqual(pinned, src)
 
 
 if __name__ == "__main__":

--- a/test/rbln/test_event.py
+++ b/test/rbln/test_event.py
@@ -13,12 +13,18 @@ import pytest
 import torch
 from torch.testing._internal.common_utils import run_tests, TestCase
 
+from test.utils import assert_device_resident_dtype
+
 
 @pytest.mark.test_set_ci
 class TestEvent(TestCase):
     def test_event_default_device_is_rbln(self):
         event = torch.Event()
         self.assertEqual(event.device.type, "rbln")
+
+    def test_ordering_tests_use_a_device_resident_dtype(self):
+        # The fences below only mean something if the data lives on the device.
+        assert_device_resident_dtype(torch.float16)
 
     def test_query_before_record_is_true(self):
         self.assertTrue(torch.Event().query())
@@ -29,7 +35,7 @@ class TestEvent(TestCase):
     def test_record_synchronize_d2h_pinned(self):
         # The vllm-rbln transfer_event pattern: non_blocking D2H into a pinned
         # buffer, record, synchronize, then read on the host.
-        src = torch.randn(256, 256)
+        src = torch.randn(256, 256, dtype=torch.float16)
         dev = src.to("rbln")
         pinned = torch.empty_like(src, pin_memory=True)
         event = torch.Event()
@@ -40,7 +46,7 @@ class TestEvent(TestCase):
         self.assertTrue(event.query())
 
     def test_record_synchronize_h2d_pinned(self):
-        src = torch.randn(128, 128).pin_memory()
+        src = torch.randn(128, 128, dtype=torch.float16).pin_memory()
         dev = src.to("rbln", non_blocking=True)
         event = torch.Event()
         event.record()
@@ -48,7 +54,7 @@ class TestEvent(TestCase):
         self.assertEqual(dev.cpu(), src)
 
     def test_event_is_reusable(self):
-        src = torch.arange(1024, dtype=torch.int64).reshape(-1, 1)
+        src = torch.arange(1024, dtype=torch.float16).reshape(-1, 1)
         dev = src.to("rbln")
         pinned = torch.empty_like(src, pin_memory=True)
         event = torch.Event()
@@ -81,7 +87,7 @@ class TestEvent(TestCase):
     def test_wait_event_across_streams(self):
         # A consumer stream waits on an event recorded on a producer stream (a real
         # device-side fence), then a host sync makes the pinned D2H visible.
-        src = torch.arange(512, dtype=torch.int32).reshape(-1, 1)
+        src = torch.arange(512, dtype=torch.float16).reshape(-1, 1)
         dev = src.to("rbln")
         pinned = torch.empty_like(src, pin_memory=True)
         producer, consumer = torch.rbln.Stream(), torch.rbln.Stream()
@@ -97,10 +103,10 @@ class TestEvent(TestCase):
     def test_cross_device_event_wait_degrades_to_host_sync(self):
         # Cross-device waits are not supported and must degrade to a host-side
         # synchronize (correct, serializing) rather than erroring.
-        src = torch.randn(128, 128)
+        src = torch.randn(128, 128, dtype=torch.float16)
         dev0 = src.to("rbln:0")
         pinned = torch.empty_like(src, pin_memory=True)
-        _warm = torch.zeros(1, device="rbln:1")  # materialize device 1's context  # noqa: F841
+        _warm = torch.zeros(1, dtype=torch.float16, device="rbln:1")  # device 1's context  # noqa: F841
         event = torch.rbln.Event()
         with torch.rbln.stream(torch.rbln.Stream(device=0)):
             pinned.copy_(dev0, non_blocking=True)

--- a/test/rbln/test_stream.py
+++ b/test/rbln/test_stream.py
@@ -39,8 +39,7 @@ class TestStream(TestCase):
         self.assertNotEqual(s1, s2)
 
     def test_stream_creation_is_bounded_by_the_pool(self):
-        # Streams come from a fixed per-device pool (torch never destroys one, so an
-        # unbounded create would leak). Past the pool size, instances reuse streams.
+        # Streams come from a fixed per-device pool; past its size, instances reuse one.
         ids = {torch.rbln.Stream().stream_id for _ in range(96)}
         self.assertLessEqual(len(ids), 32)
         self.assertNotIn(0, ids)
@@ -110,8 +109,7 @@ class TestStream(TestCase):
         self.assertEqual(pinned.flatten().tolist(), list(range(1024)))
 
     def test_matmul_on_non_default_stream(self):
-        # A real compute op (not just a copy) runs on a non-default stream and is
-        # correct. Confirms the current stream is honored across the dispatch path.
+        # A compute op, not just a copy, honors the current stream through dispatch.
         a = torch.randn(64, 64).to("rbln")
         b = torch.randn(64, 64).to("rbln")
         s = torch.rbln.Stream()
@@ -123,9 +121,8 @@ class TestStream(TestCase):
         self.assertTrue(torch.allclose(c.cpu(), expected, atol=1e-2, rtol=1e-2))
 
     def test_compute_gated_by_async_copy_event(self):
-        # Copy<->compute ordering across streams: a producer stream async-copies a
-        # weight matrix; a consumer stream waits on the event, then matmuls with it.
-        # The event fence is what makes the (still in-flight) copy safe to consume.
+        # Copy<->compute ordering across streams: the event fence is what makes the
+        # producer's still-in-flight copy safe for the consumer to matmul with.
         w_cpu = torch.randn(64, 64).pin_memory()
         x = torch.randn(8, 64).to("rbln")
         producer, consumer = torch.rbln.Stream(), torch.rbln.Stream()
@@ -140,8 +137,7 @@ class TestStream(TestCase):
         self.assertTrue(torch.allclose(y.cpu(), x.cpu() @ w_cpu, atol=1e-2, rtol=1e-2))
 
     def test_stream_context_selects_the_stream_device(self):
-        # torch.cuda.set_stream also moves the current device, so allocations inside
-        # the context land on the stream's device. Same contract here.
+        # Selecting a stream selects its device, so allocations land there.
         if torch.rbln.device_count() < 2:
             self.skipTest("needs >= 2 RBLN devices")
         torch.rbln.set_device(0)

--- a/test/rbln/test_stream.py
+++ b/test/rbln/test_stream.py
@@ -38,6 +38,13 @@ class TestStream(TestCase):
         self.assertNotEqual(s1.stream_id, 0)
         self.assertNotEqual(s1, s2)
 
+    def test_stream_creation_is_bounded_by_the_pool(self):
+        # Streams come from a fixed per-device pool (torch never destroys one, so an
+        # unbounded create would leak). Past the pool size, instances reuse streams.
+        ids = {torch.rbln.Stream().stream_id for _ in range(96)}
+        self.assertLessEqual(len(ids), 32)
+        self.assertNotIn(0, ids)
+
     def test_generic_torch_stream_on_rbln(self):
         # torch.Stream must work with no torch.rbln pybind — purely via the guard impl.
         s = torch.Stream(device="rbln")

--- a/test/rbln/test_stream.py
+++ b/test/rbln/test_stream.py
@@ -17,9 +17,13 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 from test.utils import assert_device_resident_dtype
 
 
-# fp16 matmul accumulates, so the device result is compared loosely.
-ATOL = 0.05
-RTOL = 0.05
+# The device computes fp16 matmuls in a narrower dlfloat, so results are compared on
+# relative error: it is scale-free, where an absolute bound needs retuning per shape.
+REL_TOL = 0.01
+
+
+def rel_err(got: torch.Tensor, ref: torch.Tensor) -> float:
+    return ((got.float() - ref.float()).norm() / ref.float().norm()).item()
 
 
 @pytest.mark.test_set_ci
@@ -139,7 +143,7 @@ class TestStream(TestCase):
             c = (a @ b).relu()
         torch.rbln.synchronize()
         expected = (a_cpu @ b_cpu).relu()
-        self.assertTrue(torch.allclose(c.cpu(), expected, atol=ATOL, rtol=RTOL))
+        self.assertLess(rel_err(c.cpu(), expected), REL_TOL)
 
     def test_compute_gated_by_async_copy_event(self):
         # Copy<->compute ordering across streams: the event fence is what makes the
@@ -156,7 +160,7 @@ class TestStream(TestCase):
             consumer.wait_event(ready)  # fence: w must be fully copied before use
             y = x @ w
         torch.rbln.synchronize()
-        self.assertTrue(torch.allclose(y.cpu(), x_cpu @ w_cpu, atol=ATOL, rtol=RTOL))
+        self.assertLess(rel_err(y.cpu(), x_cpu @ w_cpu), REL_TOL)
 
     def test_stream_context_selects_the_stream_device(self):
         # Selecting a stream selects its device, so allocations land there.
@@ -183,8 +187,8 @@ class TestStream(TestCase):
             c1 = a1 @ b1
         torch.rbln.synchronize(0)
         torch.rbln.synchronize(1)
-        self.assertTrue(torch.allclose(c0.cpu(), a0_cpu @ b0_cpu, atol=ATOL, rtol=RTOL))
-        self.assertTrue(torch.allclose(c1.cpu(), a1_cpu @ b1_cpu, atol=ATOL, rtol=RTOL))
+        self.assertLess(rel_err(c0.cpu(), a0_cpu @ b0_cpu), REL_TOL)
+        self.assertLess(rel_err(c1.cpu(), a1_cpu @ b1_cpu), REL_TOL)
 
 
 if __name__ == "__main__":

--- a/test/rbln/test_stream.py
+++ b/test/rbln/test_stream.py
@@ -132,6 +132,17 @@ class TestStream(TestCase):
         torch.rbln.synchronize()
         self.assertTrue(torch.allclose(y.cpu(), x.cpu() @ w_cpu, atol=1e-2, rtol=1e-2))
 
+    def test_stream_context_selects_the_stream_device(self):
+        # torch.cuda.set_stream also moves the current device, so allocations inside
+        # the context land on the stream's device. Same contract here.
+        if torch.rbln.device_count() < 2:
+            self.skipTest("needs >= 2 RBLN devices")
+        torch.rbln.set_device(0)
+        with torch.rbln.stream(torch.rbln.Stream(device=1)):
+            self.assertEqual(torch.rbln.current_device(), 1)
+            self.assertEqual(torch.zeros(4, device="rbln").device.index, 1)
+        self.assertEqual(torch.rbln.current_device(), 0)
+
     def test_multi_device_independent_streams(self):
         # Independent work on per-device streams is correct and isolated.
         if torch.rbln.device_count() < 2:

--- a/test/rbln/test_stream.py
+++ b/test/rbln/test_stream.py
@@ -1,0 +1,153 @@
+# Owner(s): ["module: PrivateUse1"]
+
+"""Test suite for torch.rbln streams (and the generic torch.Stream) on RBLN.
+
+A stream is an ordered sequence of device work: work on the same stream runs in
+order, work on different streams may run concurrently. These tests cover the
+torch.cuda-parity surface —
+Stream / current_stream / default_stream / set_stream / stream context manager /
+query / synchronize / wait_event / wait_stream — plus the intentionally
+unsupported bits (stream priorities are accepted but ignored).
+"""
+
+import pytest
+import torch
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+@pytest.mark.test_set_ci
+class TestStream(TestCase):
+    def tearDown(self):
+        # Streams are thread-local process state; leave the default selected so tests
+        # do not leak the current stream into one another.
+        torch.rbln.set_stream(torch.rbln.default_stream())
+        super().tearDown()
+
+    def test_default_stream_id_is_zero(self):
+        default = torch.rbln.default_stream()
+        self.assertEqual(default.stream_id, 0)
+        self.assertEqual(default.device.type, "rbln")
+
+    def test_current_defaults_to_default(self):
+        self.assertEqual(torch.rbln.current_stream(), torch.rbln.default_stream())
+
+    def test_new_stream_is_nonzero_and_distinct(self):
+        s1 = torch.rbln.Stream()
+        s2 = torch.rbln.Stream()
+        self.assertEqual(s1.device.type, "rbln")
+        self.assertNotEqual(s1.stream_id, 0)
+        self.assertNotEqual(s1, s2)
+
+    def test_generic_torch_stream_on_rbln(self):
+        # torch.Stream must work with no torch.rbln pybind — purely via the guard impl.
+        s = torch.Stream(device="rbln")
+        self.assertEqual(s.device.type, "rbln")
+        self.assertTrue(s.query())
+
+    def test_set_stream_and_current(self):
+        s = torch.rbln.Stream()
+        prev = torch.rbln.current_stream()
+        try:
+            torch.rbln.set_stream(s)
+            self.assertEqual(torch.rbln.current_stream(), s)
+        finally:
+            torch.rbln.set_stream(prev)
+        self.assertEqual(torch.rbln.current_stream(), prev)
+
+    def test_stream_context_manager(self):
+        s = torch.rbln.Stream()
+        default = torch.rbln.current_stream()
+        with torch.rbln.stream(s):
+            self.assertEqual(torch.rbln.current_stream(), s)
+        self.assertEqual(torch.rbln.current_stream(), default)
+
+    def test_stream_context_none_is_noop(self):
+        default = torch.rbln.current_stream()
+        with torch.rbln.stream(None):
+            self.assertEqual(torch.rbln.current_stream(), default)
+
+    def test_query_and_synchronize_idle(self):
+        s = torch.rbln.Stream()
+        self.assertTrue(s.query())
+        s.synchronize()  # idle -> no crash
+        self.assertTrue(s.query())
+
+    def test_priority_accepted_but_ignored(self):
+        s = torch.rbln.Stream(priority=-1)  # accepted; RBLN has no priorities
+        self.assertEqual(s.device.type, "rbln")
+        self.assertEqual(s.priority, 0)
+        self.assertEqual(torch.rbln.Stream.priority_range(), (0, 0))
+
+    def test_wait_stream_and_wait_event_do_not_error(self):
+        s1, s2 = torch.rbln.Stream(), torch.rbln.Stream()
+        s1.wait_stream(s2)  # record an event on s2, make s1 wait it
+        e = torch.rbln.Event()
+        e.record(s2)
+        s1.wait_event(e)  # device-side fence
+        s1.synchronize()
+        s2.synchronize()
+
+    def test_copy_on_stream_gated_by_event(self):
+        # Non-blocking D2H on a non-default stream, gated by an event recorded on it.
+        # Pinned host memory, so the event's seq wait makes the copy host-visible.
+        src = torch.arange(1024, dtype=torch.int32).reshape(-1, 1)
+        dev = src.to("rbln")
+        pinned = torch.empty_like(src, pin_memory=True)
+        s = torch.rbln.Stream()
+        e = torch.rbln.Event()
+        with torch.rbln.stream(s):
+            self.assertEqual(torch.rbln.current_stream(), s)
+            pinned.copy_(dev, non_blocking=True)
+            e.record()
+        e.synchronize()
+        self.assertEqual(pinned.flatten().tolist(), list(range(1024)))
+
+    def test_matmul_on_non_default_stream(self):
+        # A real compute op (not just a copy) runs on a non-default stream and is
+        # correct. Confirms the current stream is honored across the dispatch path.
+        a = torch.randn(64, 64).to("rbln")
+        b = torch.randn(64, 64).to("rbln")
+        s = torch.rbln.Stream()
+        with torch.rbln.stream(s):
+            self.assertEqual(torch.rbln.current_stream(), s)
+            c = (a @ b).relu()
+        torch.rbln.synchronize()
+        expected = (a.cpu() @ b.cpu()).relu()
+        self.assertTrue(torch.allclose(c.cpu(), expected, atol=1e-2, rtol=1e-2))
+
+    def test_compute_gated_by_async_copy_event(self):
+        # Copy<->compute ordering across streams: a producer stream async-copies a
+        # weight matrix; a consumer stream waits on the event, then matmuls with it.
+        # The event fence is what makes the (still in-flight) copy safe to consume.
+        w_cpu = torch.randn(64, 64).pin_memory()
+        x = torch.randn(8, 64).to("rbln")
+        producer, consumer = torch.rbln.Stream(), torch.rbln.Stream()
+        ready = torch.rbln.Event()
+        with torch.rbln.stream(producer):
+            w = w_cpu.to("rbln", non_blocking=True)
+            ready.record()
+        with torch.rbln.stream(consumer):
+            consumer.wait_event(ready)  # fence: w must be fully copied before use
+            y = x @ w
+        torch.rbln.synchronize()
+        self.assertTrue(torch.allclose(y.cpu(), x.cpu() @ w_cpu, atol=1e-2, rtol=1e-2))
+
+    def test_multi_device_independent_streams(self):
+        # Independent work on per-device streams is correct and isolated.
+        if torch.rbln.device_count() < 2:
+            self.skipTest("needs >= 2 RBLN devices")
+        a0, b0 = torch.randn(32, 32).to("rbln:0"), torch.randn(32, 32).to("rbln:0")
+        a1, b1 = torch.randn(32, 32).to("rbln:1"), torch.randn(32, 32).to("rbln:1")
+        s0, s1 = torch.rbln.Stream(device=0), torch.rbln.Stream(device=1)
+        with torch.rbln.stream(s0):
+            c0 = a0 @ b0
+        with torch.rbln.stream(s1):
+            c1 = a1 @ b1
+        torch.rbln.synchronize(0)
+        torch.rbln.synchronize(1)
+        self.assertTrue(torch.allclose(c0.cpu(), a0.cpu() @ b0.cpu(), atol=1e-2, rtol=1e-2))
+        self.assertTrue(torch.allclose(c1.cpu(), a1.cpu() @ b1.cpu(), atol=1e-2, rtol=1e-2))
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/rbln/test_stream.py
+++ b/test/rbln/test_stream.py
@@ -72,6 +72,11 @@ class TestStream(TestCase):
         with torch.rbln.stream(None):
             self.assertEqual(torch.rbln.current_stream(), default)
 
+    def test_set_stream_rejects_a_foreign_stream(self):
+        # A foreign stream id would otherwise be read as an RBLN local stream id.
+        with self.assertRaisesRegex(RuntimeError, "expect device type"):
+            torch.rbln.set_stream(torch.Stream(device="cpu"))
+
     def test_query_and_synchronize_idle(self):
         s = torch.rbln.Stream()
         self.assertTrue(s.query())

--- a/test/rbln/test_stream.py
+++ b/test/rbln/test_stream.py
@@ -14,6 +14,13 @@ import pytest
 import torch
 from torch.testing._internal.common_utils import run_tests, TestCase
 
+from test.utils import assert_device_resident_dtype
+
+
+# fp16 matmul accumulates, so the device result is compared loosely.
+ATOL = 0.05
+RTOL = 0.05
+
 
 @pytest.mark.test_set_ci
 class TestStream(TestCase):
@@ -22,6 +29,10 @@ class TestStream(TestCase):
         # do not leak the current stream into one another.
         torch.rbln.set_stream(torch.rbln.default_stream())
         super().tearDown()
+
+    def test_ordering_tests_use_a_device_resident_dtype(self):
+        # The fences below only mean something if the data lives on the device.
+        assert_device_resident_dtype(torch.float16)
 
     def test_default_stream_id_is_zero(self):
         default = torch.rbln.default_stream()
@@ -77,6 +88,11 @@ class TestStream(TestCase):
         with self.assertRaisesRegex(RuntimeError, "expect device type"):
             torch.rbln.set_stream(torch.Stream(device="cpu"))
 
+    def test_record_event_returns_an_rbln_event(self):
+        s = torch.rbln.Stream()
+        self.assertIsInstance(s.record_event(), torch.rbln.Event)
+        self.assertIsInstance(s.record_event(torch.rbln.Event()), torch.rbln.Event)
+
     def test_query_and_synchronize_idle(self):
         s = torch.rbln.Stream()
         self.assertTrue(s.query())
@@ -101,7 +117,7 @@ class TestStream(TestCase):
     def test_copy_on_stream_gated_by_event(self):
         # Non-blocking D2H on a non-default stream, gated by an event recorded on it.
         # Pinned host memory, so the event's seq wait makes the copy host-visible.
-        src = torch.arange(1024, dtype=torch.int32).reshape(-1, 1)
+        src = torch.arange(1024, dtype=torch.float16).reshape(-1, 1)
         dev = src.to("rbln")
         pinned = torch.empty_like(src, pin_memory=True)
         s = torch.rbln.Stream()
@@ -115,21 +131,22 @@ class TestStream(TestCase):
 
     def test_matmul_on_non_default_stream(self):
         # A compute op, not just a copy, honors the current stream through dispatch.
-        a = torch.randn(64, 64).to("rbln")
-        b = torch.randn(64, 64).to("rbln")
+        a_cpu, b_cpu = torch.randn(64, 64, dtype=torch.float16), torch.randn(64, 64, dtype=torch.float16)
+        a, b = a_cpu.to("rbln"), b_cpu.to("rbln")
         s = torch.rbln.Stream()
         with torch.rbln.stream(s):
             self.assertEqual(torch.rbln.current_stream(), s)
             c = (a @ b).relu()
         torch.rbln.synchronize()
-        expected = (a.cpu() @ b.cpu()).relu()
-        self.assertTrue(torch.allclose(c.cpu(), expected, atol=1e-2, rtol=1e-2))
+        expected = (a_cpu @ b_cpu).relu()
+        self.assertTrue(torch.allclose(c.cpu(), expected, atol=ATOL, rtol=RTOL))
 
     def test_compute_gated_by_async_copy_event(self):
         # Copy<->compute ordering across streams: the event fence is what makes the
         # producer's still-in-flight copy safe for the consumer to matmul with.
-        w_cpu = torch.randn(64, 64).pin_memory()
-        x = torch.randn(8, 64).to("rbln")
+        w_cpu = torch.randn(64, 64, dtype=torch.float16).pin_memory()
+        x_cpu = torch.randn(8, 64, dtype=torch.float16)
+        x = x_cpu.to("rbln")
         producer, consumer = torch.rbln.Stream(), torch.rbln.Stream()
         ready = torch.rbln.Event()
         with torch.rbln.stream(producer):
@@ -139,7 +156,7 @@ class TestStream(TestCase):
             consumer.wait_event(ready)  # fence: w must be fully copied before use
             y = x @ w
         torch.rbln.synchronize()
-        self.assertTrue(torch.allclose(y.cpu(), x.cpu() @ w_cpu, atol=1e-2, rtol=1e-2))
+        self.assertTrue(torch.allclose(y.cpu(), x_cpu @ w_cpu, atol=ATOL, rtol=RTOL))
 
     def test_stream_context_selects_the_stream_device(self):
         # Selecting a stream selects its device, so allocations land there.
@@ -155,8 +172,10 @@ class TestStream(TestCase):
         # Independent work on per-device streams is correct and isolated.
         if torch.rbln.device_count() < 2:
             self.skipTest("needs >= 2 RBLN devices")
-        a0, b0 = torch.randn(32, 32).to("rbln:0"), torch.randn(32, 32).to("rbln:0")
-        a1, b1 = torch.randn(32, 32).to("rbln:1"), torch.randn(32, 32).to("rbln:1")
+        a0_cpu, b0_cpu = torch.randn(32, 32, dtype=torch.float16), torch.randn(32, 32, dtype=torch.float16)
+        a1_cpu, b1_cpu = torch.randn(32, 32, dtype=torch.float16), torch.randn(32, 32, dtype=torch.float16)
+        a0, b0 = a0_cpu.to("rbln:0"), b0_cpu.to("rbln:0")
+        a1, b1 = a1_cpu.to("rbln:1"), b1_cpu.to("rbln:1")
         s0, s1 = torch.rbln.Stream(device=0), torch.rbln.Stream(device=1)
         with torch.rbln.stream(s0):
             c0 = a0 @ b0
@@ -164,8 +183,8 @@ class TestStream(TestCase):
             c1 = a1 @ b1
         torch.rbln.synchronize(0)
         torch.rbln.synchronize(1)
-        self.assertTrue(torch.allclose(c0.cpu(), a0.cpu() @ b0.cpu(), atol=1e-2, rtol=1e-2))
-        self.assertTrue(torch.allclose(c1.cpu(), a1.cpu() @ b1.cpu(), atol=1e-2, rtol=1e-2))
+        self.assertTrue(torch.allclose(c0.cpu(), a0_cpu @ b0_cpu, atol=ATOL, rtol=RTOL))
+        self.assertTrue(torch.allclose(c1.cpu(), a1_cpu @ b1_cpu, atol=ATOL, rtol=RTOL))
 
 
 if __name__ == "__main__":

--- a/test/utils.py
+++ b/test/utils.py
@@ -50,6 +50,18 @@ def configure_master_port_for_rccl_tests(default_port: str = _DEFAULT_DISTRIBUTE
     os.environ.setdefault("MASTER_PORT", default_port)
 
 
+def assert_device_resident_dtype(dtype: torch.dtype) -> None:
+    """Fail unless the device advertises `dtype` as device-resident.
+
+    Only fp16/bf16 are (`kCapabilityDtypes`); another dtype accepts ``device="rbln"``
+    but stays host-backed, so an ordering test written on it would run entirely on the
+    host and pass with a broken fence. Per-tensor byte counting cannot stand in for
+    this: allocation is lazy and small elementwise ops take CPU fast paths.
+    """
+    advertised = torch.accelerator.get_device_capability()["supported_dtypes"]
+    assert dtype in advertised, f"{dtype} is not device-resident; advertised: {advertised}"
+
+
 def set_deterministic_seeds(seed: int):
     """Set deterministic seeds for reproducibility.
 

--- a/torch_rbln/csrc/rbln/Module.cpp
+++ b/torch_rbln/csrc/rbln/Module.cpp
@@ -148,7 +148,14 @@ void register_stream_api(py::module_& module) {
       [pack](int64_t stream_id, c10::DeviceIndex device_index, int32_t device_type) {
         const auto stream = c10::Stream::unpack3(
             static_cast<c10::StreamId>(stream_id), device_index, static_cast<c10::DeviceType>(device_type));
-        return pack(VirtualGuardImpl(c10::kPrivateUse1).exchangeStream(stream));
+        const auto guard = VirtualGuardImpl(c10::kPrivateUse1);
+        // Selecting a stream also selects its device, as torch.cuda's setStream and
+        // torch.accelerator.set_stream both do -- otherwise a stream on another device
+        // would leave allocations going to the old one.
+        if (guard.getDevice().index() != stream.device_index()) {
+          guard.setDevice(stream.device());
+        }
+        return pack(guard.exchangeStream(stream));
       },
       "Internal: set current rbln stream; returns the previous as (stream_id, device_index, device_type)");
 }

--- a/torch_rbln/csrc/rbln/Module.cpp
+++ b/torch_rbln/csrc/rbln/Module.cpp
@@ -143,6 +143,14 @@ void register_stream_api(py::module_& module) {
   module.def(
       "_exchange_stream",
       [pack](int64_t stream_id, c10::DeviceIndex device_index, int32_t device_type) {
+        // c10::Stream::unpack3 accepts any valid device type, so a foreign stream id
+        // would otherwise be read as an RBLN local stream id.
+        TORCH_CHECK(
+            static_cast<c10::DeviceType>(device_type) == c10::kPrivateUse1,
+            "torch.rbln streams expect device type ",
+            c10::DeviceTypeName(c10::kPrivateUse1),
+            ", got ",
+            c10::DeviceTypeName(static_cast<c10::DeviceType>(device_type)));
         const auto stream = c10::Stream::unpack3(
             static_cast<c10::StreamId>(stream_id), device_index, static_cast<c10::DeviceType>(device_type));
         const auto guard = VirtualGuardImpl(c10::kPrivateUse1);

--- a/torch_rbln/csrc/rbln/Module.cpp
+++ b/torch_rbln/csrc/rbln/Module.cpp
@@ -2,6 +2,7 @@
 #include <ATen/native/rbln/RBLNCPUFastPaths.h>
 #include <ATen/native/rbln/RBLNCopy.h>
 #include <ATen/native/rbln/RBLNTensorUtils.h>
+#include <c10/core/impl/VirtualGuardImpl.h>
 #include <c10/rbln/DeviceMappingManager.h>
 #include <c10/rbln/RBLNFallbackConfig.h>
 #include <c10/rbln/RBLNFunctions.h>
@@ -108,6 +109,48 @@ void register_public_device_api(py::module_& module) {
       "_get_device_topology",
       []() -> c10::rbln::DeviceTopology { return c10::rbln::DeviceMappingManager::getInstance().getDeviceTopology(); },
       "Get the complete device topology.");
+}
+
+/**
+ * @brief Register the low-level stream primitives backing torch.rbln streams.
+ *
+ * These mirror torch.cuda's _cuda_getCurrentStream / _cuda_setStream: they exchange
+ * (stream_id, device_index, device_type) tuples with Python, which wraps them in
+ * torch.Stream. The work is delegated to the registered PrivateUse1 guard impl via
+ * VirtualGuardImpl, so this stays a thin, backend-agnostic bridge. torch.Stream /
+ * torch.Event themselves need no binding (they route through the guard impl); these
+ * exist only for the torch.cuda-style torch.rbln.{current_stream,set_stream,...} API.
+ *
+ * @param module The Python module to register the functions with
+ */
+void register_stream_api(py::module_& module) {
+  using c10::impl::VirtualGuardImpl;
+  auto pack = [](const c10::Stream& stream) {
+    return std::make_tuple(
+        static_cast<int64_t>(stream.id()),
+        static_cast<int64_t>(stream.device_index()),
+        static_cast<int64_t>(stream.device_type()));
+  };
+  module.def(
+      "_get_current_stream",
+      [pack](c10::DeviceIndex device_index) {
+        return pack(VirtualGuardImpl(c10::kPrivateUse1).getStream(c10::Device(c10::kPrivateUse1, device_index)));
+      },
+      "Internal: current rbln stream as (stream_id, device_index, device_type)");
+  module.def(
+      "_get_default_stream",
+      [pack](c10::DeviceIndex device_index) {
+        return pack(VirtualGuardImpl(c10::kPrivateUse1).getDefaultStream(c10::Device(c10::kPrivateUse1, device_index)));
+      },
+      "Internal: default rbln stream as (stream_id, device_index, device_type)");
+  module.def(
+      "_exchange_stream",
+      [pack](int64_t stream_id, c10::DeviceIndex device_index, int32_t device_type) {
+        const auto stream = c10::Stream::unpack3(
+            static_cast<c10::StreamId>(stream_id), device_index, static_cast<c10::DeviceType>(device_type));
+        return pack(VirtualGuardImpl(c10::kPrivateUse1).exchangeStream(stream));
+      },
+      "Internal: set current rbln stream; returns the previous as (stream_id, device_index, device_type)");
 }
 
 // set_device_layout_like operates on a whole tensor allocation, so a view
@@ -567,6 +610,7 @@ extern "C" PyObject* initModule() {
 
   // Step 4: Register all RBLN components
   register_public_device_api(python_module);
+  register_stream_api(python_module);
   register_internal_api(python_module);
   register_supported_dtypes_api(python_module);
 

--- a/torch_rbln/csrc/rbln/Module.cpp
+++ b/torch_rbln/csrc/rbln/Module.cpp
@@ -115,11 +115,8 @@ void register_public_device_api(py::module_& module) {
  * @brief Register the low-level stream primitives backing torch.rbln streams.
  *
  * These mirror torch.cuda's _cuda_getCurrentStream / _cuda_setStream: they exchange
- * (stream_id, device_index, device_type) tuples with Python, which wraps them in
- * torch.Stream. The work is delegated to the registered PrivateUse1 guard impl via
- * VirtualGuardImpl, so this stays a thin, backend-agnostic bridge. torch.Stream /
- * torch.Event themselves need no binding (they route through the guard impl); these
- * exist only for the torch.cuda-style torch.rbln.{current_stream,set_stream,...} API.
+ * (stream_id, device_index, device_type) tuples with Python and delegate to the
+ * PrivateUse1 guard impl. torch.Stream / torch.Event need no binding of their own.
  *
  * @param module The Python module to register the functions with
  */
@@ -149,9 +146,8 @@ void register_stream_api(py::module_& module) {
         const auto stream = c10::Stream::unpack3(
             static_cast<c10::StreamId>(stream_id), device_index, static_cast<c10::DeviceType>(device_type));
         const auto guard = VirtualGuardImpl(c10::kPrivateUse1);
-        // Selecting a stream also selects its device, as torch.cuda's setStream and
-        // torch.accelerator.set_stream both do -- otherwise a stream on another device
-        // would leave allocations going to the old one.
+        // Selecting a stream also selects its device, as torch.cuda and
+        // torch.accelerator both do.
         if (guard.getDevice().index() != stream.device_index()) {
           guard.setDevice(stream.device());
         }

--- a/torch_rbln/device/__init__.py
+++ b/torch_rbln/device/__init__.py
@@ -1,4 +1,5 @@
-from torch_rbln.device.device import *  # noqa: F403`
-from torch_rbln.device.device_tensor_utils import *  # noqa: F403`
-from torch_rbln.memory import *  # noqa: F403`
-from torch_rbln.profiler import *  # noqa: F403`
+from torch_rbln.device.device import *  # noqa: F403
+from torch_rbln.device.device_tensor_utils import *  # noqa: F403
+from torch_rbln.device.streams import *  # noqa: F403
+from torch_rbln.memory import *  # noqa: F403
+from torch_rbln.profiler import *  # noqa: F403

--- a/torch_rbln/device/streams.py
+++ b/torch_rbln/device/streams.py
@@ -1,15 +1,12 @@
 """``torch.rbln`` stream & event API (``torch.cuda`` parity).
 
 Streams and events route through the RBLN ``PrivateUse1`` device-guard
-implementation, so the backend-agnostic ``torch.Stream`` / ``torch.Event`` already
-work with ``device="rbln"``. This module adds the ``torch.cuda``-style ergonomics
-(:class:`Stream`, :class:`Event`, :func:`current_stream`, :func:`default_stream`,
-:func:`set_stream`, :func:`stream`) on top.
+implementation, so the generic ``torch.Stream`` / ``torch.Event`` already work with
+``device="rbln"``; this module adds the ``torch.cuda``-style surface on top.
 
-Three ``torch.cuda`` features have no RBLN analogue and are not supported: event
-timing (:meth:`Event.elapsed_time` raises), stream priorities (accepted but
-ignored; :meth:`Stream.priority_range` is ``(0, 0)``), and native cross-device
-event waits (they degrade to a host-side synchronize).
+Not supported: event timing (:meth:`Event.elapsed_time` raises), stream priorities
+(accepted but ignored), and native cross-device event waits (they degrade to a
+host-side synchronize).
 """
 
 from typing import Any, Optional  # noqa: UP035
@@ -43,13 +40,13 @@ class Stream(torch.Stream):
     concurrently. Mirrors :class:`torch.cuda.Stream`. ``priority`` is accepted for
     API parity but ignored (RBLN has no stream priorities).
 
-    Streams come from a fixed per-device pool and live for the process, as in
-    :mod:`torch.cuda`; past the pool size, new instances reuse earlier streams.
+    Streams come from a fixed per-device pool; past the pool size, new instances
+    reuse earlier streams (as in :mod:`torch.cuda`).
     """
 
     def __new__(cls, device: Any = None, priority: int = 0, **kwargs: Any) -> "Stream":  # noqa: PYI034
-        # Reconstruct an existing stream from its ids (current_stream/default_stream):
-        # the base wraps the ids without creating a new stream.
+        # With ids given (current_stream/default_stream), the base wraps them instead
+        # of creating a stream.
         if "stream_id" in kwargs and "device_index" in kwargs and "device_type" in kwargs:
             return super().__new__(cls, priority=priority, **kwargs)
         dev = torch.device("rbln", current_device()) if device is None else _as_rbln_device(device)
@@ -89,8 +86,6 @@ class Event(torch.Event):
         )
 
     def elapsed_time(self, other: "Event") -> float:
-        # Event timing is not supported. Raise a clear message rather than letting
-        # torch.Event.elapsed_time reject the subclass on its exact-type check.
         raise RuntimeError("RBLN does not support Event.elapsed_time (event timing is not supported).")
 
     def __repr__(self) -> str:
@@ -124,8 +119,8 @@ def set_stream(stream: Optional[Stream]) -> None:
 class StreamContext:
     r"""Context-manager that makes a stream current, restoring the previous on exit.
 
-    Mirrors :class:`torch.cuda.StreamContext`, including switching the current device
-    to the stream's device for the duration. No-op if the stream is ``None``.
+    Mirrors :class:`torch.cuda.StreamContext`: the stream's device is selected for the
+    duration. No-op if the stream is ``None``.
     """
 
     def __init__(self, stream: Optional[Stream]):

--- a/torch_rbln/device/streams.py
+++ b/torch_rbln/device/streams.py
@@ -5,8 +5,8 @@ implementation, so the generic ``torch.Stream`` / ``torch.Event`` already work w
 ``device="rbln"``; this module adds the ``torch.cuda``-style surface on top.
 
 Not supported: event timing (:meth:`Event.elapsed_time` raises), stream priorities
-(accepted but ignored), and native cross-device event waits (they degrade to a
-host-side synchronize).
+(accepted but ignored), :meth:`torch.Stream.native_handle`, and native cross-device
+event waits (they degrade to a host-side synchronize).
 """
 
 from typing import Any, Optional  # noqa: UP035

--- a/torch_rbln/device/streams.py
+++ b/torch_rbln/device/streams.py
@@ -52,6 +52,17 @@ class Stream(torch.Stream):
         dev = torch.device("rbln", current_device()) if device is None else _as_rbln_device(device)
         return super().__new__(cls, dev, priority=priority)
 
+    def record_event(self, event: Optional["Event"] = None) -> "Event":
+        """Record ``event`` on this stream, creating an :class:`Event` if ``None``.
+
+        Overridden like :meth:`torch.cuda.Stream.record_event` so the event is an
+        rbln one; the inherited method takes only a base :class:`torch.Event`.
+        """
+        if event is None:
+            event = Event()
+        event.record(self)
+        return event
+
     @property
     def priority(self) -> int:
         return 0

--- a/torch_rbln/device/streams.py
+++ b/torch_rbln/device/streams.py
@@ -109,7 +109,10 @@ def default_stream(device: Any = None) -> Stream:
 
 
 def set_stream(stream: Optional[Stream]) -> None:
-    """Set the current stream (no-op if ``None``). Prefer the :func:`stream` manager."""
+    """Set the current stream (no-op if ``None``). Prefer the :func:`stream` manager.
+
+    Also selects the stream's device, matching :func:`torch.cuda.set_stream`.
+    """
     if stream is None:
         return
     torch_rbln._C._exchange_stream(stream.stream_id, stream.device_index, stream.device_type)

--- a/torch_rbln/device/streams.py
+++ b/torch_rbln/device/streams.py
@@ -42,6 +42,9 @@ class Stream(torch.Stream):
     Work on the same stream runs in order; work on different streams may run
     concurrently. Mirrors :class:`torch.cuda.Stream`. ``priority`` is accepted for
     API parity but ignored (RBLN has no stream priorities).
+
+    Streams come from a fixed per-device pool and live for the process, as in
+    :mod:`torch.cuda`; past the pool size, new instances reuse earlier streams.
     """
 
     def __new__(cls, device: Any = None, priority: int = 0, **kwargs: Any) -> "Stream":  # noqa: PYI034

--- a/torch_rbln/device/streams.py
+++ b/torch_rbln/device/streams.py
@@ -1,0 +1,152 @@
+"""``torch.rbln`` stream & event API (``torch.cuda`` parity).
+
+Streams and events route through the RBLN ``PrivateUse1`` device-guard
+implementation, so the backend-agnostic ``torch.Stream`` / ``torch.Event`` already
+work with ``device="rbln"``. This module adds the ``torch.cuda``-style ergonomics
+(:class:`Stream`, :class:`Event`, :func:`current_stream`, :func:`default_stream`,
+:func:`set_stream`, :func:`stream`) on top.
+
+Three ``torch.cuda`` features have no RBLN analogue and are not supported: event
+timing (:meth:`Event.elapsed_time` raises), stream priorities (accepted but
+ignored; :meth:`Stream.priority_range` is ``(0, 0)``), and native cross-device
+event waits (they degrade to a host-side synchronize).
+"""
+
+from typing import Any, Optional  # noqa: UP035
+
+import torch
+
+import torch_rbln._C
+from torch_rbln.device.device import _get_device_index, current_device, device
+
+
+__all__ = [
+    "Stream",
+    "Event",
+    "current_stream",
+    "default_stream",
+    "set_stream",
+    "stream",
+    "StreamContext",
+]
+
+
+def _as_rbln_device(dev: Any) -> torch.device:
+    """Resolve ``dev`` (int / str / torch.device) to a concrete ``rbln:<idx>``."""
+    return torch.device("rbln", _get_device_index(dev))
+
+
+class Stream(torch.Stream):
+    r"""An RBLN stream: an in-order sequence of device work.
+
+    Work on the same stream runs in order; work on different streams may run
+    concurrently. Mirrors :class:`torch.cuda.Stream`. ``priority`` is accepted for
+    API parity but ignored (RBLN has no stream priorities).
+    """
+
+    def __new__(cls, device: Any = None, priority: int = 0, **kwargs: Any) -> "Stream":  # noqa: PYI034
+        # Reconstruct an existing stream from its ids (current_stream/default_stream):
+        # the base wraps the ids without creating a new stream.
+        if "stream_id" in kwargs and "device_index" in kwargs and "device_type" in kwargs:
+            return super().__new__(cls, priority=priority, **kwargs)
+        dev = torch.device("rbln", current_device()) if device is None else _as_rbln_device(device)
+        return super().__new__(cls, dev, priority=priority)
+
+    @property
+    def priority(self) -> int:
+        return 0
+
+    @staticmethod
+    def priority_range() -> tuple:
+        """``(least_priority, greatest_priority)``; ``(0, 0)`` — no priority levels."""
+        return (0, 0)
+
+    def __repr__(self) -> str:
+        return f"torch.rbln.Stream(device={self.device}, stream_id={self.stream_id})"
+
+
+class Event(torch.Event):
+    r"""An RBLN event: a recordable marker in a stream for cross-stream ordering and
+    completion queries. Mirrors :class:`torch.cuda.Event`. ``enable_timing`` is
+    accepted for API parity, but :meth:`elapsed_time` is unsupported.
+    """
+
+    def __new__(  # noqa: PYI034
+        cls,
+        enable_timing: bool = False,
+        blocking: bool = False,
+        interprocess: bool = False,
+    ) -> "Event":
+        return super().__new__(
+            cls,
+            device="rbln",
+            enable_timing=enable_timing,
+            blocking=blocking,
+            interprocess=interprocess,
+        )
+
+    def elapsed_time(self, other: "Event") -> float:
+        # Event timing is not supported. Raise a clear message rather than letting
+        # torch.Event.elapsed_time reject the subclass on its exact-type check.
+        raise RuntimeError("RBLN does not support Event.elapsed_time (event timing is not supported).")
+
+    def __repr__(self) -> str:
+        return f"torch.rbln.Event(device={self.device})"
+
+
+def current_stream(device: Any = None) -> Stream:
+    """Return the currently selected :class:`Stream` (default: current device)."""
+    idx = current_device() if device is None else _get_device_index(device)
+    stream_id, device_index, device_type = torch_rbln._C._get_current_stream(idx)
+    return Stream(stream_id=stream_id, device_index=device_index, device_type=device_type)
+
+
+def default_stream(device: Any = None) -> Stream:
+    """Return the default :class:`Stream` (default: current device)."""
+    idx = current_device() if device is None else _get_device_index(device)
+    stream_id, device_index, device_type = torch_rbln._C._get_default_stream(idx)
+    return Stream(stream_id=stream_id, device_index=device_index, device_type=device_type)
+
+
+def set_stream(stream: Optional[Stream]) -> None:
+    """Set the current stream (no-op if ``None``). Prefer the :func:`stream` manager."""
+    if stream is None:
+        return
+    torch_rbln._C._exchange_stream(stream.stream_id, stream.device_index, stream.device_type)
+
+
+class StreamContext:
+    r"""Context-manager that makes a stream current, restoring the previous on exit.
+
+    Mirrors :class:`torch.cuda.StreamContext`, including switching the current device
+    to the stream's device for the duration. No-op if the stream is ``None``.
+    """
+
+    def __init__(self, stream: Optional[Stream]):
+        self.stream = stream
+        self.src_prev_stream: Optional[Stream] = None
+        self.dst_prev_stream: Optional[Stream] = None
+
+    def __enter__(self):
+        cur_stream = self.stream
+        if cur_stream is None:
+            return
+        self.src_prev_stream = current_stream()
+        if self.src_prev_stream.device != cur_stream.device:
+            with device(cur_stream.device):
+                self.dst_prev_stream = current_stream(cur_stream.device)
+        set_stream(cur_stream)
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any):
+        cur_stream = self.stream
+        if cur_stream is None:
+            return False
+        if self.src_prev_stream is not None and self.src_prev_stream.device != cur_stream.device:
+            set_stream(self.dst_prev_stream)
+        set_stream(self.src_prev_stream)
+        return False
+
+
+def stream(stream: Optional[Stream]) -> StreamContext:
+    """Wrap :class:`StreamContext` to select a given stream (no-op if ``None``)."""
+    return StreamContext(stream)


### PR DESCRIPTION
## Summary of Changes

`torch.Stream` / `torch.Event` support for the RBLN (PrivateUse1) backend: the generic torch API, `torch.accelerator.*`, and a `torch.cuda`-style `torch.rbln.{Stream, Event, current_stream, default_stream, set_stream, stream}`. Consumer side of rebel-compiler [#12123](https://github.com/rebellions-sw/rebel_compiler/pull/12123), which expands the per-device default stream into a registry of independent seq-chains.

### Where it lives

Everything is in `RBLNGuardImpl`, so the three surfaces share one implementation. The only new pybind entry points are `_get_current_stream` / `_get_default_stream` / `_exchange_stream`, and they exist solely for the `torch.rbln` namespace.

| `RBLNGuardImpl` | C ABI |
|---|---|
| `getStream` / `exchangeStream` | `rbln_get_current_stream` / `rbln_set_current_stream` |
| `getDefaultStream` | none — `StreamId` 0 |
| `getNewStream` / `getStreamFromGlobalPool` | `rbln_stream_create`, pooled |
| `queryStream` / `synchronizeStream` | `rbln_stream_query` / `rbln_stream_synchronize` |
| `record` | `rbln_event_create` on first record, then `rbln_event_record` |
| `block` | `rbln_stream_wait_event`; cross-device falls back to `rbln_event_synchronize` |
| `queryEvent` / `synchronizeEvent` / `destroyEvent` | `rbln_event_query` / `rbln_event_synchronize` / `rbln_event_destroy` |

### Handles

A handle is `torch_device_id << 32 | local_id`. A `c10::Stream` carries `local_id` as its `StreamId` and the device in the `Stream` itself, so `StreamId` 0 is the default stream on both sides and a process that never creates a stream behaves as before. An event surfaces as its opaque 64-bit handle, which the runtime numbers from 1, so it never aliases the null "not created yet" sentinel.

### Decisions worth reviewing

| Decision | Why |
|---|---|
| `getNewStream` and `getStreamFromGlobalPool` both answer from a 32-deep per-device pool, one slot created per request | there is no destroy hook, so an unbounded create leaks and lengthens every `DrainAllStreams`. Same as CUDA; past the pool size, instances reuse a stream |
| `set_stream` selects the stream's device before exchanging the stream | matches `_cuda_setStream` and `torch.accelerator.set_stream`; otherwise allocations keep going to the old device |
| `getStream` answers the default stream only while the device has no context, and propagates failures after that | swallowing one would silently move work off the stream the caller selected. Creating a pool stream marks the context, so the shortcut cannot disagree with a stream a caller holds |
| `recordStream` stays a no-op | the runtime tags a freed block with the stream in flight at its free and folds foreign seqs into the reusing stream as cross-deps |

Rejected at the boundary: a stream whose `device_type` is not PrivateUse1 (`c10::Stream::unpack3` accepts any valid type), a `StreamId` wider than the handle's 32-bit field, a re-record onto another device's stream (as CUDA and XPU do), and an event handle of 0. `query` and `record` short-circuit during interpreter shutdown, like their synchronize counterparts.

### Not supported

| | Behavior |
|---|---|
| event timing | `elapsed_time` raises |
| stream priorities | accepted, ignored; `priority_range()` is `(0, 0)` |
| `Stream.native_handle` | unimplemented — raises on torch 2.11, absent from 2.10 |
| cross-device `wait_event` | degrades to a host-side synchronize, so it orders only the calling thread's later submissions |
| interprocess events, memory IPC | needs runtime support; see rebellions-sw/torch-rbln-internal#55 |
