### PR TITLE
fix(rbln): align torch.accelerator contract gaps (memory stats, empty_cache, capability, resize)

### DIFF
--- a/c10/rbln/RBLNAllocator.cpp
+++ b/c10/rbln/RBLNAllocator.cpp
@@ -90,9 +90,13 @@ struct RBLNAllocator final : public c10::DeviceAllocator {
    */
   void emptyCache(c10::MempoolId_t /*mempool_id*/) override {
     // Flush *every* initialized device, not just the current one (CUDA/XPU parity).
-    // Delegates to a tested seam that iterates initialized_device_indices() and
-    // context-gates internally (an unused device isn't enumerated/registered).
-    c10::rbln::empty_cache_all_initialized_devices();
+    // initialized_device_indices() context-gates internally (an unused device isn't
+    // enumerated/registered) and is unit-tested for the "span all devices" selection.
+    for (const auto idx : c10::rbln::initialized_device_indices()) {
+      const auto device = c10::Device(c10::kPrivateUse1, idx);
+      RBLN_LOG_DEBUG("Emptying cache for {}", c10::str(device));
+      c10::rbln::empty_cache(device);
+    }
   }
 
   /**

--- a/c10/rbln/RBLNAllocator.cpp
+++ b/c10/rbln/RBLNAllocator.cpp
@@ -90,13 +90,9 @@ struct RBLNAllocator final : public c10::DeviceAllocator {
    */
   void emptyCache(c10::MempoolId_t /*mempool_id*/) override {
     // Flush *every* initialized device, not just the current one (CUDA/XPU parity).
-    // Device selection is a tested seam (initialized_device_indices); it context-gates
-    // internally so an unused device isn't enumerated/registered.
-    for (const auto idx : c10::rbln::initialized_device_indices()) {
-      const auto device = c10::Device(c10::kPrivateUse1, idx);
-      RBLN_LOG_DEBUG("Emptying cache for {}", c10::str(device));
-      c10::rbln::empty_cache(device);
-    }
+    // Delegates to a tested seam that iterates initialized_device_indices() and
+    // context-gates internally (an unused device isn't enumerated/registered).
+    c10::rbln::empty_cache_all_initialized_devices();
   }
 
   /**

--- a/c10/rbln/RBLNAllocator.cpp
+++ b/c10/rbln/RBLNAllocator.cpp
@@ -82,18 +82,26 @@ struct RBLNAllocator final : public c10::DeviceAllocator {
   }
 
   /**
-   * @brief Empties the memory cache for the specified memory pool.
+   * @brief Flushes the cache for every initialized device.
    *
-   * RBLN does not support per-mempool scoping, so this function will flush the cache for the current device
-   * regardless of the mempool_id provided.
-   *
-   * @param mempool_id The identifier for the memory pool to flush.
+   * Backs the device-less torch.accelerator.empty_cache() (all-device, CUDA/XPU
+   * parity); torch.rbln.empty_cache(device) stays per-device via a separate path.
+   * mempool_id is ignored (no per-mempool scoping).
    */
   void emptyCache(c10::MempoolId_t /*mempool_id*/) override {
-    const auto current_device_index = c10::rbln::get_device_index();
-    const auto current_device = c10::Device(c10::kPrivateUse1, current_device_index);
-    RBLN_LOG_DEBUG("Emptying cache for {}", c10::str(current_device));
-    c10::rbln::empty_cache(current_device);
+    // Context flag first so an unused device isn't enumerated/registered.
+    if (!c10::rbln::any_device_context_initialized()) {
+      return;
+    }
+    const auto device_count = c10::rbln::get_device_count();
+    for (c10::DeviceIndex idx = 0; idx < device_count; ++idx) {
+      if (!c10::rbln::device_context_initialized(idx)) {
+        continue;
+      }
+      const auto device = c10::Device(c10::kPrivateUse1, idx);
+      RBLN_LOG_DEBUG("Emptying cache for {}", c10::str(device));
+      c10::rbln::empty_cache(device);
+    }
   }
 
   /**

--- a/c10/rbln/RBLNAllocator.cpp
+++ b/c10/rbln/RBLNAllocator.cpp
@@ -89,15 +89,10 @@ struct RBLNAllocator final : public c10::DeviceAllocator {
    * mempool_id is ignored (no per-mempool scoping).
    */
   void emptyCache(c10::MempoolId_t /*mempool_id*/) override {
-    // Context flag first so an unused device isn't enumerated/registered.
-    if (!c10::rbln::any_device_context_initialized()) {
-      return;
-    }
-    const auto device_count = c10::rbln::get_device_count();
-    for (c10::DeviceIndex idx = 0; idx < device_count; ++idx) {
-      if (!c10::rbln::device_context_initialized(idx)) {
-        continue;
-      }
+    // Flush *every* initialized device, not just the current one (CUDA/XPU parity).
+    // Device selection is a tested seam (initialized_device_indices); it context-gates
+    // internally so an unused device isn't enumerated/registered.
+    for (const auto idx : c10::rbln::initialized_device_indices()) {
       const auto device = c10::Device(c10::kPrivateUse1, idx);
       RBLN_LOG_DEBUG("Emptying cache for {}", c10::str(device));
       c10::rbln::empty_cache(device);

--- a/c10/rbln/RBLNFunctions.cpp
+++ b/c10/rbln/RBLNFunctions.cpp
@@ -443,6 +443,22 @@ bool any_device_context_initialized() noexcept {
           g_context_init_mask[1].load(std::memory_order_relaxed)) != 0;
 }
 
+std::vector<c10::DeviceIndex> initialized_device_indices() {
+  std::vector<c10::DeviceIndex> indices;
+  // Context flag first: nothing initialized anywhere -> empty, and skip
+  // get_device_count() so we don't enumerate/register devices as a side effect.
+  if (!any_device_context_initialized()) {
+    return indices;
+  }
+  const auto device_count = get_device_count();
+  for (c10::DeviceIndex idx = 0; idx < device_count; ++idx) {
+    if (device_context_initialized(idx)) {
+      indices.push_back(idx);
+    }
+  }
+  return indices;
+}
+
 void* malloc(c10::DeviceIndex device_index, size_t nbytes) {
   RBLN_LOG_DEBUG("logical device=rbln:{}, nbytes={}", static_cast<int>(device_index), nbytes);
   RBLN_CHECK(nbytes > 0, "nbytes must be positive, but got {}", nbytes);
@@ -836,64 +852,60 @@ c10::CachingDeviceAllocator::DeviceStats get_device_stats(const c10::Device& dev
   }
   const auto device_index = device.index();
   check_device_index(device_index);
-  const auto device_id = to_device_id(device_index);
-  RBLN_LOG_DEBUG("Calling rbln_get_memory_stats: device_id={}", device_id);
-  // CUDA parity (see memory_stats): the rbln runtime exposes per-node memory stats
-  // for node 0 only; rbln_get_memory_stats() rejects any other device with
-  // INIT_INVALID_ARGUMENT (Invalid node_id). Report zero stats for such a device
-  // rather than propagating, so a device-stats query never throws for a valid index.
-  // (check_device_index above still rejects an invalid index -- a bad index throws.)
-  try {
-    const auto memory_stats = rbln_get_memory_stats(device_id);
-
-    c10::CachingDeviceAllocator::DeviceStats stats{};
-    constexpr auto kAggregate = static_cast<size_t>(c10::CachingAllocator::StatType::AGGREGATE);
-
-    // allocated_bytes
-    stats.allocated_bytes[kAggregate].current = static_cast<int64_t>(memory_stats.GetAllocatedCurrent());
-    stats.allocated_bytes[kAggregate].peak = static_cast<int64_t>(memory_stats.GetAllocatedPeak());
-    stats.allocated_bytes[kAggregate].allocated = static_cast<int64_t>(memory_stats.GetAllocatedTotalAllocated());
-    stats.allocated_bytes[kAggregate].freed = static_cast<int64_t>(memory_stats.GetAllocatedTotalFreed());
-
-    // reserved_bytes
-    stats.reserved_bytes[kAggregate].current = static_cast<int64_t>(memory_stats.GetReservedCurrent());
-    stats.reserved_bytes[kAggregate].peak = static_cast<int64_t>(memory_stats.GetReservedPeak());
-    stats.reserved_bytes[kAggregate].allocated = static_cast<int64_t>(memory_stats.GetReservedTotalAllocated());
-    stats.reserved_bytes[kAggregate].freed = static_cast<int64_t>(memory_stats.GetReservedTotalFreed());
-
-    // active_bytes
-    stats.active_bytes[kAggregate].current = static_cast<int64_t>(memory_stats.GetActiveCurrent());
-    stats.active_bytes[kAggregate].peak = static_cast<int64_t>(memory_stats.GetActivePeak());
-
-    // inactive_split_bytes — mapped from memory_stats's "cached" (reusable fragmented blocks).
-    stats.inactive_split_bytes[kAggregate].current = static_cast<int64_t>(memory_stats.GetCachedCurrent());
-    stats.inactive_split_bytes[kAggregate].peak = static_cast<int64_t>(memory_stats.GetCachedPeak());
-
-    // scalar counters
-    stats.num_alloc_retries = static_cast<int64_t>(memory_stats.GetNumAllocRetries());
-    stats.num_ooms = static_cast<int64_t>(memory_stats.GetNumOoms());
-    stats.num_device_alloc = static_cast<int64_t>(memory_stats.GetNumDeviceAlloc());
-    stats.num_device_free = static_cast<int64_t>(memory_stats.GetNumDeviceFree());
-
-    RBLN_LOG_DEBUG(
-        "allocated(current={}, peak={}, allocated={}, freed={}), reserved(current={}, peak={}, allocated={}, freed={}), "
-        "active(current={}, peak={})",
-        stats.allocated_bytes[kAggregate].current,
-        stats.allocated_bytes[kAggregate].peak,
-        stats.allocated_bytes[kAggregate].allocated,
-        stats.allocated_bytes[kAggregate].freed,
-        stats.reserved_bytes[kAggregate].current,
-        stats.reserved_bytes[kAggregate].peak,
-        stats.reserved_bytes[kAggregate].allocated,
-        stats.reserved_bytes[kAggregate].freed,
-        stats.active_bytes[kAggregate].current,
-        stats.active_bytes[kAggregate].peak);
-    return stats;
-  } catch (const std::exception& e) {
-    RBLN_LOG_DEBUG(
-        "rbln_get_memory_stats(rbln:{}) unavailable ({}); reporting zero", static_cast<int>(device_index), e.what());
+  // CUDA parity (see memory_stats): report zero stats for a valid device this process
+  // has not allocated on, matching PyTorch's generic path (empty only for an
+  // uninitialized allocator). An initialized device still queries the runtime, so
+  // genuine failures surface rather than being masked as zero.
+  if (!device_context_initialized(device_index)) {
     return c10::CachingDeviceAllocator::DeviceStats{};
   }
+  const auto device_id = to_device_id(device_index);
+  RBLN_LOG_DEBUG("Calling rbln_get_memory_stats: device_id={}", device_id);
+  const auto memory_stats = rbln_get_memory_stats(device_id);
+
+  c10::CachingDeviceAllocator::DeviceStats stats{};
+  constexpr auto kAggregate = static_cast<size_t>(c10::CachingAllocator::StatType::AGGREGATE);
+
+  // allocated_bytes
+  stats.allocated_bytes[kAggregate].current = static_cast<int64_t>(memory_stats.GetAllocatedCurrent());
+  stats.allocated_bytes[kAggregate].peak = static_cast<int64_t>(memory_stats.GetAllocatedPeak());
+  stats.allocated_bytes[kAggregate].allocated = static_cast<int64_t>(memory_stats.GetAllocatedTotalAllocated());
+  stats.allocated_bytes[kAggregate].freed = static_cast<int64_t>(memory_stats.GetAllocatedTotalFreed());
+
+  // reserved_bytes
+  stats.reserved_bytes[kAggregate].current = static_cast<int64_t>(memory_stats.GetReservedCurrent());
+  stats.reserved_bytes[kAggregate].peak = static_cast<int64_t>(memory_stats.GetReservedPeak());
+  stats.reserved_bytes[kAggregate].allocated = static_cast<int64_t>(memory_stats.GetReservedTotalAllocated());
+  stats.reserved_bytes[kAggregate].freed = static_cast<int64_t>(memory_stats.GetReservedTotalFreed());
+
+  // active_bytes
+  stats.active_bytes[kAggregate].current = static_cast<int64_t>(memory_stats.GetActiveCurrent());
+  stats.active_bytes[kAggregate].peak = static_cast<int64_t>(memory_stats.GetActivePeak());
+
+  // inactive_split_bytes — mapped from memory_stats's "cached" (reusable fragmented blocks).
+  stats.inactive_split_bytes[kAggregate].current = static_cast<int64_t>(memory_stats.GetCachedCurrent());
+  stats.inactive_split_bytes[kAggregate].peak = static_cast<int64_t>(memory_stats.GetCachedPeak());
+
+  // scalar counters
+  stats.num_alloc_retries = static_cast<int64_t>(memory_stats.GetNumAllocRetries());
+  stats.num_ooms = static_cast<int64_t>(memory_stats.GetNumOoms());
+  stats.num_device_alloc = static_cast<int64_t>(memory_stats.GetNumDeviceAlloc());
+  stats.num_device_free = static_cast<int64_t>(memory_stats.GetNumDeviceFree());
+
+  RBLN_LOG_DEBUG(
+      "allocated(current={}, peak={}, allocated={}, freed={}), reserved(current={}, peak={}, allocated={}, freed={}), "
+      "active(current={}, peak={})",
+      stats.allocated_bytes[kAggregate].current,
+      stats.allocated_bytes[kAggregate].peak,
+      stats.allocated_bytes[kAggregate].allocated,
+      stats.allocated_bytes[kAggregate].freed,
+      stats.reserved_bytes[kAggregate].current,
+      stats.reserved_bytes[kAggregate].peak,
+      stats.reserved_bytes[kAggregate].allocated,
+      stats.reserved_bytes[kAggregate].freed,
+      stats.active_bytes[kAggregate].current,
+      stats.active_bytes[kAggregate].peak);
+  return stats;
 }
 
 void empty_cache(const c10::Device& device) {
@@ -930,25 +942,22 @@ std::map<std::string, uint64_t> memory_stats(const c10::Device& device) {
   }
   const auto device_index = device.index();
   check_device_index(device_index);
-  const auto device_id = to_device_id(device_index);
-  RBLN_LOG_DEBUG("Calling rbln_get_memory_stats: rbln:{}, device_id={}", static_cast<int>(device_index), device_id);
-  // CUDA parity: memory_stats() must not throw for a valid device index. The rbln
-  // runtime exposes per-node memory stats for node 0 only; rbln_get_memory_stats()
-  // rejects any other device with INIT_INVALID_ARGUMENT (Invalid node_id). Report
-  // empty stats (memory_allocated()/memory_reserved() then read 0) for such a device
-  // rather than propagating, matching torch.cuda.memory_stats on an unqueryable
-  // device. (check_device_index above still rejects an invalid index -- a bad index
-  // throws; only the runtime's own stats failure is absorbed here.)
-  try {
-    const auto stats = rbln_get_memory_stats(device_id);
-    const auto memory_stats = stats.GetMemoryStats();
-    RBLN_LOG_DEBUG("memory_stats={}", memory_stats);
-    return memory_stats;
-  } catch (const std::exception& e) {
-    RBLN_LOG_DEBUG(
-        "rbln_get_memory_stats(rbln:{}) unavailable ({}); reporting zero", static_cast<int>(device_index), e.what());
+  // CUDA parity: report empty stats for a valid device this process has not allocated
+  // on (memory_allocated()/memory_reserved() then read 0), matching PyTorch's generic
+  // path, which returns empty only for an uninitialized allocator. An initialized
+  // device still queries the runtime, so genuine failures surface -- device 0 works;
+  // the runtime rejects per-node stats for a device index > 0 (INIT_INVALID_ARGUMENT,
+  // Invalid node_id), and fixing that is a runtime-side change, not a swallow here.
+  // (check_device_index above still rejects an invalid index -- a bad index throws.)
+  if (!device_context_initialized(device_index)) {
     return {};
   }
+  const auto device_id = to_device_id(device_index);
+  RBLN_LOG_DEBUG("Calling rbln_get_memory_stats: rbln:{}, device_id={}", static_cast<int>(device_index), device_id);
+  const auto stats = rbln_get_memory_stats(device_id);
+  const auto memory_stats = stats.GetMemoryStats();
+  RBLN_LOG_DEBUG("memory_stats={}", memory_stats);
+  return memory_stats;
 }
 
 void reset_accumulated_memory_stats(const c10::Device& device) {

--- a/c10/rbln/RBLNFunctions.cpp
+++ b/c10/rbln/RBLNFunctions.cpp
@@ -838,51 +838,62 @@ c10::CachingDeviceAllocator::DeviceStats get_device_stats(const c10::Device& dev
   check_device_index(device_index);
   const auto device_id = to_device_id(device_index);
   RBLN_LOG_DEBUG("Calling rbln_get_memory_stats: device_id={}", device_id);
-  const auto memory_stats = rbln_get_memory_stats(device_id);
+  // CUDA parity (see memory_stats): the rbln runtime exposes per-node memory stats
+  // for node 0 only; rbln_get_memory_stats() rejects any other device with
+  // INIT_INVALID_ARGUMENT (Invalid node_id). Report zero stats for such a device
+  // rather than propagating, so a device-stats query never throws for a valid index.
+  // (check_device_index above still rejects an invalid index -- a bad index throws.)
+  try {
+    const auto memory_stats = rbln_get_memory_stats(device_id);
 
-  c10::CachingDeviceAllocator::DeviceStats stats{};
-  constexpr auto kAggregate = static_cast<size_t>(c10::CachingAllocator::StatType::AGGREGATE);
+    c10::CachingDeviceAllocator::DeviceStats stats{};
+    constexpr auto kAggregate = static_cast<size_t>(c10::CachingAllocator::StatType::AGGREGATE);
 
-  // allocated_bytes
-  stats.allocated_bytes[kAggregate].current = static_cast<int64_t>(memory_stats.GetAllocatedCurrent());
-  stats.allocated_bytes[kAggregate].peak = static_cast<int64_t>(memory_stats.GetAllocatedPeak());
-  stats.allocated_bytes[kAggregate].allocated = static_cast<int64_t>(memory_stats.GetAllocatedTotalAllocated());
-  stats.allocated_bytes[kAggregate].freed = static_cast<int64_t>(memory_stats.GetAllocatedTotalFreed());
+    // allocated_bytes
+    stats.allocated_bytes[kAggregate].current = static_cast<int64_t>(memory_stats.GetAllocatedCurrent());
+    stats.allocated_bytes[kAggregate].peak = static_cast<int64_t>(memory_stats.GetAllocatedPeak());
+    stats.allocated_bytes[kAggregate].allocated = static_cast<int64_t>(memory_stats.GetAllocatedTotalAllocated());
+    stats.allocated_bytes[kAggregate].freed = static_cast<int64_t>(memory_stats.GetAllocatedTotalFreed());
 
-  // reserved_bytes
-  stats.reserved_bytes[kAggregate].current = static_cast<int64_t>(memory_stats.GetReservedCurrent());
-  stats.reserved_bytes[kAggregate].peak = static_cast<int64_t>(memory_stats.GetReservedPeak());
-  stats.reserved_bytes[kAggregate].allocated = static_cast<int64_t>(memory_stats.GetReservedTotalAllocated());
-  stats.reserved_bytes[kAggregate].freed = static_cast<int64_t>(memory_stats.GetReservedTotalFreed());
+    // reserved_bytes
+    stats.reserved_bytes[kAggregate].current = static_cast<int64_t>(memory_stats.GetReservedCurrent());
+    stats.reserved_bytes[kAggregate].peak = static_cast<int64_t>(memory_stats.GetReservedPeak());
+    stats.reserved_bytes[kAggregate].allocated = static_cast<int64_t>(memory_stats.GetReservedTotalAllocated());
+    stats.reserved_bytes[kAggregate].freed = static_cast<int64_t>(memory_stats.GetReservedTotalFreed());
 
-  // active_bytes
-  stats.active_bytes[kAggregate].current = static_cast<int64_t>(memory_stats.GetActiveCurrent());
-  stats.active_bytes[kAggregate].peak = static_cast<int64_t>(memory_stats.GetActivePeak());
+    // active_bytes
+    stats.active_bytes[kAggregate].current = static_cast<int64_t>(memory_stats.GetActiveCurrent());
+    stats.active_bytes[kAggregate].peak = static_cast<int64_t>(memory_stats.GetActivePeak());
 
-  // inactive_split_bytes — mapped from memory_stats's "cached" (reusable fragmented blocks).
-  stats.inactive_split_bytes[kAggregate].current = static_cast<int64_t>(memory_stats.GetCachedCurrent());
-  stats.inactive_split_bytes[kAggregate].peak = static_cast<int64_t>(memory_stats.GetCachedPeak());
+    // inactive_split_bytes — mapped from memory_stats's "cached" (reusable fragmented blocks).
+    stats.inactive_split_bytes[kAggregate].current = static_cast<int64_t>(memory_stats.GetCachedCurrent());
+    stats.inactive_split_bytes[kAggregate].peak = static_cast<int64_t>(memory_stats.GetCachedPeak());
 
-  // scalar counters
-  stats.num_alloc_retries = static_cast<int64_t>(memory_stats.GetNumAllocRetries());
-  stats.num_ooms = static_cast<int64_t>(memory_stats.GetNumOoms());
-  stats.num_device_alloc = static_cast<int64_t>(memory_stats.GetNumDeviceAlloc());
-  stats.num_device_free = static_cast<int64_t>(memory_stats.GetNumDeviceFree());
+    // scalar counters
+    stats.num_alloc_retries = static_cast<int64_t>(memory_stats.GetNumAllocRetries());
+    stats.num_ooms = static_cast<int64_t>(memory_stats.GetNumOoms());
+    stats.num_device_alloc = static_cast<int64_t>(memory_stats.GetNumDeviceAlloc());
+    stats.num_device_free = static_cast<int64_t>(memory_stats.GetNumDeviceFree());
 
-  RBLN_LOG_DEBUG(
-      "allocated(current={}, peak={}, allocated={}, freed={}), reserved(current={}, peak={}, allocated={}, freed={}), "
-      "active(current={}, peak={})",
-      stats.allocated_bytes[kAggregate].current,
-      stats.allocated_bytes[kAggregate].peak,
-      stats.allocated_bytes[kAggregate].allocated,
-      stats.allocated_bytes[kAggregate].freed,
-      stats.reserved_bytes[kAggregate].current,
-      stats.reserved_bytes[kAggregate].peak,
-      stats.reserved_bytes[kAggregate].allocated,
-      stats.reserved_bytes[kAggregate].freed,
-      stats.active_bytes[kAggregate].current,
-      stats.active_bytes[kAggregate].peak);
-  return stats;
+    RBLN_LOG_DEBUG(
+        "allocated(current={}, peak={}, allocated={}, freed={}), reserved(current={}, peak={}, allocated={}, freed={}), "
+        "active(current={}, peak={})",
+        stats.allocated_bytes[kAggregate].current,
+        stats.allocated_bytes[kAggregate].peak,
+        stats.allocated_bytes[kAggregate].allocated,
+        stats.allocated_bytes[kAggregate].freed,
+        stats.reserved_bytes[kAggregate].current,
+        stats.reserved_bytes[kAggregate].peak,
+        stats.reserved_bytes[kAggregate].allocated,
+        stats.reserved_bytes[kAggregate].freed,
+        stats.active_bytes[kAggregate].current,
+        stats.active_bytes[kAggregate].peak);
+    return stats;
+  } catch (const std::exception& e) {
+    RBLN_LOG_DEBUG(
+        "rbln_get_memory_stats(rbln:{}) unavailable ({}); reporting zero", static_cast<int>(device_index), e.what());
+    return c10::CachingDeviceAllocator::DeviceStats{};
+  }
 }
 
 void empty_cache(const c10::Device& device) {
@@ -921,11 +932,23 @@ std::map<std::string, uint64_t> memory_stats(const c10::Device& device) {
   check_device_index(device_index);
   const auto device_id = to_device_id(device_index);
   RBLN_LOG_DEBUG("Calling rbln_get_memory_stats: rbln:{}, device_id={}", static_cast<int>(device_index), device_id);
-  const auto stats = rbln_get_memory_stats(device_id);
-
-  const auto memory_stats = stats.GetMemoryStats();
-  RBLN_LOG_DEBUG("memory_stats={}", memory_stats);
-  return memory_stats;
+  // CUDA parity: memory_stats() must not throw for a valid device index. The rbln
+  // runtime exposes per-node memory stats for node 0 only; rbln_get_memory_stats()
+  // rejects any other device with INIT_INVALID_ARGUMENT (Invalid node_id). Report
+  // empty stats (memory_allocated()/memory_reserved() then read 0) for such a device
+  // rather than propagating, matching torch.cuda.memory_stats on an unqueryable
+  // device. (check_device_index above still rejects an invalid index -- a bad index
+  // throws; only the runtime's own stats failure is absorbed here.)
+  try {
+    const auto stats = rbln_get_memory_stats(device_id);
+    const auto memory_stats = stats.GetMemoryStats();
+    RBLN_LOG_DEBUG("memory_stats={}", memory_stats);
+    return memory_stats;
+  } catch (const std::exception& e) {
+    RBLN_LOG_DEBUG(
+        "rbln_get_memory_stats(rbln:{}) unavailable ({}); reporting zero", static_cast<int>(device_index), e.what());
+    return {};
+  }
 }
 
 void reset_accumulated_memory_stats(const c10::Device& device) {

--- a/c10/rbln/RBLNFunctions.cpp
+++ b/c10/rbln/RBLNFunctions.cpp
@@ -934,27 +934,6 @@ void empty_cache(const c10::Device& device) {
       static_cast<int>(rc));
 }
 
-namespace {
-// Test-only seam for empty_cache_all_initialized_devices(); see the header.
-std::function<void(c10::DeviceIndex)> g_empty_cache_device_hook;
-} // namespace
-
-void set_empty_cache_device_hook_for_testing(std::function<void(c10::DeviceIndex)> hook) {
-  g_empty_cache_device_hook = std::move(hook);
-}
-
-void empty_cache_all_initialized_devices() {
-  for (const auto idx : initialized_device_indices()) {
-    if (g_empty_cache_device_hook) {
-      g_empty_cache_device_hook(idx); // observe/override in tests, skip the real flush
-      continue;
-    }
-    const auto device = c10::Device(c10::kPrivateUse1, idx);
-    RBLN_LOG_DEBUG("Emptying cache for {}", c10::str(device));
-    empty_cache(device);
-  }
-}
-
 std::map<std::string, uint64_t> memory_stats(const c10::Device& device) {
   RBLN_LOG_DEBUG("logical device={}", c10::str(device));
   // Best-effort query: empty when the runtime is unavailable.

--- a/c10/rbln/RBLNFunctions.cpp
+++ b/c10/rbln/RBLNFunctions.cpp
@@ -934,6 +934,27 @@ void empty_cache(const c10::Device& device) {
       static_cast<int>(rc));
 }
 
+namespace {
+// Test-only seam for empty_cache_all_initialized_devices(); see the header.
+std::function<void(c10::DeviceIndex)> g_empty_cache_device_hook;
+} // namespace
+
+void set_empty_cache_device_hook_for_testing(std::function<void(c10::DeviceIndex)> hook) {
+  g_empty_cache_device_hook = std::move(hook);
+}
+
+void empty_cache_all_initialized_devices() {
+  for (const auto idx : initialized_device_indices()) {
+    if (g_empty_cache_device_hook) {
+      g_empty_cache_device_hook(idx); // observe/override in tests, skip the real flush
+      continue;
+    }
+    const auto device = c10::Device(c10::kPrivateUse1, idx);
+    RBLN_LOG_DEBUG("Emptying cache for {}", c10::str(device));
+    empty_cache(device);
+  }
+}
+
 std::map<std::string, uint64_t> memory_stats(const c10::Device& device) {
   RBLN_LOG_DEBUG("logical device={}", c10::str(device));
   // Best-effort query: empty when the runtime is unavailable.

--- a/c10/rbln/RBLNFunctions.h
+++ b/c10/rbln/RBLNFunctions.h
@@ -8,6 +8,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <map>
 #include <optional>
 #include <string>
@@ -185,6 +186,23 @@ C10_RBLN_API bool any_device_context_initialized() noexcept;
  * only). Empty when no context is initialized. Order is ascending by index.
  */
 C10_RBLN_API std::vector<c10::DeviceIndex> initialized_device_indices();
+
+/**
+ * @brief Flush the cache of every initialized device (device-less empty_cache()).
+ *
+ * Backs RBLNAllocator::emptyCache(). Iterates initialized_device_indices() and calls
+ * empty_cache() per device — the "span all initialized devices, not just the current
+ * one" contract (CUDA/XPU parity). When a test observer is installed
+ * (set_empty_cache_device_hook_for_testing), it is invoked per device *instead of* the
+ * real flush, so a test can assert the dispatch without touching the runtime.
+ */
+C10_RBLN_API void empty_cache_all_initialized_devices();
+
+/**
+ * @brief Test seam: observe/override the per-device dispatch of
+ * empty_cache_all_initialized_devices(). Pass nullptr to restore the real flush.
+ */
+C10_RBLN_API void set_empty_cache_device_hook_for_testing(std::function<void(c10::DeviceIndex)> hook);
 
 /**
  * @brief Allocates memory on the specified RBLN device.

--- a/c10/rbln/RBLNFunctions.h
+++ b/c10/rbln/RBLNFunctions.h
@@ -8,7 +8,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <functional>
 #include <map>
 #include <optional>
 #include <string>
@@ -186,23 +185,6 @@ C10_RBLN_API bool any_device_context_initialized() noexcept;
  * only). Empty when no context is initialized. Order is ascending by index.
  */
 C10_RBLN_API std::vector<c10::DeviceIndex> initialized_device_indices();
-
-/**
- * @brief Flush the cache of every initialized device (device-less empty_cache()).
- *
- * Backs RBLNAllocator::emptyCache(). Iterates initialized_device_indices() and calls
- * empty_cache() per device — the "span all initialized devices, not just the current
- * one" contract (CUDA/XPU parity). When a test observer is installed
- * (set_empty_cache_device_hook_for_testing), it is invoked per device *instead of* the
- * real flush, so a test can assert the dispatch without touching the runtime.
- */
-C10_RBLN_API void empty_cache_all_initialized_devices();
-
-/**
- * @brief Test seam: observe/override the per-device dispatch of
- * empty_cache_all_initialized_devices(). Pass nullptr to restore the real flush.
- */
-C10_RBLN_API void set_empty_cache_device_hook_for_testing(std::function<void(c10::DeviceIndex)> hook);
 
 /**
  * @brief Allocates memory on the specified RBLN device.

--- a/c10/rbln/RBLNFunctions.h
+++ b/c10/rbln/RBLNFunctions.h
@@ -176,6 +176,17 @@ C10_RBLN_API bool device_context_initialized(c10::DeviceIndex device_index) noex
 C10_RBLN_API bool any_device_context_initialized() noexcept;
 
 /**
+ * @brief Logical device indices this process has initialized (a live context on).
+ *
+ * The set of devices the device-less torch.accelerator.empty_cache() must flush —
+ * every initialized device, not just the current one (CUDA/XPU parity). Extracted
+ * as a seam so the "span all initialized devices" selection is unit-testable without
+ * observing per-device runtime state (the runtime exposes memory stats for node 0
+ * only). Empty when no context is initialized. Order is ascending by index.
+ */
+C10_RBLN_API std::vector<c10::DeviceIndex> initialized_device_indices();
+
+/**
  * @brief Allocates memory on the specified RBLN device.
  *
  * This function allocates a contiguous block of memory on the given RBLN

--- a/c10/rbln/RBLNHooksInterface.cpp
+++ b/c10/rbln/RBLNHooksInterface.cpp
@@ -61,7 +61,8 @@ bool RBLNHooksInterface::hasPrimaryContext(c10::DeviceIndex device_index) const 
 
 void RBLNHooksInterface::resizePrivateUse1Bytes(const c10::Storage& storage, size_t new_nbytes) const {
   RBLN_LOG_DEBUG("storage={}, new_nbytes={}", fmt::ptr(&storage), new_nbytes);
-  RBLN_CHECK(new_nbytes > 0, "New nbytes must be positive, but got {}", new_nbytes);
+  // new_nbytes == 0 is a valid request (e.g. untyped_storage().resize_(0)); the
+  // branch below already handles the zero-size case (null DataPtr, nbytes = 0).
   RBLN_CHECK(storage.resizable(), "Storage must be resizable");
   auto* allocator = storage.allocator();
   RBLN_CHECK(allocator != nullptr, "Cannot resize storage without allocator");

--- a/c10/rbln/RBLNSupportedDtypes.h
+++ b/c10/rbln/RBLNSupportedDtypes.h
@@ -23,8 +23,8 @@ inline constexpr std::array<c10::ScalarType, 0> kAmpDtypes = {};
 // which ops dispatch natively, so it is broader than kDispatchDtypes and
 // includes fp32/int32/int64. Must match the v2v/copy engine set
 // (ENGINE_DTYPES in test/utils_v2v.py).
-inline constexpr std::array<c10::ScalarType, 5> kCapabilityDtypes = {
-    c10::kHalf, c10::kBFloat16, c10::kFloat, c10::kInt, c10::kLong};
+inline constexpr std::array<c10::ScalarType, 5> kCapabilityDtypes =
+    {c10::kHalf, c10::kBFloat16, c10::kFloat, c10::kInt, c10::kLong};
 
 constexpr bool is_dispatch_dtype(c10::ScalarType s) noexcept {
   for (const auto d : kDispatchDtypes) {

--- a/c10/rbln/RBLNSupportedDtypes.h
+++ b/c10/rbln/RBLNSupportedDtypes.h
@@ -18,13 +18,11 @@ inline constexpr std::array<c10::ScalarType, 2> kSdpaDtypes = {c10::kHalf, c10::
 // dtypes once AutocastPrivateUse1 is registered.
 inline constexpr std::array<c10::ScalarType, 0> kAmpDtypes = {};
 
-// torch.accelerator device-capability dtypes: the set RBLN can *allocate* and
-// *type-convert* on device. Per the upstream contract this is independent of
-// which ops dispatch natively, so it is broader than kDispatchDtypes and
-// includes fp32/int32/int64. Must match the v2v/copy engine set
-// (ENGINE_DTYPES in test/utils_v2v.py).
-inline constexpr std::array<c10::ScalarType, 5> kCapabilityDtypes =
-    {c10::kHalf, c10::kBFloat16, c10::kFloat, c10::kInt, c10::kLong};
+// torch.accelerator device-capability dtypes (backs get_device_capability):
+// dtypes actually resident in RBLN device memory. Other dtypes accept
+// device="rbln" but are CPU-backed (0 device bytes), so they are not a device
+// capability. Empirically only fp16/bf16 (verified in test_accelerator_contract.py).
+inline constexpr std::array<c10::ScalarType, 2> kCapabilityDtypes = {c10::kHalf, c10::kBFloat16};
 
 constexpr bool is_dispatch_dtype(c10::ScalarType s) noexcept {
   for (const auto d : kDispatchDtypes) {

--- a/c10/rbln/RBLNSupportedDtypes.h
+++ b/c10/rbln/RBLNSupportedDtypes.h
@@ -18,6 +18,14 @@ inline constexpr std::array<c10::ScalarType, 2> kSdpaDtypes = {c10::kHalf, c10::
 // dtypes once AutocastPrivateUse1 is registered.
 inline constexpr std::array<c10::ScalarType, 0> kAmpDtypes = {};
 
+// torch.accelerator device-capability dtypes: the set RBLN can *allocate* and
+// *type-convert* on device. Per the upstream contract this is independent of
+// which ops dispatch natively, so it is broader than kDispatchDtypes and
+// includes fp32/int32/int64. Must match the v2v/copy engine set
+// (ENGINE_DTYPES in test/utils_v2v.py).
+inline constexpr std::array<c10::ScalarType, 5> kCapabilityDtypes = {
+    c10::kHalf, c10::kBFloat16, c10::kFloat, c10::kInt, c10::kLong};
+
 constexpr bool is_dispatch_dtype(c10::ScalarType s) noexcept {
   for (const auto d : kDispatchDtypes) {
     if (s == d) {

--- a/c10/rbln/impl/RBLNGuardImpl.cpp
+++ b/c10/rbln/impl/RBLNGuardImpl.cpp
@@ -105,9 +105,8 @@ c10::DeviceCapability RBLNGuardImpl::getDeviceCapability(c10::Device device) con
         ")");
   }
 
-  // Capability = the dtypes RBLN can allocate and type-convert on device
-  // (allocation + conversion, per the upstream torch.accelerator contract),
-  // which is broader than native-op dispatch. See kCapabilityDtypes.
+  // Capability = the dtypes resident in device memory (allocation/conversion
+  // capability, not native-op dispatch). See kCapabilityDtypes.
   c10::DeviceCapability capability;
   capability.capability_data.capability_bits = 0;
   for (const auto scalar_type : c10::rbln::kCapabilityDtypes) {
@@ -117,15 +116,6 @@ c10::DeviceCapability RBLNGuardImpl::getDeviceCapability(c10::Device device) con
         break;
       case c10::kBFloat16:
         capability.capability_data.supported_scalar_types.has_BFloat16 = 1;
-        break;
-      case c10::kFloat:
-        capability.capability_data.supported_scalar_types.has_Float = 1;
-        break;
-      case c10::kInt:
-        capability.capability_data.supported_scalar_types.has_Int = 1;
-        break;
-      case c10::kLong:
-        capability.capability_data.supported_scalar_types.has_Long = 1;
         break;
       default:
         TORCH_CHECK(false, "unhandled capability dtype ", c10::toString(scalar_type));

--- a/c10/rbln/impl/RBLNGuardImpl.cpp
+++ b/c10/rbln/impl/RBLNGuardImpl.cpp
@@ -2,6 +2,8 @@
 #include <c10/rbln/RBLNLogging.h>
 #include <c10/rbln/impl/RBLNGuardImpl.h>
 
+#include <c10/core/DeviceCapability.h>
+
 #include <exception>
 
 namespace c10::rbln::impl {
@@ -85,6 +87,16 @@ c10::DeviceIndex RBLNGuardImpl::deviceCount() const noexcept {
     RBLN_WARN_NOTHROW("Failed to get device count, returning 0: unknown exception");
     return 0;
   }
+}
+
+c10::DeviceCapability RBLNGuardImpl::getDeviceCapability(c10::Device /*device*/) const {
+  // Native-dispatch dtypes only (fp16/bf16); CPU-fallback dtypes are not device
+  // capabilities. Mirrors kDispatchDtypes in c10/rbln/RBLNSupportedDtypes.h.
+  c10::DeviceCapability capability;
+  capability.capability_data.capability_bits = 0;
+  capability.capability_data.supported_scalar_types.has_Half = 1;
+  capability.capability_data.supported_scalar_types.has_BFloat16 = 1;
+  return capability;
 }
 
 c10::Stream RBLNGuardImpl::getStream(c10::Device device) const {

--- a/c10/rbln/impl/RBLNGuardImpl.cpp
+++ b/c10/rbln/impl/RBLNGuardImpl.cpp
@@ -1,5 +1,6 @@
 #include <c10/rbln/RBLNHooksInterface.h>
 #include <c10/rbln/RBLNLogging.h>
+#include <c10/rbln/RBLNSupportedDtypes.h>
 #include <c10/rbln/impl/RBLNGuardImpl.h>
 
 #include <c10/core/DeviceCapability.h>
@@ -89,13 +90,47 @@ c10::DeviceIndex RBLNGuardImpl::deviceCount() const noexcept {
   }
 }
 
-c10::DeviceCapability RBLNGuardImpl::getDeviceCapability(c10::Device /*device*/) const {
-  // Native-dispatch dtypes only (fp16/bf16); CPU-fallback dtypes are not device
-  // capabilities. Mirrors kDispatchDtypes in c10/rbln/RBLNSupportedDtypes.h.
+c10::DeviceCapability RBLNGuardImpl::getDeviceCapability(c10::Device device) const {
+  // Validate the requested index so a stale/out-of-range device can't silently
+  // report a capability. A no-device host (count == 0) skips the range check.
+  const auto count = deviceCount();
+  if (count > 0) {
+    const auto index = device.has_index() ? device.index() : c10::rbln::get_device_index();
+    TORCH_CHECK(
+        index >= 0 && index < count,
+        "rbln device index ",
+        static_cast<int>(index),
+        " is out of range [0, ",
+        static_cast<int>(count),
+        ")");
+  }
+
+  // Capability = the dtypes RBLN can allocate and type-convert on device
+  // (allocation + conversion, per the upstream torch.accelerator contract),
+  // which is broader than native-op dispatch. See kCapabilityDtypes.
   c10::DeviceCapability capability;
   capability.capability_data.capability_bits = 0;
-  capability.capability_data.supported_scalar_types.has_Half = 1;
-  capability.capability_data.supported_scalar_types.has_BFloat16 = 1;
+  for (const auto scalar_type : c10::rbln::kCapabilityDtypes) {
+    switch (scalar_type) {
+      case c10::kHalf:
+        capability.capability_data.supported_scalar_types.has_Half = 1;
+        break;
+      case c10::kBFloat16:
+        capability.capability_data.supported_scalar_types.has_BFloat16 = 1;
+        break;
+      case c10::kFloat:
+        capability.capability_data.supported_scalar_types.has_Float = 1;
+        break;
+      case c10::kInt:
+        capability.capability_data.supported_scalar_types.has_Int = 1;
+        break;
+      case c10::kLong:
+        capability.capability_data.supported_scalar_types.has_Long = 1;
+        break;
+      default:
+        TORCH_CHECK(false, "unhandled capability dtype ", c10::toString(scalar_type));
+    }
+  }
   return capability;
 }
 

--- a/c10/rbln/impl/RBLNGuardImpl.h
+++ b/c10/rbln/impl/RBLNGuardImpl.h
@@ -58,7 +58,9 @@ struct RBLNGuardImpl final : public c10::impl::DeviceGuardImplInterface {
   /**
    * @brief Reports supported dtypes (backs torch.accelerator.get_device_capability).
    *
-   * Advertises only the natively-dispatched dtypes (fp16/bf16); CPU-fallback dtypes are excluded.
+   * supported_dtypes is the device's allocation/conversion capability, not native
+   * op dispatch. RBLN advertises fp16/bf16 (kCapabilityDtypes) — the only dtypes
+   * resident in device memory; other dtypes are CPU-backed even under device="rbln".
    */
   c10::DeviceCapability getDeviceCapability(c10::Device device) const override;
 

--- a/c10/rbln/impl/RBLNGuardImpl.h
+++ b/c10/rbln/impl/RBLNGuardImpl.h
@@ -56,6 +56,13 @@ struct RBLNGuardImpl final : public c10::impl::DeviceGuardImplInterface {
   c10::DeviceIndex deviceCount() const noexcept override;
 
   /**
+   * @brief Reports supported dtypes (backs torch.accelerator.get_device_capability).
+   *
+   * Advertises only the natively-dispatched dtypes (fp16/bf16); CPU-fallback dtypes are excluded.
+   */
+  c10::DeviceCapability getDeviceCapability(c10::Device device) const override;
+
+  /**
    * @brief Returns the current stream for the input device.
    *
    * @param device The input device.

--- a/test/cpp/core/RBLNAllocatorTest.cpp
+++ b/test/cpp/core/RBLNAllocatorTest.cpp
@@ -157,13 +157,12 @@ TEST_F(RBLNAllocatorTest, EmptyCache) {
   EXPECT_NO_THROW(device_allocator->emptyCache());
 }
 
-// Regression guard for the device-less empty_cache() "span all devices" contract: it
-// must dispatch to *every* initialized device, not just the current one. Per-device
-// release is unobservable here (the runtime exposes memory stats for node 0 only), so
-// a test hook records which devices emptyCache() actually dispatches to and we assert
-// a non-current initialized device is among them (a current-device-only regression
-// would drop it). Exercises emptyCache() itself, not just the selection helper.
-TEST_F(RBLNAllocatorTest, EmptyCacheDispatchesToNonCurrentInitializedDevice) {
+// Regression guard for the device-less empty_cache() "span all devices" contract:
+// emptyCache() iterates initialized_device_indices(), which must include *every*
+// initialized device, not just the current one (a current-device-only regression drops
+// the rest). Per-device release is unobservable here (the runtime exposes memory stats
+// for node 0 only), so we assert the selection includes a non-current initialized device.
+TEST_F(RBLNAllocatorTest, EmptyCacheSpansNonCurrentInitializedDevice) {
   if (c10::rbln::get_device_count() < 2) {
     GTEST_SKIP() << "needs >= 2 devices to exercise a non-current device";
   }
@@ -179,14 +178,12 @@ TEST_F(RBLNAllocatorTest, EmptyCacheDispatchesToNonCurrentInitializedDevice) {
     const auto d0 = allocator->allocate(1024);
     EXPECT_NE(d0.get(), nullptr);
   }
+  // Sanity-check emptyCache() runs over the multi-device selection without throwing.
+  EXPECT_NO_THROW(GetDeviceAllocator()->emptyCache());
 
-  std::vector<c10::DeviceIndex> dispatched;
-  c10::rbln::set_empty_cache_device_hook_for_testing([&](c10::DeviceIndex i) { dispatched.push_back(i); });
-  GetDeviceAllocator()->emptyCache();
-  c10::rbln::set_empty_cache_device_hook_for_testing(nullptr); // restore real flush
-
+  const auto indices = c10::rbln::initialized_device_indices();
   const auto contains = [&](c10::DeviceIndex i) {
-    for (const auto x : dispatched) {
+    for (const auto x : indices) {
       if (x == i) {
         return true;
       }
@@ -194,7 +191,8 @@ TEST_F(RBLNAllocatorTest, EmptyCacheDispatchesToNonCurrentInitializedDevice) {
     return false;
   };
   EXPECT_TRUE(contains(0));
-  EXPECT_TRUE(contains(1)) << "emptyCache() skipped non-current initialized device 1 (current-device-only regression)";
+  EXPECT_TRUE(contains(1))
+      << "initialized_device_indices() dropped non-current device 1 (current-device-only regression)";
 }
 
 // recordStream must be a safe no-op — RBLN has no stream-based async execution.

--- a/test/cpp/core/RBLNAllocatorTest.cpp
+++ b/test/cpp/core/RBLNAllocatorTest.cpp
@@ -157,6 +157,41 @@ TEST_F(RBLNAllocatorTest, EmptyCache) {
   EXPECT_NO_THROW(device_allocator->emptyCache());
 }
 
+// Regression guard for the device-less empty_cache() "span all devices" contract:
+// its device selection (initialized_device_indices) must cover *every* initialized
+// device, not just the current one (a current-device-only regression drops the rest).
+// The per-device release itself is unobservable here — the runtime exposes memory
+// stats for node 0 only — so we assert the selection includes a non-current device.
+TEST_F(RBLNAllocatorTest, EmptyCacheSpansNonCurrentInitializedDevice) {
+  if (c10::rbln::get_device_count() < 2) {
+    GTEST_SKIP() << "needs >= 2 devices to exercise a non-current device";
+  }
+  auto* allocator = c10::GetAllocator(c10::kPrivateUse1);
+  // Initialize a non-current device (index 1), then make device 0 current again.
+  c10::rbln::set_device_index(1);
+  {
+    const auto d1 = allocator->allocate(1024);
+    EXPECT_NE(d1.get(), nullptr);
+  }
+  c10::rbln::set_device_index(0);
+  {
+    const auto d0 = allocator->allocate(1024);
+    EXPECT_NE(d0.get(), nullptr);
+  }
+
+  const auto indices = c10::rbln::initialized_device_indices();
+  const auto contains = [&](c10::DeviceIndex i) {
+    for (const auto x : indices) {
+      if (x == i) {
+        return true;
+      }
+    }
+    return false;
+  };
+  EXPECT_TRUE(contains(0));
+  EXPECT_TRUE(contains(1)) << "empty_cache() would skip non-current initialized device 1";
+}
+
 // recordStream must be a safe no-op — RBLN has no stream-based async execution.
 TEST_F(RBLNAllocatorTest, RecordStreamIsNoOp) {
   auto* device_allocator = GetDeviceAllocator();

--- a/test/cpp/core/RBLNAllocatorTest.cpp
+++ b/test/cpp/core/RBLNAllocatorTest.cpp
@@ -157,12 +157,13 @@ TEST_F(RBLNAllocatorTest, EmptyCache) {
   EXPECT_NO_THROW(device_allocator->emptyCache());
 }
 
-// Regression guard for the device-less empty_cache() "span all devices" contract:
-// its device selection (initialized_device_indices) must cover *every* initialized
-// device, not just the current one (a current-device-only regression drops the rest).
-// The per-device release itself is unobservable here — the runtime exposes memory
-// stats for node 0 only — so we assert the selection includes a non-current device.
-TEST_F(RBLNAllocatorTest, EmptyCacheSpansNonCurrentInitializedDevice) {
+// Regression guard for the device-less empty_cache() "span all devices" contract: it
+// must dispatch to *every* initialized device, not just the current one. Per-device
+// release is unobservable here (the runtime exposes memory stats for node 0 only), so
+// a test hook records which devices emptyCache() actually dispatches to and we assert
+// a non-current initialized device is among them (a current-device-only regression
+// would drop it). Exercises emptyCache() itself, not just the selection helper.
+TEST_F(RBLNAllocatorTest, EmptyCacheDispatchesToNonCurrentInitializedDevice) {
   if (c10::rbln::get_device_count() < 2) {
     GTEST_SKIP() << "needs >= 2 devices to exercise a non-current device";
   }
@@ -179,9 +180,13 @@ TEST_F(RBLNAllocatorTest, EmptyCacheSpansNonCurrentInitializedDevice) {
     EXPECT_NE(d0.get(), nullptr);
   }
 
-  const auto indices = c10::rbln::initialized_device_indices();
+  std::vector<c10::DeviceIndex> dispatched;
+  c10::rbln::set_empty_cache_device_hook_for_testing([&](c10::DeviceIndex i) { dispatched.push_back(i); });
+  GetDeviceAllocator()->emptyCache();
+  c10::rbln::set_empty_cache_device_hook_for_testing(nullptr); // restore real flush
+
   const auto contains = [&](c10::DeviceIndex i) {
-    for (const auto x : indices) {
+    for (const auto x : dispatched) {
       if (x == i) {
         return true;
       }
@@ -189,7 +194,7 @@ TEST_F(RBLNAllocatorTest, EmptyCacheSpansNonCurrentInitializedDevice) {
     return false;
   };
   EXPECT_TRUE(contains(0));
-  EXPECT_TRUE(contains(1)) << "empty_cache() would skip non-current initialized device 1";
+  EXPECT_TRUE(contains(1)) << "emptyCache() skipped non-current initialized device 1 (current-device-only regression)";
 }
 
 // recordStream must be a safe no-op — RBLN has no stream-based async execution.

--- a/test/cpp/core/RBLNAllocatorTest.cpp
+++ b/test/cpp/core/RBLNAllocatorTest.cpp
@@ -157,29 +157,42 @@ TEST_F(RBLNAllocatorTest, EmptyCache) {
   EXPECT_NO_THROW(device_allocator->emptyCache());
 }
 
-// Regression guard for the device-less empty_cache() "span all devices" contract:
-// emptyCache() iterates initialized_device_indices(), which must include *every*
-// initialized device, not just the current one (a current-device-only regression drops
-// the rest). Per-device release is unobservable here (the runtime exposes memory stats
-// for node 0 only), so we assert the selection includes a non-current initialized device.
+// Regression guard for the device-less empty_cache() "span all devices" contract
+// (CUDA/XPU parity): emptyCache() must release *every* initialized device, not just the
+// current one. Device 0 is left non-current with a cached (freed-but-reserved) block, so a
+// current-device-only regression leaves that block intact — asserted released here.
+// Device 0's reserved bytes are observable (the runtime exposes per-node stats for node 0
+// only); the selection seam is additionally checked via initialized_device_indices().
 TEST_F(RBLNAllocatorTest, EmptyCacheSpansNonCurrentInitializedDevice) {
   if (c10::rbln::get_device_count() < 2) {
     GTEST_SKIP() << "needs >= 2 devices to exercise a non-current device";
   }
-  auto* allocator = c10::GetAllocator(c10::kPrivateUse1);
-  // Initialize a non-current device (index 1), then make device 0 current again.
+  constexpr size_t kAggregate = static_cast<size_t>(c10::CachingAllocator::StatType::AGGREGATE);
+  auto* allocator = GetDeviceAllocator();
+
+  // Build a cached block on device 0, then measure its reserved bytes while still current.
+  c10::rbln::set_device_index(0);
+  {
+    const auto d0 = allocator->allocate(32ULL << 20);
+    EXPECT_NE(d0.get(), nullptr);
+  }
+  const auto reserved_before = allocator->getDeviceStats(0).reserved_bytes[kAggregate].current;
+  if (reserved_before <= 0) {
+    GTEST_SKIP() << "allocator retained no reserved block on device 0 to observe (lazy malloc)";
+  }
+
+  // Make device 1 current so device 0 is the non-current initialized device.
   c10::rbln::set_device_index(1);
   {
     const auto d1 = allocator->allocate(1024);
     EXPECT_NE(d1.get(), nullptr);
   }
-  c10::rbln::set_device_index(0);
-  {
-    const auto d0 = allocator->allocate(1024);
-    EXPECT_NE(d0.get(), nullptr);
-  }
-  // Sanity-check emptyCache() runs over the multi-device selection without throwing.
-  EXPECT_NO_THROW(GetDeviceAllocator()->emptyCache());
+
+  EXPECT_NO_THROW(allocator->emptyCache());
+
+  // Device 0 (non-current) must have been released too, not just the current device.
+  EXPECT_LT(allocator->getDeviceStats(0).reserved_bytes[kAggregate].current, reserved_before)
+      << "emptyCache() left non-current device 0 reserved (current-device-only regression)";
 
   const auto indices = c10::rbln::initialized_device_indices();
   const auto contains = [&](c10::DeviceIndex i) {
@@ -191,8 +204,7 @@ TEST_F(RBLNAllocatorTest, EmptyCacheSpansNonCurrentInitializedDevice) {
     return false;
   };
   EXPECT_TRUE(contains(0));
-  EXPECT_TRUE(contains(1))
-      << "initialized_device_indices() dropped non-current device 1 (current-device-only regression)";
+  EXPECT_TRUE(contains(1)) << "initialized_device_indices() dropped non-current device 1";
 }
 
 // recordStream must be a safe no-op — RBLN has no stream-based async execution.

--- a/test/cpp/core/RBLNAllocatorTest.cpp
+++ b/test/cpp/core/RBLNAllocatorTest.cpp
@@ -4,6 +4,36 @@
 #include <c10/rbln/RBLNHooksInterface.h>
 #include <gtest/gtest.h>
 
+#include <cstdlib>
+#include <string>
+
+namespace {
+// Forces TORCH_RBLN_EAGER_MALLOC for its scope and restores the prior value on exit (all
+// paths, including GTEST_SKIP), so toggling eager malloc can't leak into later tests.
+class ScopedEagerMalloc {
+ public:
+  explicit ScopedEagerMalloc(const char* value) {
+    const char* saved = std::getenv("TORCH_RBLN_EAGER_MALLOC");
+    had_ = saved != nullptr;
+    if (had_) {
+      saved_ = saved;
+    }
+    setenv("TORCH_RBLN_EAGER_MALLOC", value, /*overwrite=*/1);
+  }
+  ~ScopedEagerMalloc() {
+    if (had_) {
+      setenv("TORCH_RBLN_EAGER_MALLOC", saved_.c_str(), /*overwrite=*/1);
+    } else {
+      unsetenv("TORCH_RBLN_EAGER_MALLOC");
+    }
+  }
+
+ private:
+  bool had_;
+  std::string saved_;
+};
+} // namespace
+
 class RBLNAllocatorTest : public ::testing::Test {
  protected:
   static void SetUpTestSuite() {
@@ -170,6 +200,11 @@ TEST_F(RBLNAllocatorTest, EmptyCacheSpansNonCurrentInitializedDevice) {
   constexpr size_t kAggregate = static_cast<size_t>(c10::CachingAllocator::StatType::AGGREGATE);
   auto* allocator = GetDeviceAllocator();
 
+  // Force eager malloc so the allocation below reserves device memory (a lazy malloc would
+  // stage on the host and leave reserved at 0, silently voiding the assertion).
+  const ScopedEagerMalloc eager("1");
+  ASSERT_TRUE(c10::rbln::is_eager_malloc());
+
   // Build a cached block on device 0, then measure its reserved bytes while still current.
   c10::rbln::set_device_index(0);
   {
@@ -177,9 +212,7 @@ TEST_F(RBLNAllocatorTest, EmptyCacheSpansNonCurrentInitializedDevice) {
     EXPECT_NE(d0.get(), nullptr);
   }
   const auto reserved_before = allocator->getDeviceStats(0).reserved_bytes[kAggregate].current;
-  if (reserved_before <= 0) {
-    GTEST_SKIP() << "allocator retained no reserved block on device 0 to observe (lazy malloc)";
-  }
+  ASSERT_GT(reserved_before, 0) << "eager allocation reserved no device memory on device 0";
 
   // Make device 1 current so device 0 is the non-current initialized device.
   c10::rbln::set_device_index(1);

--- a/test/cpp/core/RBLNSupportedDtypesTest.cpp
+++ b/test/cpp/core/RBLNSupportedDtypesTest.cpp
@@ -54,9 +54,8 @@ TEST_F(RBLNSupportedDtypesTest, SdpaCatalogIsFloatOnly) {
 }
 
 TEST_F(RBLNSupportedDtypesTest, CapabilityCatalogContents) {
-  // Allocation/conversion capability is broader than native dispatch: it also
-  // covers fp32/int32/int64 (the v2v/copy engine dtypes).
-  constexpr c10::ScalarType kExpected[] = {c10::kHalf, c10::kBFloat16, c10::kFloat, c10::kInt, c10::kLong};
+  // Device-resident dtypes only (fp16/bf16); other dtypes are CPU-backed.
+  constexpr c10::ScalarType kExpected[] = {c10::kHalf, c10::kBFloat16};
   for (const auto scalar_type : kExpected) {
     EXPECT_TRUE(contains(c10::rbln::kCapabilityDtypes, scalar_type));
   }

--- a/test/cpp/core/RBLNSupportedDtypesTest.cpp
+++ b/test/cpp/core/RBLNSupportedDtypesTest.cpp
@@ -56,8 +56,7 @@ TEST_F(RBLNSupportedDtypesTest, SdpaCatalogIsFloatOnly) {
 TEST_F(RBLNSupportedDtypesTest, CapabilityCatalogContents) {
   // Allocation/conversion capability is broader than native dispatch: it also
   // covers fp32/int32/int64 (the v2v/copy engine dtypes).
-  constexpr c10::ScalarType kExpected[] = {
-      c10::kHalf, c10::kBFloat16, c10::kFloat, c10::kInt, c10::kLong};
+  constexpr c10::ScalarType kExpected[] = {c10::kHalf, c10::kBFloat16, c10::kFloat, c10::kInt, c10::kLong};
   for (const auto scalar_type : kExpected) {
     EXPECT_TRUE(contains(c10::rbln::kCapabilityDtypes, scalar_type));
   }

--- a/test/cpp/core/RBLNSupportedDtypesTest.cpp
+++ b/test/cpp/core/RBLNSupportedDtypesTest.cpp
@@ -53,6 +53,16 @@ TEST_F(RBLNSupportedDtypesTest, SdpaCatalogIsFloatOnly) {
   }
 }
 
+TEST_F(RBLNSupportedDtypesTest, CapabilityCatalogContents) {
+  // Allocation/conversion capability is broader than native dispatch: it also
+  // covers fp32/int32/int64 (the v2v/copy engine dtypes).
+  constexpr c10::ScalarType kExpected[] = {
+      c10::kHalf, c10::kBFloat16, c10::kFloat, c10::kInt, c10::kLong};
+  for (const auto scalar_type : kExpected) {
+    EXPECT_TRUE(contains(c10::rbln::kCapabilityDtypes, scalar_type));
+  }
+}
+
 TEST_F(RBLNSupportedDtypesTest, IsDispatchDtypeAcceptsAdmitted) {
   for (const auto scalar_type : c10::rbln::kDispatchDtypes) {
     EXPECT_TRUE(c10::rbln::is_dispatch_dtype(scalar_type));
@@ -74,5 +84,6 @@ TEST_F(RBLNSupportedDtypesTest, IsDispatchDtypeRejectsUnsupported) {
 static_assert(!c10::rbln::kDispatchDtypes.empty(), "dispatch dtype catalog must not be empty");
 static_assert(!c10::rbln::kSdpaDtypes.empty(), "SDPA dtype catalog must not be empty");
 static_assert(c10::rbln::kAmpDtypes.empty(), "AMP dtype catalog is intentionally empty until autocast is implemented");
+static_assert(!c10::rbln::kCapabilityDtypes.empty(), "capability dtype catalog must not be empty");
 static_assert(c10::rbln::is_dispatch_dtype(c10::kHalf), "is_dispatch_dtype must be constexpr");
 static_assert(!c10::rbln::is_dispatch_dtype(c10::kFloat), "is_dispatch_dtype must be constexpr");

--- a/test/internal/test_memory_stats.py
+++ b/test/internal/test_memory_stats.py
@@ -40,6 +40,14 @@ class TestMemoryStats(TestCase):
         # Clear any existing state to ensure test isolation (matching C++ test)
         # Use try-except to handle potential initialization issues
         try:
+            # torch.rbln.memory_stats() reports {} for a device this process has not
+            # allocated on (CUDA parity, via the device_context_initialized gate). This
+            # class reads the dotted stat keys directly (e.g. stats["allocated.current"]),
+            # so initialize the device context with a throwaway allocation first — else
+            # the first read below KeyErrors on the empty dict. (Mirrors the warmup in
+            # TestAcceleratorMemoryAPI.setUp for the torch.accelerator path.)
+            warmup = torch.empty(1, device=self.device, dtype=torch.float16)
+            del warmup
             torch.rbln.empty_cache(self.device)
             torch.rbln.reset_accumulated_memory_stats(self.device)
             torch.rbln.reset_peak_memory_stats(self.device)

--- a/test/internal/test_memory_stats.py
+++ b/test/internal/test_memory_stats.py
@@ -529,12 +529,13 @@ class TestMemoryStats(TestCase):
         """None device arguments must normalize to the current logical device."""
         expected_device = torch.device("rbln:1")
         stats = {
-            "allocated_bytes.all.current": 128,
-            "reserved_bytes.all.current": 256,
+            "allocated.current": 128,
+            "reserved.current": 256,
         }
 
         with (
             patch("torch_rbln.memory.torch_rbln._C.current_device", return_value=1),
+            patch("torch_rbln.memory._no_rbln_device", return_value=False),
             patch(
                 "torch_rbln.memory.torch_rbln._C.memory_stats",
                 return_value=stats,
@@ -545,6 +546,7 @@ class TestMemoryStats(TestCase):
 
         with (
             patch("torch_rbln.memory.torch_rbln._C.current_device", return_value=1),
+            patch("torch_rbln.memory._no_rbln_device", return_value=False),
             patch(
                 "torch_rbln.memory.torch_rbln._C.memory_stats",
                 return_value=stats,
@@ -555,6 +557,7 @@ class TestMemoryStats(TestCase):
 
         with (
             patch("torch_rbln.memory.torch_rbln._C.current_device", return_value=1),
+            patch("torch_rbln.memory._no_rbln_device", return_value=False),
             patch(
                 "torch_rbln.memory.torch_rbln._C.memory_stats",
                 return_value=stats,
@@ -569,6 +572,7 @@ class TestMemoryStats(TestCase):
 
         with (
             patch("torch_rbln.memory.torch_rbln._C.current_device", return_value=1),
+            patch("torch_rbln.memory._no_rbln_device", return_value=False),
             patch(
                 "torch_rbln.memory.torch_rbln._C.empty_cache",
             ) as mock_empty_cache,
@@ -583,6 +587,7 @@ class TestMemoryStats(TestCase):
 
         with (
             patch("torch_rbln.memory.torch_rbln._C.current_device", return_value=1),
+            patch("torch_rbln.memory._no_rbln_device", return_value=False),
             patch(
                 "torch_rbln.memory.torch_rbln._C.reset_peak_memory_stats",
             ) as mock_reset_peak,

--- a/test/internal/test_memory_stats.py
+++ b/test/internal/test_memory_stats.py
@@ -37,23 +37,22 @@ class TestMemoryStats(TestCase):
         self.device_id = 0
         self.device = f"rbln:{self.device_id}"
 
-        # Clear any existing state to ensure test isolation (matching C++ test)
-        # Use try-except to handle potential initialization issues
-        try:
-            # torch.rbln.memory_stats() reports {} for a device this process has not
-            # allocated on (CUDA parity, via the device_context_initialized gate). This
-            # class reads the dotted stat keys directly (e.g. stats["allocated.current"]),
-            # so initialize the device context with a throwaway allocation first — else
-            # the first read below KeyErrors on the empty dict. (Mirrors the warmup in
-            # TestAcceleratorMemoryAPI.setUp for the torch.accelerator path.)
-            warmup = torch.empty(1, device=self.device, dtype=torch.float16)
-            del warmup
-            torch.rbln.empty_cache(self.device)
-            torch.rbln.reset_accumulated_memory_stats(self.device)
-            torch.rbln.reset_peak_memory_stats(self.device)
-        except Exception as e:
-            # If memory functions are not available, skip the test
-            self.skipTest(f"Memory functions not available: {e}")
+        # Skip only when there is no device to test; a warmup/reset failure below is a
+        # real regression and must fail the suite, not be swallowed into a skip.
+        if torch.rbln.device_count() == 0:
+            self.skipTest("no rbln device available")
+
+        # torch.rbln.memory_stats() reports {} for a device this process has not
+        # allocated on (CUDA parity, via the device_context_initialized gate). This
+        # class reads the dotted stat keys directly (e.g. stats["allocated.current"]),
+        # so initialize the device context with a throwaway allocation first — else
+        # the first read below KeyErrors on the empty dict. (Mirrors the warmup in
+        # TestAcceleratorMemoryAPI.setUp for the torch.accelerator path.)
+        warmup = torch.empty(1, device=self.device, dtype=torch.float16)
+        del warmup
+        torch.rbln.empty_cache(self.device)
+        torch.rbln.reset_accumulated_memory_stats(self.device)
+        torch.rbln.reset_peak_memory_stats(self.device)
 
         # rebel-compiler's caching allocator rounds every allocation up to a
         # fixed page granularity (4KB in recent runtimes). Probe it here so the

--- a/test/rbln/test_accelerator_contract.py
+++ b/test/rbln/test_accelerator_contract.py
@@ -1,0 +1,100 @@
+# Owner(s): ["module: PrivateUse1"]
+
+"""Regression tests for torch.accelerator / torch.rbln contract gaps.
+
+Covers:
+- ``torch.rbln.memory_*`` reading the RBLN allocator's dotted stat keys
+  (``allocated.current`` etc.), not the CUDA-style ``allocated_bytes.all.current``.
+- Device-argument normalization (accept None/int/str/torch.device, reject
+  non-rbln devices and out-of-range indices).
+- ``torch.accelerator.get_device_capability()`` advertising the natively
+  dispatched dtypes.
+- PrivateUse1 storage resize-to-zero.
+- ``torch.accelerator.empty_cache()`` (no device arg) spanning every
+  initialized device.
+"""
+
+import pytest
+import torch
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+import torch_rbln  # noqa: F401 -- registers the rbln device + torch.rbln namespace
+
+
+class TestRblnMemoryHelpers(TestCase):
+    """``torch.rbln.memory_*`` must read the RBLN allocator's dotted stat keys."""
+
+    @pytest.mark.test_set_ci
+    def test_memory_helpers_match_stats_and_are_nonzero(self):
+        torch.rbln.empty_cache()
+        torch.rbln.reset_peak_memory_stats()
+
+        keep = torch.randn(1024, 1024, device="rbln:0", dtype=torch.float16)
+        _ = keep + keep
+
+        stats = torch.rbln.memory_stats()
+        self.assertEqual(torch.rbln.memory_allocated(), stats.get("allocated.current", 0))
+        self.assertEqual(torch.rbln.max_memory_allocated(), stats.get("allocated.peak", 0))
+        self.assertEqual(torch.rbln.memory_reserved(), stats.get("reserved.current", 0))
+        self.assertEqual(torch.rbln.max_memory_reserved(), stats.get("reserved.peak", 0))
+        # Regression: the CUDA-style key made these return 0 despite a live allocation.
+        self.assertGreater(torch.rbln.memory_allocated(), 0)
+        del keep
+
+    @pytest.mark.test_set_ci
+    def test_memory_stats_rejects_non_rbln_devices(self):
+        for bad in ("cpu", "cuda:0", torch.device("cpu")):
+            with self.assertRaises(ValueError):
+                torch.rbln.memory_stats(bad)
+
+    @pytest.mark.test_set_ci
+    def test_memory_stats_accepts_all_device_forms(self):
+        current = torch.accelerator.current_device_index()
+        for dev in (None, 0, "rbln:0", "rbln", torch.device("rbln", 0), torch.device("rbln", current)):
+            self.assertIsInstance(torch.rbln.memory_stats(dev), dict)
+
+    @pytest.mark.test_set_ci
+    def test_memory_stats_rejects_out_of_range_index(self):
+        with self.assertRaises(ValueError):
+            torch.rbln.memory_stats(torch.rbln.device_count())  # first out-of-range index
+
+
+class TestDeviceCapability(TestCase):
+    """``torch.accelerator.get_device_capability()`` reports the native dtypes."""
+
+    @pytest.mark.test_set_ci
+    def test_supported_dtypes_are_native_floats(self):
+        cap = torch.accelerator.get_device_capability()
+        self.assertIn("supported_dtypes", cap)
+        # RBLN dispatches fp16/bf16 natively; fallback-only dtypes are excluded.
+        self.assertEqual(set(cap["supported_dtypes"]), {torch.float16, torch.bfloat16})
+
+
+class TestStorageResizeToZero(TestCase):
+    """PrivateUse1 storage must accept ``resize_(0)``."""
+
+    @pytest.mark.test_set_ci
+    def test_resize_storage_to_zero(self):
+        x = torch.empty(16, device="rbln:0", dtype=torch.float16)
+        storage = x.untyped_storage()
+        storage.resize_(0)
+        self.assertEqual(storage.nbytes(), 0)
+
+
+class TestAcceleratorEmptyCache(TestCase):
+    """Device-less ``torch.accelerator.empty_cache()`` iterates all initialized devices."""
+
+    @pytest.mark.test_set_ci
+    def test_generic_empty_cache_runs(self):
+        # Materialize then free so the allocator holds cache, then call the
+        # device-less generic empty_cache: it walks every initialized device and
+        # must complete without error (with one device it iterates once).
+        scratch = torch.randn(512, 512, device="rbln:0", dtype=torch.float16)
+        _ = scratch + scratch
+        del scratch
+        torch.accelerator.empty_cache()
+        self.assertGreaterEqual(torch.rbln.memory_reserved(), 0)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/rbln/test_accelerator_contract.py
+++ b/test/rbln/test_accelerator_contract.py
@@ -161,9 +161,10 @@ class TestAcceleratorEmptyCache(TestCase):
     but the rbln runtime's per-node memory-stats query supports node 0 only, so on a
     device index > 0 ``memory_reserved()`` either raises (an initialized device, the
     runtime rejects the query) or reads 0 (an uninitialized device, the gate) — never
-    the real figure. The all-device dispatch is instead covered in C++ by
-    ``RBLNAllocatorTest.EmptyCacheDispatchesToNonCurrentInitializedDevice``, which
-    observes emptyCache()'s per-device calls directly."""
+    the real figure. The all-device selection is instead covered in C++ by
+    ``RBLNAllocatorTest.EmptyCacheSpansNonCurrentInitializedDevice`` (emptyCache()
+    iterates ``initialized_device_indices()``, asserted to include a non-current
+    device)."""
 
     @staticmethod
     def _hold_then_free_reserved(device):

--- a/test/rbln/test_accelerator_contract.py
+++ b/test/rbln/test_accelerator_contract.py
@@ -88,22 +88,27 @@ class TestRblnMemoryHelpers(TestCase):
 
     @pytest.mark.test_set_ci
     def test_accelerator_memory_stats_uninitialized_device_reports_zero_not_raise(self):
-        # Same parity guarantee on the generic torch.accelerator path, which routes to
-        # the C10 getDeviceStats() hook -- a separate code path from
-        # torch.rbln.memory_stats(). An uninitialized valid device reports zero, not raise.
+        # The generic torch.accelerator path routes to the C10 getDeviceStats() hook --
+        # a separate code path from torch.rbln.memory_stats(). It must report zero (not
+        # raise) for a valid, uninitialized device index.
         count = torch.rbln.device_count()
         if count < 2:
             self.skipTest("needs a second, never-allocated device index")
-        idx = count - 1
-        # The regression is that this raised INIT_INVALID_ARGUMENT; the guarantee is a
-        # clean return. An uninitialized device yields empty stats; any populated entry
-        # must be zero.
-        stats = torch.accelerator.memory_stats(idx)  # must not raise
+        # Initialize the allocator with a live device-0 allocation first: otherwise
+        # torch.accelerator short-circuits to an empty dict *before* reaching
+        # getDeviceStats(), making the check below vacuous. With it initialized, querying
+        # an uninitialized index actually exercises getDeviceStats() (populated zeros).
+        keep = torch.randn(1024, 1024, device="rbln:0", dtype=torch.float16)
+        _ = keep + keep
+        idx = count - 1  # highest index: not touched by other tests in this worker
+        stats = torch.accelerator.memory_stats(idx)  # must not raise (regression: INIT_INVALID_ARGUMENT)
         self.assertIsInstance(stats, dict)
+        self.assertGreater(len(stats), 0, "getDeviceStats() was not exercised (accelerator returned an empty dict)")
         self.assertTrue(
             all(v == 0 for v in stats.values() if isinstance(v, int)),
             msg=f"expected zero stats for uninitialized rbln:{idx}, got nonzero entries",
         )
+        del keep
 
 
 @pytest.mark.single_worker
@@ -151,15 +156,14 @@ class TestAcceleratorEmptyCache(TestCase):
     other workers' allocations.
 
     Note: the all-devices span — ``empty_cache()`` walking *every* initialized
-    device, not just the current one — is intentionally not asserted here.
+    device, not just the current one — is not asserted at the Python level.
     Confirming a non-current device was released means reading its reserved bytes,
-    but the rbln runtime's per-node memory-stats query only supports node 0:
-    ``memory_reserved(idx > 0)`` reports 0 for every device index > 0 (the runtime
-    rejects the query and the backend reports zero for CUDA parity — see
-    test_memory_stats_unqueryable_device_reports_zero_not_raise), even for a device
-    holding live memory. So the multi-device release is unobservable through the
-    stats API on current hardware; that loop stays covered by the C++ review of
-    RBLNAllocator::emptyCache()'s per-device iteration."""
+    but the rbln runtime's per-node memory-stats query supports node 0 only, so on a
+    device index > 0 ``memory_reserved()`` either raises (an initialized device, the
+    runtime rejects the query) or reads 0 (an uninitialized device, the gate) — never
+    the real figure. The all-device dispatch is instead covered in C++ by
+    ``RBLNAllocatorTest.EmptyCacheDispatchesToNonCurrentInitializedDevice``, which
+    observes emptyCache()'s per-device calls directly."""
 
     @staticmethod
     def _hold_then_free_reserved(device):

--- a/test/rbln/test_accelerator_contract.py
+++ b/test/rbln/test_accelerator_contract.py
@@ -69,6 +69,17 @@ class TestRblnMemoryHelpers(TestCase):
             torch.rbln.memory_stats(torch.rbln.device_count())  # first out-of-range index
 
     @pytest.mark.test_set_ci
+    def test_memory_stats_rejects_int8_wrapped_index(self):
+        # torch.device's index is an int8_t: raw 256 wraps to 0, 257 to 1, 255 to -1
+        # (current device). Such values must be rejected from the original int/str, not
+        # normalized to an in-range device by the silent wrap.
+        count = torch.rbln.device_count()
+        wrapped = [255, 256, 257, "rbln:255", "rbln:256", 256 + max(count - 1, 0)]
+        for bad in wrapped:
+            with self.assertRaises(ValueError, msg=f"{bad!r} slipped past the range check"):
+                torch.rbln.memory_stats(bad)
+
+    @pytest.mark.test_set_ci
     def test_memory_stats_uninitialized_device_reports_zero_not_raise(self):
         # CUDA parity: memory_stats() must not throw for a *valid* device index this
         # process has not allocated on. It reports zero (like torch.cuda.memory_stats
@@ -118,22 +129,28 @@ class TestDeviceCapability(TestCase):
     Single-worker: measures global device memory."""
 
     @pytest.mark.test_set_ci
-    def test_capability_reports_device_resident_dtypes(self):
-        supported = torch.accelerator.get_device_capability()["supported_dtypes"]
-        self.assertEqual(set(supported), {torch.float16, torch.bfloat16})
-        # Each advertised dtype must actually occupy device memory (a compute op
-        # materializes it on the NPU); a CPU-backed dtype would report 0 bytes.
-        for dtype in supported:
+    def test_capability_matches_device_resident_dtypes(self):
+        # Probe a candidate set spanning both advertised (fp16/bf16) and unadvertised
+        # (fp32/int) dtypes, classify each by whether a compute op materializes it in
+        # device memory, and require the advertised set to equal the resident set — so a
+        # dtype that is resident but missing from the advertisement is caught too, not
+        # just the reverse.
+        advertised = set(torch.accelerator.get_device_capability()["supported_dtypes"])
+        candidates = [torch.float16, torch.bfloat16, torch.float32, torch.int32, torch.int64]
+        resident = set()
+        for dtype in candidates:
             torch.rbln.empty_cache()
             before = torch.rbln.memory_allocated(0)
             scratch = torch.empty(1024 * 1024, dtype=dtype, device="rbln:0")
             scratch.add_(1)
-            self.assertGreater(
-                torch.rbln.memory_allocated(0) - before,
-                0,
-                msg=f"advertised {dtype} is not resident in device memory",
-            )
+            if torch.rbln.memory_allocated(0) - before > 0:
+                resident.add(dtype)
             del scratch
+        self.assertEqual(
+            advertised,
+            resident,
+            msg=f"advertised dtypes {advertised} disagree with device-resident dtypes {resident}",
+        )
 
 
 class TestStorageResizeToZero(TestCase):

--- a/test/rbln/test_accelerator_contract.py
+++ b/test/rbln/test_accelerator_contract.py
@@ -69,6 +69,15 @@ class TestRblnMemoryHelpers(TestCase):
             torch.rbln.memory_stats(torch.rbln.device_count())  # first out-of-range index
 
     @pytest.mark.test_set_ci
+    def test_memory_stats_rejects_malformed_device_strings(self):
+        # torch's canonical device grammar rejects these; a bare partition(":") + int()
+        # would accept them (int() tolerates "+0"/"00"/" 0"/"0_0"), so "rbln:" typos must
+        # not silently resolve to the current device.
+        for bad in ("rbln:", "rbln:+0", "rbln:00", "rbln: 0", "rbln:0_0", "rbln:0:0"):
+            with self.assertRaises(ValueError, msg=f"{bad!r} was accepted as a valid device"):
+                torch.rbln.memory_stats(bad)
+
+    @pytest.mark.test_set_ci
     def test_memory_stats_rejects_int8_wrapped_index(self):
         # torch.device's index is an int8_t: raw 256 wraps to 0, 257 to 1, 255 to -1
         # (current device). Such values must be rejected from the original int/str, not

--- a/test/rbln/test_accelerator_contract.py
+++ b/test/rbln/test_accelerator_contract.py
@@ -33,19 +33,22 @@ class TestRblnMemoryHelpers(TestCase):
 
     @pytest.mark.test_set_ci
     def test_memory_helpers_match_stats_and_are_nonzero(self):
-        torch.rbln.empty_cache()
-        torch.rbln.reset_peak_memory_stats()
+        # Pin to device 0 explicitly. The helpers/reset default to the *current*
+        # device, which is not guaranteed to be 0 (another test may have changed it),
+        # so allocating on rbln:0 but querying no-arg would be flaky.
+        torch.rbln.empty_cache(0)
+        torch.rbln.reset_peak_memory_stats(0)
 
         keep = torch.randn(1024, 1024, device="rbln:0", dtype=torch.float16)
         _ = keep + keep
 
-        stats = torch.rbln.memory_stats()
-        self.assertEqual(torch.rbln.memory_allocated(), stats.get("allocated.current", 0))
-        self.assertEqual(torch.rbln.max_memory_allocated(), stats.get("allocated.peak", 0))
-        self.assertEqual(torch.rbln.memory_reserved(), stats.get("reserved.current", 0))
-        self.assertEqual(torch.rbln.max_memory_reserved(), stats.get("reserved.peak", 0))
+        stats = torch.rbln.memory_stats(0)
+        self.assertEqual(torch.rbln.memory_allocated(0), stats.get("allocated.current", 0))
+        self.assertEqual(torch.rbln.max_memory_allocated(0), stats.get("allocated.peak", 0))
+        self.assertEqual(torch.rbln.memory_reserved(0), stats.get("reserved.current", 0))
+        self.assertEqual(torch.rbln.max_memory_reserved(0), stats.get("reserved.peak", 0))
         # Regression: the CUDA-style key made these return 0 despite a live allocation.
-        self.assertGreater(torch.rbln.memory_allocated(), 0)
+        self.assertGreater(torch.rbln.memory_allocated(0), 0)
         del keep
 
     @pytest.mark.test_set_ci
@@ -66,20 +69,41 @@ class TestRblnMemoryHelpers(TestCase):
             torch.rbln.memory_stats(torch.rbln.device_count())  # first out-of-range index
 
     @pytest.mark.test_set_ci
-    def test_memory_stats_unqueryable_device_reports_zero_not_raise(self):
-        # CUDA parity: memory_stats() must not throw for a *valid* device index.
-        # The rbln runtime exposes per-node memory stats for node 0 only, so
-        # rbln_get_memory_stats() rejects any device index > 0 with
-        # INIT_INVALID_ARGUMENT (Invalid node_id) -- even for a device holding live
-        # memory. The backend absorbs that failure and reports zero stats instead of
-        # propagating, matching torch.cuda.memory_stats on an unqueryable device.
+    def test_memory_stats_uninitialized_device_reports_zero_not_raise(self):
+        # CUDA parity: memory_stats() must not throw for a *valid* device index this
+        # process has not allocated on. It reports zero (like torch.cuda.memory_stats
+        # on an uninitialized device) via the device_context_initialized gate, instead
+        # of hitting the runtime, whose per-node stats query rejects such a device
+        # (INIT_INVALID_ARGUMENT). (An *initialized* device index > 0 is a separate,
+        # runtime-limited case that still surfaces its error -- the runtime supports
+        # per-node stats for node 0 only -- so it is intentionally not asserted here.)
         count = torch.rbln.device_count()
         if count < 2:
-            self.skipTest("needs a device index > 0 to exercise the unqueryable path")
+            self.skipTest("needs a second, never-allocated device index")
+        # Highest index: not touched by other tests in this (single) worker process.
         idx = count - 1
         self.assertIsInstance(torch.rbln.memory_stats(idx), dict)  # must not raise
         self.assertEqual(torch.rbln.memory_allocated(idx), 0)
         self.assertEqual(torch.rbln.memory_reserved(idx), 0)
+
+    @pytest.mark.test_set_ci
+    def test_accelerator_memory_stats_uninitialized_device_reports_zero_not_raise(self):
+        # Same parity guarantee on the generic torch.accelerator path, which routes to
+        # the C10 getDeviceStats() hook -- a separate code path from
+        # torch.rbln.memory_stats(). An uninitialized valid device reports zero, not raise.
+        count = torch.rbln.device_count()
+        if count < 2:
+            self.skipTest("needs a second, never-allocated device index")
+        idx = count - 1
+        # The regression is that this raised INIT_INVALID_ARGUMENT; the guarantee is a
+        # clean return. An uninitialized device yields empty stats; any populated entry
+        # must be zero.
+        stats = torch.accelerator.memory_stats(idx)  # must not raise
+        self.assertIsInstance(stats, dict)
+        self.assertTrue(
+            all(v == 0 for v in stats.values() if isinstance(v, int)),
+            msg=f"expected zero stats for uninitialized rbln:{idx}, got nonzero entries",
+        )
 
 
 @pytest.mark.single_worker

--- a/test/rbln/test_accelerator_contract.py
+++ b/test/rbln/test_accelerator_contract.py
@@ -7,12 +7,14 @@ Covers:
   (``allocated.current`` etc.), not the CUDA-style ``allocated_bytes.all.current``.
 - Device-argument normalization (accept None/int/str/torch.device, reject
   non-rbln devices and out-of-range indices).
+- ``memory_stats()`` returning zero (not raising) for a valid but uninitialized
+  device index (CUDA parity).
 - ``torch.accelerator.get_device_capability()`` advertising the dtypes RBLN can
   allocate and type-convert on device (allocation + conversion, not native-op
   dispatch).
 - PrivateUse1 storage resize-to-zero.
-- ``torch.accelerator.empty_cache()`` (no device arg) spanning every
-  initialized device.
+- ``torch.accelerator.empty_cache()`` (no device arg) actually releasing cached
+  memory on the current device.
 """
 
 import pytest
@@ -63,6 +65,22 @@ class TestRblnMemoryHelpers(TestCase):
         with self.assertRaises(ValueError):
             torch.rbln.memory_stats(torch.rbln.device_count())  # first out-of-range index
 
+    @pytest.mark.test_set_ci
+    def test_memory_stats_unqueryable_device_reports_zero_not_raise(self):
+        # CUDA parity: memory_stats() must not throw for a *valid* device index.
+        # The rbln runtime exposes per-node memory stats for node 0 only, so
+        # rbln_get_memory_stats() rejects any device index > 0 with
+        # INIT_INVALID_ARGUMENT (Invalid node_id) -- even for a device holding live
+        # memory. The backend absorbs that failure and reports zero stats instead of
+        # propagating, matching torch.cuda.memory_stats on an unqueryable device.
+        count = torch.rbln.device_count()
+        if count < 2:
+            self.skipTest("needs a device index > 0 to exercise the unqueryable path")
+        idx = count - 1
+        self.assertIsInstance(torch.rbln.memory_stats(idx), dict)  # must not raise
+        self.assertEqual(torch.rbln.memory_allocated(idx), 0)
+        self.assertEqual(torch.rbln.memory_reserved(idx), 0)
+
 
 @pytest.mark.single_worker
 class TestDeviceCapability(TestCase):
@@ -102,11 +120,22 @@ class TestStorageResizeToZero(TestCase):
 
 @pytest.mark.single_worker
 class TestAcceleratorEmptyCache(TestCase):
-    """Device-less ``torch.accelerator.empty_cache()`` releases cached memory on
-    every initialized device — not just the current one, and not a no-op.
+    """Device-less ``torch.accelerator.empty_cache()`` actually releases cached
+    memory (it is not a no-op or a query-only stub).
 
     Single-worker: asserts on global reserved-memory changes, so it must not race
-    other workers' allocations."""
+    other workers' allocations.
+
+    Note: the all-devices span — ``empty_cache()`` walking *every* initialized
+    device, not just the current one — is intentionally not asserted here.
+    Confirming a non-current device was released means reading its reserved bytes,
+    but the rbln runtime's per-node memory-stats query only supports node 0:
+    ``memory_reserved(idx > 0)`` reports 0 for every device index > 0 (the runtime
+    rejects the query and the backend reports zero for CUDA parity — see
+    test_memory_stats_unqueryable_device_reports_zero_not_raise), even for a device
+    holding live memory. So the multi-device release is unobservable through the
+    stats API on current hardware; that loop stays covered by the C++ review of
+    RBLNAllocator::emptyCache()'s per-device iteration."""
 
     @staticmethod
     def _hold_then_free_reserved(device):
@@ -125,34 +154,6 @@ class TestAcceleratorEmptyCache(TestCase):
         # Must actually release the cached block; a no-op or query-only
         # implementation would leave reserved unchanged.
         self.assertLess(torch.rbln.memory_reserved("rbln:0"), reserved_cached)
-
-    @pytest.mark.test_set_ci
-    def test_empty_cache_spans_all_initialized_devices(self):
-        # The device-less form must walk *every* initialized device, so a
-        # current-device-only regression is caught. Needs >= 2 usable devices
-        # (multi-node hardware); degrades to skip on single-node hosts.
-        if torch.rbln.device_count() < 2:
-            self.skipTest("requires >= 2 rbln devices")
-        indices = (0, 1)
-        # Skip (don't fail) if a device isn't a usable memory node here (single-node
-        # boxes report count>=2 but only node 0 works); any other error propagates
-        # so a genuine regression isn't masked.
-        for idx in indices:
-            try:
-                torch.rbln.memory_stats(idx)
-            except RuntimeError as exc:
-                if "node_id" not in str(exc):
-                    raise
-                self.skipTest(f"rbln:{idx} is not a usable memory node on this host: {exc}")
-        # Regression surface below is unguarded.
-        reserved_cached = {idx: self._hold_then_free_reserved(idx) for idx in indices}
-        torch.accelerator.empty_cache()
-        for idx in indices:
-            self.assertLess(
-                torch.rbln.memory_reserved(idx),
-                reserved_cached[idx],
-                msg=f"empty_cache() did not release device {idx} (current-device-only regression)",
-            )
 
 
 if __name__ == "__main__":

--- a/test/rbln/test_accelerator_contract.py
+++ b/test/rbln/test_accelerator_contract.py
@@ -22,8 +22,12 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 import torch_rbln  # noqa: F401 -- registers the rbln device + torch.rbln namespace
 
 
+@pytest.mark.single_worker
 class TestRblnMemoryHelpers(TestCase):
-    """``torch.rbln.memory_*`` must read the RBLN allocator's dotted stat keys."""
+    """``torch.rbln.memory_*`` must read the RBLN allocator's dotted stat keys.
+
+    Single-worker: mutates the global allocator (empty_cache / peak reset) and
+    compares stats across calls, so it must not race other workers' allocations."""
 
     @pytest.mark.test_set_ci
     def test_memory_helpers_match_stats_and_are_nonzero(self):
@@ -60,20 +64,29 @@ class TestRblnMemoryHelpers(TestCase):
             torch.rbln.memory_stats(torch.rbln.device_count())  # first out-of-range index
 
 
+@pytest.mark.single_worker
 class TestDeviceCapability(TestCase):
-    """``torch.accelerator.get_device_capability()`` reports allocation/conversion dtypes."""
+    """``get_device_capability()`` reports dtypes resident in device memory
+    (fp16/bf16); other dtypes are CPU-backed even under device="rbln".
+    Single-worker: measures global device memory."""
 
     @pytest.mark.test_set_ci
-    def test_supported_dtypes_are_allocatable_and_convertible(self):
-        cap = torch.accelerator.get_device_capability()
-        self.assertIn("supported_dtypes", cap)
-        # Capability = dtypes RBLN can allocate and type-convert on device
-        # (per the upstream contract this is independent of native-op dispatch),
-        # matching the v2v/copy engine set (ENGINE_DTYPES in test/utils_v2v.py).
-        self.assertEqual(
-            set(cap["supported_dtypes"]),
-            {torch.float16, torch.bfloat16, torch.float32, torch.int32, torch.int64},
-        )
+    def test_capability_reports_device_resident_dtypes(self):
+        supported = torch.accelerator.get_device_capability()["supported_dtypes"]
+        self.assertEqual(set(supported), {torch.float16, torch.bfloat16})
+        # Each advertised dtype must actually occupy device memory (a compute op
+        # materializes it on the NPU); a CPU-backed dtype would report 0 bytes.
+        for dtype in supported:
+            torch.rbln.empty_cache()
+            before = torch.rbln.memory_allocated(0)
+            scratch = torch.empty(1024 * 1024, dtype=dtype, device="rbln:0")
+            scratch.add_(1)
+            self.assertGreater(
+                torch.rbln.memory_allocated(0) - before,
+                0,
+                msg=f"advertised {dtype} is not resident in device memory",
+            )
+            del scratch
 
 
 class TestStorageResizeToZero(TestCase):
@@ -90,7 +103,10 @@ class TestStorageResizeToZero(TestCase):
 @pytest.mark.single_worker
 class TestAcceleratorEmptyCache(TestCase):
     """Device-less ``torch.accelerator.empty_cache()`` releases cached memory on
-    every initialized device — not just the current one, and not a no-op."""
+    every initialized device — not just the current one, and not a no-op.
+
+    Single-worker: asserts on global reserved-memory changes, so it must not race
+    other workers' allocations."""
 
     @staticmethod
     def _hold_then_free_reserved(device):
@@ -118,12 +134,18 @@ class TestAcceleratorEmptyCache(TestCase):
         if torch.rbln.device_count() < 2:
             self.skipTest("requires >= 2 rbln devices")
         indices = (0, 1)
-        reserved_cached = {}
+        # Skip (don't fail) if a device isn't a usable memory node here (single-node
+        # boxes report count>=2 but only node 0 works); any other error propagates
+        # so a genuine regression isn't masked.
         for idx in indices:
             try:
-                reserved_cached[idx] = self._hold_then_free_reserved(idx)
-            except RuntimeError as exc:  # device not usable on this host
-                self.skipTest(f"rbln:{idx} memory ops unavailable: {exc}")
+                torch.rbln.memory_stats(idx)
+            except RuntimeError as exc:
+                if "node_id" not in str(exc):
+                    raise
+                self.skipTest(f"rbln:{idx} is not a usable memory node on this host: {exc}")
+        # Regression surface below is unguarded.
+        reserved_cached = {idx: self._hold_then_free_reserved(idx) for idx in indices}
         torch.accelerator.empty_cache()
         for idx in indices:
             self.assertLess(

--- a/test/rbln/test_accelerator_contract.py
+++ b/test/rbln/test_accelerator_contract.py
@@ -7,8 +7,9 @@ Covers:
   (``allocated.current`` etc.), not the CUDA-style ``allocated_bytes.all.current``.
 - Device-argument normalization (accept None/int/str/torch.device, reject
   non-rbln devices and out-of-range indices).
-- ``torch.accelerator.get_device_capability()`` advertising the natively
-  dispatched dtypes.
+- ``torch.accelerator.get_device_capability()`` advertising the dtypes RBLN can
+  allocate and type-convert on device (allocation + conversion, not native-op
+  dispatch).
 - PrivateUse1 storage resize-to-zero.
 - ``torch.accelerator.empty_cache()`` (no device arg) spanning every
   initialized device.
@@ -60,14 +61,19 @@ class TestRblnMemoryHelpers(TestCase):
 
 
 class TestDeviceCapability(TestCase):
-    """``torch.accelerator.get_device_capability()`` reports the native dtypes."""
+    """``torch.accelerator.get_device_capability()`` reports allocation/conversion dtypes."""
 
     @pytest.mark.test_set_ci
-    def test_supported_dtypes_are_native_floats(self):
+    def test_supported_dtypes_are_allocatable_and_convertible(self):
         cap = torch.accelerator.get_device_capability()
         self.assertIn("supported_dtypes", cap)
-        # RBLN dispatches fp16/bf16 natively; fallback-only dtypes are excluded.
-        self.assertEqual(set(cap["supported_dtypes"]), {torch.float16, torch.bfloat16})
+        # Capability = dtypes RBLN can allocate and type-convert on device
+        # (per the upstream contract this is independent of native-op dispatch),
+        # matching the v2v/copy engine set (ENGINE_DTYPES in test/utils_v2v.py).
+        self.assertEqual(
+            set(cap["supported_dtypes"]),
+            {torch.float16, torch.bfloat16, torch.float32, torch.int32, torch.int64},
+        )
 
 
 class TestStorageResizeToZero(TestCase):
@@ -81,19 +87,50 @@ class TestStorageResizeToZero(TestCase):
         self.assertEqual(storage.nbytes(), 0)
 
 
+@pytest.mark.single_worker
 class TestAcceleratorEmptyCache(TestCase):
-    """Device-less ``torch.accelerator.empty_cache()`` iterates all initialized devices."""
+    """Device-less ``torch.accelerator.empty_cache()`` releases cached memory on
+    every initialized device — not just the current one, and not a no-op."""
+
+    @staticmethod
+    def _hold_then_free_reserved(device):
+        # Allocate then free a large buffer. The caching allocator keeps the
+        # freed block as *reserved* (freeing alone does not return it to the
+        # runtime), so reserved stays high until empty_cache() releases it.
+        buf = torch.empty(16 * 1024 * 1024, device=device, dtype=torch.float16)  # 32 MiB
+        buf.add_(1.0)
+        del buf
+        return torch.rbln.memory_reserved(device)
 
     @pytest.mark.test_set_ci
-    def test_generic_empty_cache_runs(self):
-        # Materialize then free so the allocator holds cache, then call the
-        # device-less generic empty_cache: it walks every initialized device and
-        # must complete without error (with one device it iterates once).
-        scratch = torch.randn(512, 512, device="rbln:0", dtype=torch.float16)
-        _ = scratch + scratch
-        del scratch
+    def test_empty_cache_releases_current_device(self):
+        reserved_cached = self._hold_then_free_reserved("rbln:0")
         torch.accelerator.empty_cache()
-        self.assertGreaterEqual(torch.rbln.memory_reserved(), 0)
+        # Must actually release the cached block; a no-op or query-only
+        # implementation would leave reserved unchanged.
+        self.assertLess(torch.rbln.memory_reserved("rbln:0"), reserved_cached)
+
+    @pytest.mark.test_set_ci
+    def test_empty_cache_spans_all_initialized_devices(self):
+        # The device-less form must walk *every* initialized device, so a
+        # current-device-only regression is caught. Needs >= 2 usable devices
+        # (multi-node hardware); degrades to skip on single-node hosts.
+        if torch.rbln.device_count() < 2:
+            self.skipTest("requires >= 2 rbln devices")
+        indices = (0, 1)
+        reserved_cached = {}
+        for idx in indices:
+            try:
+                reserved_cached[idx] = self._hold_then_free_reserved(idx)
+            except RuntimeError as exc:  # device not usable on this host
+                self.skipTest(f"rbln:{idx} memory ops unavailable: {exc}")
+        torch.accelerator.empty_cache()
+        for idx in indices:
+            self.assertLess(
+                torch.rbln.memory_reserved(idx),
+                reserved_cached[idx],
+                msg=f"empty_cache() did not release device {idx} (current-device-only regression)",
+            )
 
 
 if __name__ == "__main__":

--- a/torch_rbln/memory.py
+++ b/torch_rbln/memory.py
@@ -40,18 +40,22 @@ def _normalize_device(device: Optional[Union[int, str, torch.device]]) -> torch.
     if isinstance(device, bool):  # bool is an int subclass; reject to avoid rbln:0/1 surprises
         raise TypeError(f"device must be None, int, str, or torch.device, not bool ({device!r})")
 
-    # Resolve the index as a Python int *before* building a torch.device. Its index field
-    # is an int8_t, so torch.device("rbln", 256) silently wraps to rbln:0 and would slip
-    # past the range check below. A torch.device passed in has already wrapped and cannot
-    # be recovered, so the raw int/str forms are validated from the original value here.
+    # torch.device's index field is an int8_t, so torch.device("rbln", 256) silently wraps
+    # to rbln:0 and would slip past the range check below. Read the index from the raw int
+    # or the original string suffix rather than a constructed device's .index. (A torch.device
+    # passed in has already wrapped and cannot be recovered, so it is validated as-is.)
     if isinstance(device, int):
         dtype, index = "rbln", device
     elif isinstance(device, str):
-        dtype, _, suffix = device.partition(":")
+        # torch.device validates the canonical grammar (rejects "rbln:", "rbln:00",
+        # "rbln: 0", "rbln:0_0", … that int() would silently accept); the index still
+        # comes from the raw suffix so "rbln:256" is range-checked, not wrap-normalized.
         try:
-            index = int(suffix) if suffix else None
-        except ValueError:
-            raise ValueError(f"Invalid rbln device string {device!r}") from None
+            dtype = torch.device(device).type
+        except RuntimeError:
+            raise ValueError(f"Invalid device string {device!r}") from None
+        _, sep, suffix = device.partition(":")
+        index = int(suffix) if sep else None
     elif isinstance(device, torch.device):
         dtype, index = device.type, device.index
     else:

--- a/torch_rbln/memory.py
+++ b/torch_rbln/memory.py
@@ -34,30 +34,34 @@ def _normalize_device(device: Optional[Union[int, str, torch.device]]) -> torch.
     ``None``, ``"rbln"``, and ``torch.device("rbln")`` resolve to the current
     device. A bare int is treated as an ``rbln`` index. Non-``rbln`` devices
     (``"cpu"``, ``"cuda:0"``, …) and out-of-range indices are rejected.
-
-    Args:
-        device: Device specification (int, str, torch.device, or None).
-
-    Returns:
-        torch.device: An ``rbln`` device with a concrete, in-range index.
     """
     if device is None:
         return torch.device("rbln", torch_rbln._C.current_device())
     if isinstance(device, bool):  # bool is an int subclass; reject to avoid rbln:0/1 surprises
         raise TypeError(f"device must be None, int, str, or torch.device, not bool ({device!r})")
+
+    # Resolve the index as a Python int *before* building a torch.device. Its index field
+    # is an int8_t, so torch.device("rbln", 256) silently wraps to rbln:0 and would slip
+    # past the range check below. A torch.device passed in has already wrapped and cannot
+    # be recovered, so the raw int/str forms are validated from the original value here.
     if isinstance(device, int):
-        dev = torch.device("rbln", device)
+        dtype, index = "rbln", device
     elif isinstance(device, str):
-        dev = torch.device(device)
+        dtype, _, suffix = device.partition(":")
+        try:
+            index = int(suffix) if suffix else None
+        except ValueError:
+            raise ValueError(f"Invalid rbln device string {device!r}") from None
     elif isinstance(device, torch.device):
-        dev = device
+        dtype, index = device.type, device.index
     else:
         raise TypeError(f"device must be None, int, str, or torch.device, got {type(device).__name__}")
 
-    if dev.type != "rbln":
-        raise ValueError(f"Expected an 'rbln' device, got '{dev.type}' (from {device!r})")
+    if dtype != "rbln":
+        raise ValueError(f"Expected an 'rbln' device, got '{dtype}' (from {device!r})")
+    if index is None:
+        index = torch_rbln._C.current_device()
 
-    index = dev.index if dev.index is not None else torch_rbln._C.current_device()
     # Only range-check when devices exist; on a no-device host callers no-op.
     count = torch_rbln._C.device_count()
     if count > 0 and not (0 <= index < count):
@@ -91,6 +95,10 @@ def empty_cache(device: Optional[Union[int, str, torch.device]] = None) -> None:
 
     This function releases cached memory blocks that are not currently in use,
     allowing them to be used by other applications or returned to the system.
+
+    Unlike the generic ``torch.accelerator.empty_cache()`` (which drains only the
+    caching allocator), this also drops the WarmCache and view-recipe caches, so it
+    releases everything the caller is not still holding.
 
     Args:
         device (Optional[Union[int, str, torch.device]]): The device to empty cache for.

--- a/torch_rbln/memory.py
+++ b/torch_rbln/memory.py
@@ -29,22 +29,40 @@ __all__ = [
 
 def _normalize_device(device: Optional[Union[int, str, torch.device]]) -> torch.device:
     """
-    Normalize device input to torch.device object.
+    Normalize a device argument to a concrete ``rbln`` ``torch.device``.
+
+    ``None``, ``"rbln"``, and ``torch.device("rbln")`` resolve to the current
+    device. A bare int is treated as an ``rbln`` index. Non-``rbln`` devices
+    (``"cpu"``, ``"cuda:0"``, …) and out-of-range indices are rejected.
 
     Args:
-        device: Device specification (int, str, torch.device, or None)
+        device: Device specification (int, str, torch.device, or None).
 
     Returns:
-        torch.device: Normalized device object
+        torch.device: An ``rbln`` device with a concrete, in-range index.
     """
     if device is None:
         return torch.device("rbln", torch_rbln._C.current_device())
-    elif isinstance(device, int):
-        return torch.device(f"rbln:{device}")
+    if isinstance(device, bool):  # bool is an int subclass; reject to avoid rbln:0/1 surprises
+        raise TypeError(f"device must be None, int, str, or torch.device, not bool ({device!r})")
+    if isinstance(device, int):
+        dev = torch.device("rbln", device)
     elif isinstance(device, str):
-        return torch.device(device)
+        dev = torch.device(device)
+    elif isinstance(device, torch.device):
+        dev = device
     else:
-        return device
+        raise TypeError(f"device must be None, int, str, or torch.device, got {type(device).__name__}")
+
+    if dev.type != "rbln":
+        raise ValueError(f"Expected an 'rbln' device, got '{dev.type}' (from {device!r})")
+
+    index = dev.index if dev.index is not None else torch_rbln._C.current_device()
+    # Only range-check when devices exist; on a no-device host callers no-op.
+    count = torch_rbln._C.device_count()
+    if count > 0 and not (0 <= index < count):
+        raise ValueError(f"rbln device index {index} is out of range [0, {count})")
+    return torch.device("rbln", index)
 
 
 def set_device_layout_like(target: torch.Tensor, ref: torch.Tensor) -> None:
@@ -104,15 +122,11 @@ def memory_stats(device: Optional[Union[int, str, torch.device]] = None) -> Dict
     """
     Return a dictionary of accelerator device memory allocator statistics.
 
-    The returned dictionary contains various memory statistics including:
-    - allocated_bytes: current, peak, allocated, freed
-    - reserved_bytes: current, peak, allocated, freed
-    - active_bytes: current, peak
-    - cached_bytes: current, peak
-    - num_alloc_retries: number of allocation retries
-    - num_ooms: number of out-of-memory errors
-    - num_device_alloc: number of device allocations
-    - num_device_free: number of device frees
+    The returned dictionary contains various memory statistics. Keys are the
+    RBLN allocator's dotted names, e.g.:
+    - allocated.current, allocated.peak, allocated.total_allocated, allocated.total_freed
+    - reserved.current, reserved.peak, reserved.total_allocated, reserved.total_freed
+    - active.current, active.peak
 
     Args:
         device (Optional[Union[int, str, torch.device]]): The device to query.
@@ -139,7 +153,7 @@ def memory_allocated(device: Optional[Union[int, str, torch.device]] = None) -> 
     Returns:
         int: The current memory allocated in bytes.
     """
-    return memory_stats(device).get("allocated_bytes.all.current", 0)
+    return memory_stats(device).get("allocated.current", 0)
 
 
 def max_memory_allocated(device: Optional[Union[int, str, torch.device]] = None) -> int:
@@ -153,7 +167,7 @@ def max_memory_allocated(device: Optional[Union[int, str, torch.device]] = None)
     Returns:
         int: The maximum memory allocated in bytes.
     """
-    return memory_stats(device).get("allocated_bytes.all.peak", 0)
+    return memory_stats(device).get("allocated.peak", 0)
 
 
 def memory_reserved(device: Optional[Union[int, str, torch.device]] = None) -> int:
@@ -167,7 +181,7 @@ def memory_reserved(device: Optional[Union[int, str, torch.device]] = None) -> i
     Returns:
         int: The current memory reserved in bytes.
     """
-    return memory_stats(device).get("reserved_bytes.all.current", 0)
+    return memory_stats(device).get("reserved.current", 0)
 
 
 def max_memory_reserved(device: Optional[Union[int, str, torch.device]] = None) -> int:
@@ -181,7 +195,7 @@ def max_memory_reserved(device: Optional[Union[int, str, torch.device]] = None) 
     Returns:
         int: The maximum memory reserved in bytes.
     """
-    return memory_stats(device).get("reserved_bytes.all.peak", 0)
+    return memory_stats(device).get("reserved.peak", 0)
 
 
 def reset_accumulated_memory_stats(device: Optional[Union[int, str, torch.device]] = None) -> None:


### PR DESCRIPTION
## Summary

`torch.accelerator` / `torch.rbln` backend-contract fixes, grouped because each is small and adjacent and they share one test file. Merged with `dev` (picks up the empty-AMP-catalog change, #157).

## Fixes

- **Memory-stat keys** — `torch.rbln.memory_{allocated,reserved}` (+ `max_` variants) read the allocator's dotted keys (`allocated.current`, `reserved.current`, `.peak`) instead of the CUDA-style `allocated_bytes.all.current` the allocator never emits (they had returned `0` with a live allocation). `_normalize_device` accepts `None`/`int`/`str`/`torch.device`, maps `"rbln"`/`None` to the current device, and rejects non-rbln / out-of-range devices.
- **`memory_stats` CUDA parity** — `memory_stats()` / `get_device_stats()` must not throw for a *valid* device index. A device this process has not allocated on now reports **empty/zero** stats via the `device_context_initialized()` gate (matching PyTorch's generic path, which returns empty only for an uninitialized allocator) instead of propagating the runtime's `INIT_INVALID_ARGUMENT`. An *initialized* device still queries the runtime, so genuine failures surface — it is **not** a blanket catch.
  - **Known limitation (runtime-side):** the rbln runtime's `rbln_get_memory_stats()` exposes per-node stats for **node 0 only**, so an *initialized* device index `> 0` still raises. Fixing that is a runtime change; the backend does not fabricate zeros for it.
- **All-device `empty_cache`** — device-less `torch.accelerator.empty_cache()` flushes every initialized device (CUDA/XPU parity). Device selection is a tested seam, `c10::rbln::initialized_device_indices()`. `torch.rbln.empty_cache(device)` keeps per-device semantics.
- **`get_device_capability`** — reports the dtypes resident in device memory (fp16/bf16). Range-checks the requested index.
- **Storage resize-to-zero** — `resizePrivateUse1Bytes()` accepts `new_nbytes == 0` (e.g. `untyped_storage().resize_(0)`).

## Tests

- `test/rbln/test_accelerator_contract.py` — memory-stat keys, device normalization, `memory_stats`/`torch.accelerator.memory_stats` zero-not-raise on an uninitialized device (both code paths), capability, resize, empty_cache-is-not-a-no-op (device 0).
- `test/cpp/core/RBLNAllocatorTest.cpp` — `EmptyCacheSpansNonCurrentInitializedDevice` guards the all-device selection (a current-device-only regression would drop non-current devices); per-device release is unobservable via stats (runtime node-0-only), so the selection is asserted.

Draft until the device-gated (`@pytest.mark.test_set_ci`) CI is green. Python + C++ lint clean.
