### PR TITLE
test(distributed): skip test_tp_pp_autoport.py on ATOM devices

### DIFF
--- a/test/distributed/test_tp_pp_autoport.py
+++ b/test/distributed/test_tp_pp_autoport.py
@@ -19,6 +19,8 @@ import pytest
 import torch
 from torch.testing._internal.common_utils import run_tests, TestCase
 
+from test.utils import is_atom_device
+
 
 _TARGET_MODULE = "test.distributed.test_tp_pp"
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -51,6 +53,10 @@ def _invoke_test_tp_pp(env_overrides: dict) -> subprocess.CompletedProcess:
 
 @pytest.mark.test_set_ci
 @pytest.mark.single_worker
+@pytest.mark.skipif(
+    is_atom_device(),
+    reason="autoport concurrency path is REBEL-only; ATOM does not run the RCCL RDMA autoport init",
+)
 class TestTPPPAutoportConcurrent(TestCase):
     """Run test_tp_pp.py concurrently on two disjoint device partitions."""
 


### PR DESCRIPTION
## Summary of Changes

Gate ``test/distributed/test_tp_pp_autoport.py``
(``TestTPPPAutoportConcurrent``) to run on REBEL devices only. By
policy, the RCCL autoport concurrency smoke test is scoped to the
REBEL lineup; on ATOM it now cleanly skips instead of executing.

Concrete change: add
``@pytest.mark.skipif(is_atom_device(), reason=...)`` to the test
class, alongside the existing ``@pytest.mark.test_set_ci`` and
``@pytest.mark.single_worker`` marks. The 8-device requirement
inside the test method is unchanged, so REBEL hosts with fewer
devices still get the existing skip.

### Why not delete the file?

An earlier draft deleted the whole test. Feedback: keep the coverage
for REBEL; only exclude ATOM. This PR is the smallest edit that
implements that policy.

### Behavior matrix

| Host arch | Devices >= 8 | Result |
|-----------|---:|---|
| REBEL     | yes | runs |
| REBEL     | no  | skipped (existing device-count check) |
| ATOM      | any | skipped (new class-level skipif) |
| unknown / no NPU | any | skipped (device-count check; ``is_atom_device()`` is ``False`` so the class marker is inert, then the method-level guard fires) |

``is_atom_device()`` is safe to call at import time even on hosts
without an NPU: internally it wraps ``rebel.device_info.get_npu_name``
in a broad ``try/except`` and returns ``False`` on failure
(``get_device_arch() == "unknown"``).

---

## Related Issues / Tickets

* Related to prior autoport work (#73)

---

## Type of Change

- [x] ``test`` -- Narrow the arch scope of an existing test
- [ ] ``feature``
- [ ] ``core``
- [ ] ``fix``
- [ ] ``perf``
- [ ] ``refactor``
- [ ] ``docs``

---

## Affected Modules

- [x] Tests only (``test/distributed/test_tp_pp_autoport.py``)

---

## How to Test

1. On a REBEL host with >= 8 devices:
   ``pytest test/distributed/test_tp_pp_autoport.py``
   → collects and runs ``TestTPPPAutoportConcurrent.test_autoport_concurrent_device_split``.
2. On an ATOM host:
   ``pytest test/distributed/test_tp_pp_autoport.py``
   → collected but skipped with the reason string
   ``"autoport concurrency path is REBEL-only; ATOM does not run the RCCL RDMA autoport init"``.
3. Lintrunner:
   ``lintrunner --paths-cmd='git diff --name-only origin/dev'`` -> clean.

---

## Checklist

* [x] PR title follows Conventional Commits format
* [ ] This PR is linked to a corresponding issue
* [x] Linting passes
* [ ] All CI tests pass
* [x] The test method is described, and the expected result is clearly stated

---

## Notes

- No production code paths change.
- If ATOM later gains RCCL autoport support, dropping this skipif is
  the only revert step needed.