### PR TITLE
fix(amp): advertise empty AMP dtype catalog so autocast disables gracefully

### DIFF
--- a/c10/rbln/RBLNSupportedDtypes.h
+++ b/c10/rbln/RBLNSupportedDtypes.h
@@ -11,7 +11,12 @@ namespace c10::rbln {
 // don't leak into `sdpa` or `amp`, which must stay float-only.
 inline constexpr std::array<c10::ScalarType, 2> kDispatchDtypes = {c10::kHalf, c10::kBFloat16};
 inline constexpr std::array<c10::ScalarType, 2> kSdpaDtypes = {c10::kHalf, c10::kBFloat16};
-inline constexpr std::array<c10::ScalarType, 2> kAmpDtypes = {c10::kHalf, c10::kBFloat16};
+// AMP autocast is not implemented yet: no AutocastPrivateUse1 cast policy is
+// registered, so dispatching an op under torch.autocast("rbln") would hit a
+// missing kernel (NotImplementedError). Advertise an empty set so torch
+// disables autocast with a warning instead of crashing. Restore the float
+// dtypes once AutocastPrivateUse1 is registered.
+inline constexpr std::array<c10::ScalarType, 0> kAmpDtypes = {};
 
 constexpr bool is_dispatch_dtype(c10::ScalarType s) noexcept {
   for (const auto d : kDispatchDtypes) {

--- a/test/cpp/core/RBLNSupportedDtypesTest.cpp
+++ b/test/cpp/core/RBLNSupportedDtypesTest.cpp
@@ -40,21 +40,15 @@ TEST_F(RBLNSupportedDtypesTest, SdpaCatalogContents) {
   }
 }
 
-TEST_F(RBLNSupportedDtypesTest, AmpCatalogContents) {
-  constexpr c10::ScalarType kExpected[] = {c10::kHalf, c10::kBFloat16};
-  for (const auto scalar_type : kExpected) {
-    EXPECT_TRUE(contains(c10::rbln::kAmpDtypes, scalar_type));
-  }
+TEST_F(RBLNSupportedDtypesTest, AmpCatalogIsEmpty) {
+  // AMP autocast is not implemented yet (no AutocastPrivateUse1 cast policy), so
+  // the catalog advertises no dtypes and torch disables autocast instead of
+  // dispatching to a missing kernel. See RBLNSupportedDtypes.h.
+  EXPECT_TRUE(c10::rbln::kAmpDtypes.empty());
 }
 
 TEST_F(RBLNSupportedDtypesTest, SdpaCatalogIsFloatOnly) {
   for (const auto scalar_type : c10::rbln::kSdpaDtypes) {
-    EXPECT_TRUE(c10::isFloatingType(scalar_type));
-  }
-}
-
-TEST_F(RBLNSupportedDtypesTest, AmpCatalogIsFloatOnly) {
-  for (const auto scalar_type : c10::rbln::kAmpDtypes) {
     EXPECT_TRUE(c10::isFloatingType(scalar_type));
   }
 }
@@ -79,6 +73,6 @@ TEST_F(RBLNSupportedDtypesTest, IsDispatchDtypeRejectsUnsupported) {
 
 static_assert(!c10::rbln::kDispatchDtypes.empty(), "dispatch dtype catalog must not be empty");
 static_assert(!c10::rbln::kSdpaDtypes.empty(), "SDPA dtype catalog must not be empty");
-static_assert(!c10::rbln::kAmpDtypes.empty(), "AMP dtype catalog must not be empty");
+static_assert(c10::rbln::kAmpDtypes.empty(), "AMP dtype catalog is intentionally empty until autocast is implemented");
 static_assert(c10::rbln::is_dispatch_dtype(c10::kHalf), "is_dispatch_dtype must be constexpr");
 static_assert(!c10::rbln::is_dispatch_dtype(c10::kFloat), "is_dispatch_dtype must be constexpr");

--- a/test/rbln/test_amp_autocast.py
+++ b/test/rbln/test_amp_autocast.py
@@ -22,9 +22,9 @@ import warnings
 
 import pytest
 import torch
-import torch_rbln  # noqa: F401  (registers the rbln device module + autocast plumbing)
 from torch.testing._internal.common_utils import run_tests, TestCase
 
+import torch_rbln  # noqa: F401  (registers the rbln device module + autocast plumbing)
 from torch_rbln._internal.ops_utils import SupportedDtypes
 
 

--- a/test/rbln/test_amp_autocast.py
+++ b/test/rbln/test_amp_autocast.py
@@ -1,0 +1,115 @@
+# Owner(s): ["module: PrivateUse1"]
+
+"""AMP / autocast behavior for the RBLN backend.
+
+RBLN does not implement AMP autocast yet (no ``AutocastPrivateUse1`` cast policy
+is registered). The dtype catalog therefore advertises an *empty* AMP set, so
+entering ``torch.autocast("rbln", ...)`` makes torch disable autocast with a
+warning instead of dispatching an op to a missing Autocast kernel (which used to
+raise ``NotImplementedError`` on the first op).
+
+Two invariants this suite locks down:
+1. The empty catalog is coherent across the C++/Python chain
+   (``c10::rbln::kAmpDtypes`` -> ``_amp_dtypes()`` -> ``SupportedDtypes.amp`` ->
+   ``get_amp_supported_dtype()``).
+2. ``get_amp_supported_dtype`` must still *exist* on the device module:
+   transformers/accelerate enter ``torch.autocast(device_type="rbln", ...)``
+   (notably the pervasive ``enabled=False`` "force float32" blocks), which
+   asserts the function is registered.
+"""
+
+import warnings
+
+import pytest
+import torch
+import torch_rbln  # noqa: F401  (registers the rbln device module + autocast plumbing)
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+from torch_rbln._internal.ops_utils import SupportedDtypes
+
+
+@pytest.mark.test_set_ci
+class TestAmpCatalog(TestCase):
+    """The AMP dtype catalog is empty and coherent end-to-end."""
+
+    def test_amp_catalog_is_empty(self):
+        self.assertIsInstance(SupportedDtypes.amp, tuple)
+        self.assertEqual(SupportedDtypes.amp, ())
+
+    def test_get_amp_supported_dtype_empty(self):
+        self.assertEqual(torch.rbln.get_amp_supported_dtype(), [])
+
+    def test_get_amp_supported_dtype_still_exists(self):
+        # Removing this function makes torch.autocast(device_type="rbln", ...) raise
+        # AssertionError, breaking transformers/accelerate. Guard against that.
+        self.assertTrue(hasattr(torch.rbln, "get_amp_supported_dtype"))
+
+
+@pytest.mark.test_set_ci
+class TestAutocastDisabledGracefully(TestCase):
+    """Entering an rbln autocast region must never crash on the first op."""
+
+    @staticmethod
+    def _matmul_rbln():
+        a = torch.randn(32, 32, device="rbln")
+        b = torch.randn(32, 32, device="rbln")
+        return a @ b
+
+    def test_fp16_autocast_disables_with_warning(self):
+        with self.assertWarns(UserWarning):
+            with torch.autocast(device_type="rbln", dtype=torch.float16):
+                y = self._matmul_rbln()
+        # Disabled -> the op ran in its native dtype (fp32), not fp16.
+        self.assertEqual(y.dtype, torch.float32)
+
+    def test_bf16_autocast_disables_with_warning(self):
+        with self.assertWarns(UserWarning):
+            with torch.autocast(device_type="rbln", dtype=torch.bfloat16):
+                y = self._matmul_rbln()
+        self.assertEqual(y.dtype, torch.float32)
+
+    def test_enabled_false_force_fp32_block(self):
+        # transformers' pervasive ``with autocast(enabled=False): # Force float32``.
+        # Works independently of the advertised dtypes (value is not consulted here).
+        with torch.autocast(device_type="rbln", enabled=False):
+            y = self._matmul_rbln()
+        self.assertEqual(y.dtype, torch.float32)
+
+
+@pytest.mark.test_set_ci
+class TestAutocastRealModelEager(TestCase):
+    """A real (tiny) transformers LlamaForCausalLM run eagerly under an rbln autocast
+    region must not crash and must match the plain fp32 path (autocast is a no-op)."""
+
+    @staticmethod
+    def _tiny_llama():
+        transformers = pytest.importorskip("transformers")
+        cfg = transformers.LlamaConfig(
+            vocab_size=256,
+            hidden_size=64,
+            intermediate_size=128,
+            num_hidden_layers=1,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            max_position_embeddings=64,
+            dtype=torch.float32,
+        )
+        torch.manual_seed(0)
+        return transformers.LlamaForCausalLM(cfg).eval()
+
+    def test_llama_eager_autocast_matches_fp32(self):
+        model = self._tiny_llama().to("rbln:0")
+        ids = torch.randint(0, 256, (1, 8)).to("rbln:0")
+        with torch.no_grad():
+            plain = model(ids).logits.cpu()
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")  # "Disabling autocast" is expected here
+                with torch.autocast(device_type="rbln", dtype=torch.float16):
+                    autocast_logits = model(ids).logits.cpu()
+        # autocast disabled -> identical fp32 execution.
+        self.assertEqual(autocast_logits.dtype, torch.float32)
+        torch.testing.assert_close(autocast_logits, plain)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/rbln/test_internal_op_utils.py
+++ b/test/rbln/test_internal_op_utils.py
@@ -296,12 +296,10 @@ class TestInternalOpUtils(TestCase):
         self.assertNotIn(torch.int32, SupportedDtypes.sdpa)
 
     def test_supported_dtypes_amp(self):
-        """Tuple of ``float16`` and ``bfloat16``; the AMP autocast path must stay float-only."""
+        """Empty: AMP autocast is not implemented (no AutocastPrivateUse1 policy),
+        so the catalog advertises no dtypes and torch disables autocast."""
         self.assertIsInstance(SupportedDtypes.amp, tuple)
-        self.assertIn(torch.bfloat16, SupportedDtypes.amp)
-        self.assertIn(torch.float16, SupportedDtypes.amp)
-        self.assertNotIn(torch.float32, SupportedDtypes.amp)
-        self.assertNotIn(torch.int32, SupportedDtypes.amp)
+        self.assertEqual(SupportedDtypes.amp, ())
 
     def test_get_amp_supported_dtype_matches_catalog(self):
         """``get_amp_supported_dtype()`` delegates to ``SupportedDtypes.amp``."""


### PR DESCRIPTION
## Purpose
`torch.rbln.get_amp_supported_dtype()` advertised `fp16`/`bf16`, but no
`AutocastPrivateUse1` cast policy is registered. So entering
`torch.autocast("rbln", dtype=fp16/bf16)` dispatched the first op to a missing
Autocast kernel and raised `NotImplementedError`:

```
NotImplementedError: Could not run 'aten::matmul' with arguments from the 'Autocastrbln' backend.
```

This advertises an **empty** AMP dtype set from the single source of truth
(`c10::rbln::kAmpDtypes`). torch then disables autocast with a clear warning
("Disabling autocast") and runs ops normally (fp32) instead of crashing.

We do **not** implement real autocast here on purpose: it would only help eager
mode (the compile/rebel path does not honor eager autocast), and it needs a full
op cast-policy list + per-op HW validation. That can land later when
`AutocastPrivateUse1` is registered — at which point the dtypes are restored.

Note: `get_amp_supported_dtype` is intentionally kept. transformers/accelerate
enter `torch.autocast(device_type="rbln", ...)` (notably the pervasive
`enabled=False` "force float32" blocks), and torch asserts the function exists;
only its return value changes.

## Related issue
N/A (scoped down from the AMP finding in an internal `dev` review; no separate
tracking issue).

## Affected modules
- C++ extension (`c10/rbln/RBLNSupportedDtypes.h` — single source of truth)
- Tests (C++ dtype catalog test; Python internal-op-utils; new AMP suite)

## Type of change
Bug Fix

## How to test
```
python -m pytest test/rbln/test_amp_autocast.py -v
python -m pytest test/rbln/test_internal_op_utils.py -k amp -v
ctest --test-dir build -R RBLNSupportedDtypes
```
Expected: all pass.
- `get_amp_supported_dtype() == []`, `SupportedDtypes.amp == ()`.
- `torch.autocast("rbln", dtype=fp16|bf16)` emits a UserWarning and does **not**
  crash; ops inside run in fp32.
- `torch.autocast("rbln", enabled=False)` (force-fp32) works.
- A tiny `LlamaForCausalLM` run eagerly under an rbln autocast region matches the
  plain fp32 logits.
