### PR TITLE
fix(profiler): register the kineto bridge unconditionally so import doesn't seal RBLN_DEVICES

### DIFF
--- a/test/rbln/test_import_rbln_devices_seal.py
+++ b/test/rbln/test_import_rbln_devices_seal.py
@@ -1,0 +1,98 @@
+# Owner(s): ["module: PrivateUse1"]
+
+"""Importing torch_rbln must not seal ``RBLN_DEVICES``.
+
+The rbln runtime seals ``RBLN_DEVICES`` on its first device-resolving call (e.g. an
+NPU-name query) and then raises ``RBLN_DEVICES environment variable changed at runtime
+(Sealed)`` if the value later changes. A vLLM data-parallel worker inherits a
+partition-wide ``RBLN_DEVICES`` and remaps it per rank *after* import, so import must not
+query the device arch.
+
+torch-rbln #151 gated the kineto profiler on ``is_atom_device()`` at import, which called
+``get_npu_name(0)`` and sealed ``RBLN_DEVICES`` (0.3.0rc0 OK, rc2 failed). The bridge now
+registers unconditionally; ATOM is gated by the runtime (``rbln_kineto_is_active()``
+reports inactive on ATOM, rebel-compiler #12079), not by an import-time arch query.
+"""
+
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+_PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+@pytest.mark.test_set_ci
+class TestImportDoesNotSeal(TestCase):
+    """After import (or a non-RBLN profiler), ``RBLN_DEVICES`` must still be remappable.
+
+    Each subprocess sets ``RBLN_DEVICES``, runs the scenario, remaps it, then makes the
+    first device-resolving call; it must not raise "changed at runtime (Sealed)".
+    ``"0"`` -> ``"0,1"`` is a real change keeping logical device 0 valid; a non-seal
+    device error is unrelated.
+    """
+
+    def _assert_no_seal(self, result: subprocess.CompletedProcess):
+        self.assertTrue(
+            result.returncode == 0 and "NO_SEAL_OK" in result.stdout,
+            "RBLN_DEVICES was sealed before the remap\n"
+            f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}",
+        )
+
+    def _run(self, script: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=_PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+
+    def test_import_does_not_seal(self):
+        script = f"""
+            import os, sys
+            sys.path.insert(0, {_PROJECT_ROOT!r})
+            os.environ["RBLN_DEVICES"] = "0"
+            import torch_rbln  # noqa: F401
+            os.environ["RBLN_DEVICES"] = "0,1"   # worker remaps per rank AFTER import
+            from rebel._C import get_npu_name
+            try:
+                get_npu_name(0)
+                print("NO_SEAL_OK")
+            except RuntimeError as e:
+                if "changed at runtime" in str(e) or "Sealed" in str(e):
+                    print("SEALED: " + str(e).strip())
+                    sys.exit(1)
+                print("NO_SEAL_OK")  # a device-topology error is unrelated to the seal invariant
+        """
+        self._assert_no_seal(self._run(script))
+
+    def test_cpu_only_profiler_does_not_seal(self):
+        script = f"""
+            import os, sys
+            sys.path.insert(0, {_PROJECT_ROOT!r})
+            os.environ["RBLN_DEVICES"] = "0"
+            import torch, torch_rbln
+            from torch.profiler import profile, ProfilerActivity
+            with profile(activities=[ProfilerActivity.CPU]):
+                pass
+            os.environ["RBLN_DEVICES"] = "0,1"
+            from rebel._C import get_npu_name
+            try:
+                get_npu_name(0)
+                print("NO_SEAL_OK")
+            except RuntimeError as e:
+                if "changed at runtime" in str(e) or "Sealed" in str(e):
+                    print("SEALED: " + str(e).strip())
+                    sys.exit(1)
+                print("NO_SEAL_OK")
+        """
+        self._assert_no_seal(self._run(script))
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch_rbln/__init__.py
+++ b/torch_rbln/__init__.py
@@ -202,14 +202,16 @@ def _create_process_group_rbln(dist_backend_opts, pg_options):
 
 
 def _initialize_kineto_profiler() -> None:
-    """Register the rbln torch.profiler (kineto) bridge."""
-    from torch_rbln._internal.device_arch_utils import is_atom_device
-    from torch_rbln._internal.log_utils import rbln_log_info
+    """Register the rbln torch.profiler (kineto) bridge (a runtime-free libkineto
+    factory registration).
 
-    if is_atom_device():
-        rbln_log_info("rbln torch.profiler activities are not supported on ATOM and will be skipped")
-        return
-
+    Do NOT query the device arch here (e.g. ``is_atom_device()``): ``get_npu_name`` seals
+    ``RBLN_DEVICES`` in the rbln runtime, and a vLLM data-parallel worker remaps
+    ``RBLN_DEVICES`` *after* import -> ``RBLN_DEVICES environment variable changed at
+    runtime (Sealed)``. ATOM is gated by the runtime instead: ``rbln_kineto_is_active()``
+    (which the C++ profiler ``configure()`` checks) reports inactive on ATOM
+    (rebel-compiler #12079), so no rbln session is created there.
+    """
     try:
         import torch_rbln._C
 


### PR DESCRIPTION
## Summary

Register the kineto profiler bridge unconditionally at import instead of gating it on `is_atom_device()`. The import-time arch query (`get_npu_name`) sealed `RBLN_DEVICES`, breaking vLLM data-parallel workers that remap it after import. ATOM profiling is now gated by the runtime, so nothing is lost.

## Problem

Reported on `vllm_rbln_exec.parity_runner --dp 4` with `RBLN_DEVICES=4,5,6,7`:

```
File ".../vllm_rbln/v1/worker/rbln_worker.py", line 195, in determine_available_memory
    device_name = current_platform.get_device_name().lower()
File ".../vllm_rbln/platform.py", line 116, in get_device_name
    rebel.get_npu_name(device_id)
RuntimeError: RBLN_DEVICES environment variable changed at runtime (Sealed)
```

Bisected to torch-rbln: **0.3.0rc0 OK, 0.3.0rc2 fails**. The rbln runtime seals `RBLN_DEVICES` on its first device-resolving call and raises if it later changes. A DP worker inherits a partition-wide `RBLN_DEVICES` and remaps it per rank *after* import, so anything that resolves the device at import breaks it.

## Root cause

#151 (`ea528145`, "skip registration on ATOM (unsupported)") moved the kineto bridge registration to Python init (runs at `import`) and gated it on `is_atom_device()` → `rebel.get_npu_name(0)`. That import-time query seals `RBLN_DEVICES` at the inherited value before the worker can remap it. rc0 registered the bridge in C++ with no arch query.

## Fix — #151's intent is preserved, moved to the correct layer

At the time of #151, the runtime did not gate ATOM, so the "skip on ATOM" check lived in torch-rbln — but it ran at import and sealed `RBLN_DEVICES`.

Since then, **rebel-compiler #12079 ("disable kineto export on ATOM SoCs")** moved that gate into the runtime: `rbln_kineto_is_active()` now returns inactive on ATOM, **side-effect-free** (it reads the already-registered profiling context's arch — it does **not** query the NPU name or seal `RBLN_DEVICES`). The C++ profiler `configure()` already gates session creation on `rbln_kineto_is_active()`, so ATOM sessions are still skipped.

So this PR removes the import-time `is_atom_device()` gate and registers unconditionally. **#151's intent (no rbln kineto profiling on ATOM) is preserved by the runtime, not dropped**; the import-time seal is gone. There are **no C++ changes** — `configure()`'s existing `is_active` check plus #12079 do the gating.

Requires rebel-compiler with #12079 (the pinned `dev416` includes it; merged 2026-07-13).

## Testing

`test/rbln/test_import_rbln_devices_seal.py`: after `import torch_rbln`, and after a CPU-only `torch.profiler`, remapping `RBLN_DEVICES` and querying the NPU must not raise the seal error.
