### PR TITLE
feat(index): native v2v fast-path for aten::index.Tensor

### DIFF
--- a/aten/src/ATen/native/RBLNRegisterOps.cpp
+++ b/aten/src/ATen/native/RBLNRegisterOps.cpp
@@ -144,6 +144,8 @@ TORCH_LIBRARY_IMPL(aten, PrivateUse1, m) {
   m.impl("index_select", TORCH_FN(at::native::rbln::index_select_rbln));
   m.impl("index_select.out", TORCH_FN(at::native::rbln::index_select_out_rbln));
   m.impl("index_copy.out", TORCH_FN(at::native::rbln::index_copy_out_rbln));
+  // Native for a single index on one axis (== index_select); other forms fall back to CPU inside the kernel.
+  m.impl("index.Tensor_out", torch::CppFunction::makeFromBoxedFunction<&at::native::rbln::index_out_rbln>());
   m.impl("repeat_interleave.Tensor", TORCH_FN(at::native::rbln::repeat_interleave_Tensor_rbln));
   m.impl("cat.out", TORCH_FN(at::native::rbln::cat_out_rbln));
 
@@ -199,7 +201,6 @@ TORCH_LIBRARY_IMPL(aten, PrivateUse1, m) {
   m.impl("masked_select", torch::CppFunction::makeFromBoxedFunction<&fallback_rbln>());
   m.impl("masked_select.out", torch::CppFunction::makeFromBoxedFunction<&fallback_rbln>());
   m.impl("masked_scatter_", torch::CppFunction::makeFromBoxedFunction<&fallback_rbln>());
-  m.impl("index.Tensor_out", torch::CppFunction::makeFromBoxedFunction<&fallback_rbln>());
   m.impl("_index_put_impl_", torch::CppFunction::makeFromBoxedFunction<&fallback_rbln>());
   m.impl("index_add.out", torch::CppFunction::makeFromBoxedFunction<&fallback_rbln>());
   m.impl("index_fill_.int_Scalar", torch::CppFunction::makeFromBoxedFunction<&fallback_rbln>());

--- a/aten/src/ATen/native/rbln/RBLNTensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/rbln/RBLNTensorAdvancedIndexing.cpp
@@ -232,11 +232,13 @@ void index_out_rbln(const c10::OperatorHandle& op, torch::jit::Stack* stack) {
       fast = true;
     }
 
-    // Take the fast path only when `out` already has the exact shape aten::index
-    // would produce — the structured .out contract may otherwise require a resize
-    // that only the CPU fallback performs. `out` is contiguous, so a view with
-    // `axis` flattened aliases it and index_select writes into its storage.
-    if (fast && out.defined() && out.is_contiguous() && out.sizes().equals(expected)) {
+    // Fast path only when `out` already has the shape aten::index would produce —
+    // a mismatch means the .out contract wants a resize only the fallback does.
+    // `out` may be non-contiguous: a transposed / permuted N-D index makes the
+    // functional wrapper allocate it with the index's strides. Contiguous `out` is
+    // written in place (a flattened-axis view aliases its storage); otherwise the
+    // gather goes to a contiguous staging buffer copied into `out`'s layout.
+    if (fast && out.defined() && out.sizes().equals(expected)) {
       // Advanced indexing raises IndexError (not a plain RuntimeError) when an
       // index is out of range; match that before delegating to index_select.
       TORCH_CHECK_INDEX(
@@ -248,8 +250,16 @@ void index_out_rbln(const c10::OperatorHandle& op, torch::jit::Stack* stack) {
           self.size(axis));
       std::vector<int64_t> vshape = self.sizes().vec();
       vshape[axis] = flat_idx.numel();
-      at::Tensor out_view = out.view(vshape);
-      index_select_out_rbln(self, axis, flat_idx, out_view);
+      if (out.is_contiguous()) {
+        at::Tensor out_view = out.view(vshape);
+        index_select_out_rbln(self, axis, flat_idx, out_view);
+      } else {
+        // Gather into a contiguous buffer, then copy into `out`'s strided layout
+        // (mirrors index_select_out_rbln's own non-contig handling).
+        at::Tensor staging = at::empty(vshape, out.options().memory_format(c10::MemoryFormat::Contiguous));
+        index_select_out_rbln(self, axis, flat_idx, staging);
+        out.copy_(staging.view(expected));
+      }
       torch::jit::drop(*stack, static_cast<size_t>(num_args));
       torch::jit::push(*stack, std::move(out));
       return;

--- a/aten/src/ATen/native/rbln/RBLNTensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/rbln/RBLNTensorAdvancedIndexing.cpp
@@ -2,13 +2,17 @@
 
 #include <ATen/MemoryOverlap.h>
 #include <ATen/core/Tensor.h>
+#include <ATen/core/stack.h> // torch::jit::drop / push
 #include <ATen/native/Resize.h>
+#include <ATen/native/rbln/RBLNCPUFallback.h>
 #include <ATen/native/rbln/RBLNIndexUtils.h>
 #include <ATen/native/rbln/RBLNStridedV2V.h>
 #include <ATen/native/rbln/RBLNTensorUtils.h>
 #include <ATen/ops/empty.h>
 #include <ATen/ops/index_copy.h>
 #include <ATen/ops/index_select.h>
+#include <ATen/ops/nonzero.h>
+#include <ATen/ops/where.h>
 #include <c10/rbln/RBLNFallbackConfig.h>
 #include <c10/rbln/RBLNLogging.h>
 #include <c10/rbln/RBLNV2VBatch.h>
@@ -138,6 +142,123 @@ at::Tensor index_select_rbln(const at::Tensor& self, int64_t dim, const at::Tens
 
   at::Tensor out = at::empty(out_shape, self.options().memory_format(c10::MemoryFormat::Contiguous));
   return index_select_out_rbln(self, dim, index, out);
+}
+
+// ===========================================================================
+// index.Tensor_out (advanced indexing) — native white-list fast-path
+// ===========================================================================
+//
+// White-list = a SINGLE index on one axis (all other slots `None`), which is a
+// plain on-device gather: each output element is a contiguous slice of `self`,
+// so the whole thing reduces to `self.index_select(axis, flat_idx)` (native
+// v2v) and writes straight into the pre-allocated `out`:
+//   - integer index of rank >= 1 (1-D / N-D): `flat_idx = idx.reshape(-1)`;
+//     `out` is `self`'s shape with `axis` replaced by `idx`'s shape, so viewing
+//     it with `axis` flattened is exactly the index_select output. (A 0-D index
+//     does not reach here — `x[scalar]` decomposes to select upstream.)
+//   - 1-D boolean mask over `axis`: `flat_idx` = its True positions.
+//
+// The fast path is taken only when `out` already has the exact expected shape
+// (else the resize the .out contract may require is left to the fallback).
+//
+// Everything else (multiple index tensors, N-D / non-leading masks, broadcasting,
+// non-contiguous `self`) stays on the CPU fallback. Boxed so that path can reuse
+// `cpu_fallback_rbln`. The functional `index.Tensor` (`x[idx]`) reaches this via
+// the CompositeExplicitAutogradNonFunctional out wrapper.
+void index_out_rbln(const c10::OperatorHandle& op, torch::jit::Stack* stack) {
+  // aten::index.Tensor_out(Tensor self, Tensor?[] indices, *, Tensor(a!) out)
+  const int64_t num_args = static_cast<int64_t>(op.schema().arguments().size());
+  const int64_t base = static_cast<int64_t>(stack->size()) - num_args;
+  const at::Tensor self = (*stack)[base].toTensor();
+  const c10::List<c10::optional<at::Tensor>> indices = (*stack)[base + 1].toOptionalTensorList();
+
+  // Find the single non-None index and its axis (its position in `indices` is
+  // the indexed dim; leading `None`s shift it, e.g. `x[:, idx]` -> axis 1).
+  int64_t axis = -1;
+  int64_t num_present = 0;
+  for (size_t i = 0; i < indices.size(); ++i) {
+    const c10::optional<at::Tensor> e = indices.get(i);
+    if (e.has_value() && e->defined()) {
+      ++num_present;
+      axis = static_cast<int64_t>(i);
+    }
+  }
+
+  // `self.numel() > 0`: an empty `self` (some dim is 0) makes advanced indexing a
+  //   no-op that skips bounds checks (e.g. empty(3,0)[[3]] -> (1,0), no IndexError);
+  //   leave that to the fallback rather than replicate the special case.
+  // `indices.size() <= self.dim()`: more index slots than dims is "too many
+  //   indices" (IndexError); the fallback raises it correctly.
+  const bool eligible = num_present == 1 && self.defined() && self.numel() > 0 && self.device().is_privateuseone() &&
+      self.is_contiguous() && static_cast<int64_t>(indices.size()) <= self.dim() && axis >= 0 && axis < self.dim();
+
+  if (eligible) {
+    const at::Tensor idx = indices.get(axis).value();
+    at::Tensor out = (*stack)[base + 2].toTensor();
+    const auto st = idx.scalar_type();
+
+    // Build the 1-D integer index along `axis` (host-side: the index is tiny and
+    // index_select copies it to host anyway, so no net v2h added) together with
+    // the exact output shape aten::index.Tensor must produce for this form.
+    at::Tensor flat_idx;
+    std::vector<int64_t> expected;
+    bool fast = false;
+    if ((st == at::kLong || st == at::kInt) && idx.dim() >= 1) {
+      // integer index of rank >= 1: out = self[:axis] + idx.shape + self[axis+1:]
+      // (a 0-D index does not reach here — it decomposes to select upstream).
+      flat_idx = idx.reshape({-1});
+      // Host-side and widened to int64: the negative-wrap add and the bounds
+      // compare below must not overflow int32 when an axis exceeds INT32_MAX.
+      flat_idx = (flat_idx.is_cpu() ? flat_idx.contiguous() : flat_idx.cpu().contiguous()).to(at::kLong);
+      // advanced indexing wraps negatives; index_select does not.
+      if (flat_idx.numel() > 0 && flat_idx.lt(0).any().item<bool>())
+        flat_idx = at::where(flat_idx.lt(0), flat_idx + self.size(axis), flat_idx);
+      for (int64_t d = 0; d < axis; ++d)
+        expected.push_back(self.size(d));
+      for (int64_t d = 0; d < idx.dim(); ++d)
+        expected.push_back(idx.size(d));
+      for (int64_t d = axis + 1; d < self.dim(); ++d)
+        expected.push_back(self.size(d));
+      fast = true;
+    } else if (st == at::kBool && idx.dim() == 1 && idx.size(0) == self.size(axis)) {
+      // 1-D boolean mask over `axis`: out = self[:axis] + (K,) + self[axis+1:]
+      const at::Tensor mask_cpu = idx.is_cpu() ? idx.contiguous() : idx.cpu().contiguous();
+      flat_idx = mask_cpu.nonzero().squeeze(-1); // True positions -> (K,)
+      for (int64_t d = 0; d < axis; ++d)
+        expected.push_back(self.size(d));
+      expected.push_back(flat_idx.numel());
+      for (int64_t d = axis + 1; d < self.dim(); ++d)
+        expected.push_back(self.size(d));
+      fast = true;
+    }
+
+    // Take the fast path only when `out` already has the exact shape aten::index
+    // would produce — the structured .out contract may otherwise require a resize
+    // that only the CPU fallback performs. `out` is contiguous, so a view with
+    // `axis` flattened aliases it and index_select writes into its storage.
+    if (fast && out.defined() && out.is_contiguous() && out.sizes().equals(expected)) {
+      // Advanced indexing raises IndexError (not a plain RuntimeError) when an
+      // index is out of range; match that before delegating to index_select.
+      TORCH_CHECK_INDEX(
+          flat_idx.numel() == 0 ||
+              (flat_idx.ge(0).all().item<bool>() && flat_idx.lt(self.size(axis)).all().item<bool>()),
+          "index out of bounds for dimension ",
+          axis,
+          " with size ",
+          self.size(axis));
+      std::vector<int64_t> vshape = self.sizes().vec();
+      vshape[axis] = flat_idx.numel();
+      at::Tensor out_view = out.view(vshape);
+      index_select_out_rbln(self, axis, flat_idx, out_view);
+      torch::jit::drop(*stack, static_cast<size_t>(num_args));
+      torch::jit::push(*stack, std::move(out));
+      return;
+    }
+  }
+
+  // Not white-listed -> identical to the previous (pre-kernel) behaviour.
+  c10::rbln::log_cpu_fallback(op.schema().name());
+  at::native::rbln::cpu_fallback_rbln(op, stack);
 }
 
 // ===========================================================================

--- a/aten/src/ATen/native/rbln/RBLNTensorAdvancedIndexing.h
+++ b/aten/src/ATen/native/rbln/RBLNTensorAdvancedIndexing.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ATen/core/Tensor.h>
+#include <ATen/native/CPUFallback.h> // c10::OperatorHandle, torch::jit::Stack
 
 // Mirrors aten/src/ATen/native/TensorAdvancedIndexing.cpp upstream — the file
 // that hosts index_select / index_copy / index_add / index_put / gather /
@@ -24,6 +25,17 @@ at::Tensor& index_select_out_rbln(
 
 /// Non-out overload: allocates a fresh contiguous output and delegates.
 at::Tensor index_select_rbln(const at::Tensor& self, int64_t dim, const at::Tensor& index);
+
+// ---------------------------------------------------------------------------
+// index.Tensor_out (advanced indexing) — native white-list fast-path
+//
+// Boxed kernel: runs natively (via index_select) for a SINGLE index on one axis
+// — an integer index of any rank, or a 1-D boolean mask — and falls back to CPU
+// for every other form (multiple indices, non-leading masks, non-contiguous
+// self). See the .cpp.
+// ---------------------------------------------------------------------------
+
+void index_out_rbln(const c10::OperatorHandle& op, torch::jit::Stack* stack);
 
 // ---------------------------------------------------------------------------
 // index_copy

--- a/test/filters.py
+++ b/test/filters.py
@@ -116,9 +116,11 @@ _ops_with_public_api_name_mismatch = [
 
 # Ops with a native RBLN kernel that are not declared in our native_functions.yaml
 # (the kernels are registered manually in RBLNRegisterOps.cpp). Hardcoded so opinfo
-# discovery picks them up.
+# discovery picks them up. ``__getitem__`` is the upstream OpInfo that exercises
+# aten::index.Tensor (advanced indexing) — the op served by index_out_rbln.
 _ops_with_rbln_native_kernel = [
     "cat",
+    "__getitem__",
     "index_copy",
     "index_select",
     "repeat_interleave",

--- a/test/rbln/test_cat_index_select_v2v.py
+++ b/test/rbln/test_cat_index_select_v2v.py
@@ -702,6 +702,32 @@ class TestIndexTensorV2V(TestCase):
         idx2d = torch.tensor([[0, 2], [1, 0]], dtype=torch.long)
         _check(to_dev(src)[:, idx2d.to(DEVICE)], src[:, idx2d])
 
+    # -- white-listed native path: transposed / permuted N-D index -------------
+    # A non-contiguous index makes the wrapper hand the kernel a non-contig `out`;
+    # the native path must still gather (via a staging buffer) rather than fall back.
+
+    def test_index_nd_integer_transposed(self):
+        src = torch.arange(30, dtype=torch.float32).reshape(5, 6)
+        idx = torch.tensor([[1, 2], [3, 0], [2, 4]], dtype=torch.long)
+        idx_t = idx.t()  # (2, 3), non-contiguous -> non-contig result `out`
+        assert not src[idx_t].is_contiguous(), "test must exercise a non-contig out"
+        _check(to_dev(src)[idx.to(DEVICE).t()], src[idx_t])
+
+    def test_index_nd_integer_permuted(self):
+        src = torch.arange(10, dtype=torch.float32)
+        idx = (torch.arange(24, dtype=torch.long) % 10).reshape(2, 3, 4)
+        idx_p = idx.permute(2, 0, 1)  # (4, 2, 3), non-contiguous
+        assert not src[idx_p].is_contiguous(), "test must exercise a non-contig out"
+        _check(to_dev(src)[idx.to(DEVICE).permute(2, 0, 1)], src[idx_p])
+
+    def test_index_nd_integer_transposed_mid_axis(self):
+        """`x[:, idx_t]` — transposed N-D index on a non-leading axis."""
+        src = torch.arange(4 * 6, dtype=torch.float32).reshape(4, 6)
+        idx = torch.tensor([[1, 2, 0], [3, 0, 5]], dtype=torch.long)
+        idx_t = idx.t()  # (3, 2), non-contiguous
+        assert not src[:, idx_t].is_contiguous(), "test must exercise a non-contig out"
+        _check(to_dev(src)[:, idx.to(DEVICE).t()], src[:, idx_t])
+
     # -- white-listed native path: 1-D boolean mask ----------------------------
 
     def test_index_bool_mask(self):
@@ -775,6 +801,18 @@ class TestIndexTensorV2V(TestCase):
         r = torch.tensor([0, 2, 4]).to(DEVICE)
         c = torch.tensor([1, 3, 5]).to(DEVICE)
         self.assertFalse(self._ran_native_gather(lambda: to_dev(src)[r, c]))
+
+    def test_index_transposed_nd_routes_native_via_staging(self):
+        """A transposed N-D index makes the wrapper allocate a non-contiguous
+        `out`; the native path must gather into a staging buffer rather than fall
+        back. Asserting the result is non-contig AND the native primitive ran pins
+        down the staging branch specifically."""
+        src = torch.arange(30, dtype=torch.float16).reshape(5, 6)
+        idx = torch.tensor([[1, 2], [3, 0], [2, 4]], dtype=torch.long)
+        assert not src[idx.t()].is_contiguous(), "test must exercise a non-contig out"
+        got = to_dev(src)[idx.to(DEVICE).t()]
+        self.assertFalse(got.is_contiguous(), "a non-contig out must reach the kernel")
+        self.assertTrue(self._ran_native_gather(lambda: to_dev(src)[idx.to(DEVICE).t()]))
 
 
 instantiate_device_type_tests(TestCatV2V, globals(), only_for="privateuse1")

--- a/test/rbln/test_cat_index_select_v2v.py
+++ b/test/rbln/test_cat_index_select_v2v.py
@@ -603,8 +603,183 @@ class TestIndexSelectV2V(TestCase):
             torch.index_select(to_dev(a_cpu), 0, bad_idx)
 
 
+# ---------------------------------------------------------------------------
+# index.Tensor (advanced indexing)
+#
+# `x[idx]` lowers to aten::index.Tensor and reaches the native `index.Tensor_out`
+# kernel through the composite out wrapper. The kernel serves any SINGLE index on
+# one axis natively (via the v2v index_select) — an integer index of any rank, or
+# a 1-D boolean mask — and hands every other form (multiple index tensors,
+# non-leading masks, non-contiguous self) to the CPU fallback. Both paths must
+# match the CPU reference bit-for-bit.
+# ---------------------------------------------------------------------------
+
+
+def _index_at_axis(x: torch.Tensor, axis: int, idx: torch.Tensor) -> torch.Tensor:
+    """`x[:, ..., idx, ...]` with `idx` placed on `axis` (all other slots full)."""
+    a = axis % x.dim()
+    key: list = [slice(None)] * a + [idx]
+    return x[tuple(key)]
+
+
+@pytest.mark.test_set_ci
+@pytest.mark.usefixtures("enable_deploy_mode")
+class TestIndexTensorV2V(TestCase):
+    """Tests for the native `aten::index.Tensor` white-list fast-path (a single
+    index on one axis -> v2v `index_select`) and its CPU fallback for the
+    non-white-listed advanced-indexing forms."""
+
+    def _check_bracket(self, src_cpu: torch.Tensor, idx: torch.Tensor) -> None:
+        """`src[idx]` on device (idx on CPU) vs the CPU reference."""
+        _check(to_dev(src_cpu)[idx], src_cpu[idx])
+
+    def _ran_native_gather(self, fn) -> bool:
+        """Whether `fn` ran the native v2v index_select gather rather than the CPU
+        fallback. index.Tensor_out is registered, so the dispatch-shim fallback
+        counter never fires for it and gives no routing signal; we instead probe
+        the runtime primitive the native gather emits (`v2v_multi`). This is an
+        implementation-detail signal, used only to guard against a silent
+        regression back to the fallback."""
+        with torch.rbln.explain() as p:
+            fn()
+        return "v2v_multi" in p.dump().get("rebel_runtime", {}).get("by_primitive", {})
+
+    # -- white-listed native path: single 1-D integer index --------------------
+
+    @dtypes(torch.float16, torch.bfloat16, torch.float32, torch.int32)
+    def test_index_basic_dim0(self, dtype):
+        src = torch.arange(30, dtype=dtype).reshape(5, 6)
+        self._check_bracket(src, torch.tensor([3, 0, 4, 1], dtype=torch.long))
+
+    @parametrize("axis", [0, 1, 2, -1])
+    def test_index_all_dims(self, axis):
+        src = torch.arange(2 * 3 * 4, dtype=torch.float32).reshape(2, 3, 4)
+        idx = torch.tensor([1, 0, 1], dtype=torch.long)
+        _check(_index_at_axis(to_dev(src), axis, idx), _index_at_axis(src, axis, idx))
+
+    def test_index_scattered(self):
+        src = torch.arange(100, dtype=torch.float32).reshape(10, 10)
+        self._check_bracket(src, torch.tensor([7, 2, 9, 0, 5, 5, 7], dtype=torch.long))
+
+    def test_index_consecutive(self):
+        src = torch.arange(8 * 16, dtype=torch.bfloat16).reshape(8, 16)
+        self._check_bracket(src, torch.arange(3, dtype=torch.long))
+
+    def test_index_empty(self):
+        src = torch.arange(20, dtype=torch.float32).reshape(4, 5)
+        self._check_bracket(src, torch.tensor([], dtype=torch.long))
+
+    def test_index_negative_wrap(self):
+        """Advanced indexing wraps negatives; the kernel must match (it normalises
+        before delegating to index_select, which rejects negatives)."""
+        src = torch.arange(30, dtype=torch.float32).reshape(5, 6)
+        self._check_bracket(src, torch.tensor([-1, -5, 2, -2], dtype=torch.long))
+
+    def test_index_int32(self):
+        src = torch.arange(30, dtype=torch.float32).reshape(5, 6)
+        self._check_bracket(src, torch.tensor([4, 0, 2], dtype=torch.int32))
+
+    def test_index_idx_on_device(self):
+        src = torch.arange(30, dtype=torch.float32).reshape(5, 6)
+        idx = torch.tensor([4, 0, 2], dtype=torch.long)
+        _check(to_dev(src)[idx.to(DEVICE)], src[idx])
+
+    def test_index_repeat(self):
+        src = torch.arange(20, dtype=torch.float16).reshape(4, 5)
+        self._check_bracket(src, torch.tensor([2, 2, 2, 2], dtype=torch.long))
+
+    # -- white-listed native path: N-D and 0-D integer index -------------------
+
+    def test_index_nd_integer(self):
+        """N-D integer index: out = idx.shape + self.shape[1:] (flatten -> gather
+        -> reshape). Includes a repeat to exercise the flattened gather."""
+        src = torch.arange(30, dtype=torch.float32).reshape(5, 6)
+        idx2d = torch.tensor([[1, 2], [3, 0], [2, 2]], dtype=torch.long)
+        self._check_bracket(src, idx2d)
+
+    def test_index_nd_integer_mid_axis(self):
+        src = torch.arange(2 * 3 * 4, dtype=torch.float32).reshape(2, 3, 4)
+        idx2d = torch.tensor([[0, 2], [1, 0]], dtype=torch.long)
+        _check(to_dev(src)[:, idx2d.to(DEVICE)], src[:, idx2d])
+
+    # -- white-listed native path: 1-D boolean mask ----------------------------
+
+    def test_index_bool_mask(self):
+        src = torch.arange(30, dtype=torch.float32).reshape(5, 6)
+        mask = torch.tensor([True, False, True, False, True])
+        _check(to_dev(src)[mask.to(DEVICE)], src[mask])
+
+    def test_index_bool_mask_mid_axis(self):
+        """`x[:, mask]` — 1-D mask over a non-leading axis."""
+        src = torch.arange(30, dtype=torch.float32).reshape(5, 6)
+        mask = torch.tensor([True, False, True, True, False, True])  # len == axis 1
+        _check(to_dev(src)[:, mask.to(DEVICE)], src[:, mask])
+
+    # -- non-white-listed: CPU fallback, must still match the reference ---------
+
+    def test_index_two_tensor_fallback(self):
+        src = torch.arange(30, dtype=torch.float32).reshape(5, 6)
+        r = torch.tensor([0, 2, 4], dtype=torch.long)
+        c = torch.tensor([1, 3, 5], dtype=torch.long)
+        _check(to_dev(src)[r.to(DEVICE), c.to(DEVICE)], src[r, c])
+
+    def test_index_full_mask_fallback(self):
+        """A full-shape mask selects individual elements (data-dependent, scalar
+        picks) -> CPU fallback."""
+        src = torch.arange(30, dtype=torch.float32).reshape(5, 6)
+        mask = src > 12
+        _check(to_dev(src)[mask.to(DEVICE)], src[mask])
+
+    def test_index_noncontiguous_self_fallback(self):
+        """Non-contiguous `self` is not white-listed -> CPU fallback."""
+        src = torch.arange(30, dtype=torch.float32).reshape(5, 6).t()  # (6, 5), non-contig
+        self._check_bracket(src, torch.tensor([1, 4, 0], dtype=torch.long))
+
+    def test_index_empty_self_fallback(self):
+        """An empty non-indexed dim makes indexing a no-op with no bounds check
+        (empty(3, 0)[[3]] -> (1, 0)); must match CPU, not raise."""
+        src = torch.empty(3, 0, dtype=torch.float32)
+        self._check_bracket(src, torch.tensor([3], dtype=torch.long))
+
+    # -- semantics parity with upstream advanced indexing ----------------------
+
+    def test_index_out_of_bounds_raises_indexerror(self):
+        """Out-of-range index raises IndexError (not a plain RuntimeError)."""
+        src = torch.arange(30, dtype=torch.float32).reshape(5, 6)
+        with self.assertRaises(IndexError):
+            to_dev(src)[torch.tensor([5]).to(DEVICE)]  # 5 == size(0)
+        with self.assertRaises(IndexError):
+            to_dev(src)[torch.tensor([-6]).to(DEVICE)]  # -6 < -size(0)
+
+    def test_index_too_many_indices_raises(self):
+        """More index slots than dims is 'too many indices' -> IndexError."""
+        src = to_dev(torch.arange(6, dtype=torch.float32).reshape(2, 3))
+        with self.assertRaises(IndexError):
+            torch.ops.aten.index.Tensor(src, [torch.tensor([0]).to(DEVICE), None, None])
+
+    # -- routing: white-listed forms take the native gather; others fall back ---
+
+    def test_index_routes_native(self):
+        """The white-listed forms must actually run the native gather (not just
+        return the right values via the fallback)."""
+        src = torch.arange(30, dtype=torch.float16).reshape(5, 6)
+        self.assertTrue(self._ran_native_gather(lambda: to_dev(src)[torch.tensor([1, 2, 3]).to(DEVICE)]))
+        self.assertTrue(self._ran_native_gather(lambda: to_dev(src)[torch.tensor([[1, 2], [3, 0]]).to(DEVICE)]))
+        self.assertTrue(
+            self._ran_native_gather(lambda: to_dev(src)[torch.tensor([True, False, True, False, True]).to(DEVICE)])
+        )
+
+    def test_index_fallback_not_native(self):
+        """A non-white-listed form must NOT take the native gather."""
+        src = torch.arange(30, dtype=torch.float16).reshape(5, 6)
+        r = torch.tensor([0, 2, 4]).to(DEVICE)
+        c = torch.tensor([1, 3, 5]).to(DEVICE)
+        self.assertFalse(self._ran_native_gather(lambda: to_dev(src)[r, c]))
+
+
 instantiate_device_type_tests(TestCatV2V, globals(), only_for="privateuse1")
 instantiate_device_type_tests(TestIndexSelectV2V, globals(), only_for="privateuse1")
+instantiate_device_type_tests(TestIndexTensorV2V, globals(), only_for="privateuse1")
 
 
 if __name__ == "__main__":

--- a/test/rbln/test_cat_index_select_v2v.py
+++ b/test/rbln/test_cat_index_select_v2v.py
@@ -805,14 +805,19 @@ class TestIndexTensorV2V(TestCase):
     def test_index_transposed_nd_routes_native_via_staging(self):
         """A transposed N-D index makes the wrapper allocate a non-contiguous
         `out`; the native path must gather into a staging buffer rather than fall
-        back. Asserting the result is non-contig AND the native primitive ran pins
-        down the staging branch specifically."""
+        back to CPU.
+
+        The index is kept on CPU on purpose. A *device* non-contiguous index would
+        emit `v2v_multi` from its own `reshape(-1)` clone before the routing
+        decision, masking a fallback (the gather signal and the reshape signal
+        would be indistinguishable). With a CPU index that reshape is host-side, so
+        the only device `v2v_multi` is the gather itself — the decisive
+        native-vs-fallback signal."""
         src = torch.arange(30, dtype=torch.float16).reshape(5, 6)
-        idx = torch.tensor([[1, 2], [3, 0], [2, 4]], dtype=torch.long)
-        assert not src[idx.t()].is_contiguous(), "test must exercise a non-contig out"
-        got = to_dev(src)[idx.to(DEVICE).t()]
-        self.assertFalse(got.is_contiguous(), "a non-contig out must reach the kernel")
-        self.assertTrue(self._ran_native_gather(lambda: to_dev(src)[idx.to(DEVICE).t()]))
+        idx_t = torch.tensor([[1, 2], [3, 0], [2, 4]], dtype=torch.long).t()  # CPU, non-contig
+        src_dev = to_dev(src)
+        self.assertFalse(src_dev[idx_t].is_contiguous(), "test must exercise a non-contig out")
+        self.assertTrue(self._ran_native_gather(lambda: src_dev[idx_t]))
 
 
 instantiate_device_type_tests(TestCatV2V, globals(), only_for="privateuse1")


### PR DESCRIPTION
## What

`aten::index.Tensor` (advanced indexing, i.e. `x[idx]`) was registered to the CPU
fallback on RBLN. This adds a **native v2v fast-path for any single index on one
axis** of a contiguous device tensor — the forms that are a plain on-device
*slice* gather, i.e. exactly `self.index_select(axis, flat_idx)`:

- an **integer index of rank ≥ 1** — `x[idx]`, `x[:, idx]`, `x[idx2d]` (N-D),
  negatives wrapped to match indexing semantics;
- a **1-D boolean mask** on one axis — `x[mask]`, `x[:, mask]` (True positions → index_select).

Because `index.Tensor_out` receives a pre-allocated `out`, the kernel just views
`out` with the indexed axis flattened and lets `index_select` write into it.

Every other form (multiple index tensors, non-leading / multi-dim masks,
non-contiguous `self`) keeps the existing CPU fallback, **bit-identical**.
(A 0-D index — `x[scalar]` — never reaches this op; it decomposes to `select` upstream.)

## Why these forms

They all reduce to copying contiguous slices, so native strictly avoids the
whole-`self` device→host→device round-trip the fallback pays, and wins regardless
of tensor size. Forms that would degenerate to per-scalar gathers (`x[r, c]`,
full-shape masks) are intentionally left on the fallback — native there isn't a
guaranteed win.

## How

- `index_out_rbln` (boxed) on `index.Tensor_out`: white-list check → build a 1-D
  integer `flat_idx` (integer: `idx.reshape(-1)` + negative-wrap; bool: nonzero
  positions) → `index_select_out_rbln` into a flattened view of `out`. Non-white-listed
  forms fall through to `cpu_fallback_rbln`.
- **Contract-safe**: the fast path runs only when `out` already has the exact
  expected shape (otherwise the `.out` resize is left to the fallback), and it
  raises `IndexError` (not a plain `RuntimeError`) on out-of-range indices —
  matching advanced-indexing semantics.
- The functional `index.Tensor` (`x[idx]`) inherits the path via the
  `CompositeExplicitAutogradNonFunctional` out wrapper — no separate registration.

## Tests

- `TestIndexTensorV2V` — native forms (int 1-D / N-D, negative wrap, mid-axis,
  int32, empty, device-side index, 1-D mask incl. non-leading) and fallback forms
  (multiple indices, full-shape mask, non-contiguous self), each vs the CPU reference,
  **plus routing guards** that assert the white-listed forms actually run the native
  gather (not just return correct values via the fallback).
- Whitelisted `__getitem__` (the upstream OpInfo covering `aten::index.Tensor`) in
  `test_ops`, so `test_compare_cpu` device-vs-CPU parity runs on fp16/bf16 — same
  treatment as the other native ops (`cat`, `index_select`, …).

## Serving impact (brief)

Removes a per-decode device→host→device round-trip on the sampler's index path when
sampler tensors are device-resident. Small but consistent in local measurement
(~+3–5% decode throughput on a MiniMax spec-decode + RDS serve). The core of this
PR is the native `index` op itself.
