### PR TITLE
feat(generator): initial generator support

### DIFF
--- a/aten/src/ATen/native/rbln/RBLNCPUFallback.cpp
+++ b/aten/src/ATen/native/rbln/RBLNCPUFallback.cpp
@@ -370,6 +370,44 @@ void cpu_fallback_rbln(
   std::vector<uint64_t> borrow_ids(tensor_args.size(), 0);
   std::vector<at::Tensor> cpu_tensors(tensor_args.size());
 
+  // If anything below throws (e.g. dtype-mismatched or wrong-device out=),
+  // the borrows above must still be released — else the next free on
+  // a still-borrowed vaddr fails, and since c10::rbln::free throws from
+  // a ~TensorImpl (noexcept) deleter that escalates to std::terminate.
+  // The RAII guard releases any still-live borrow (updated=false) on
+  // destruction; Step 4 zeroes borrow_ids on the happy path, so the guard
+  // is then a no-op.
+  struct BorrowReleaseGuard {
+    std::vector<uint64_t>& borrow_ids;
+    std::vector<std::vector<uint64_t>>& tensorlist_borrow_ids;
+    ~BorrowReleaseGuard() {
+      for (auto& bid : borrow_ids) {
+        if (bid != 0) {
+          try {
+            c10::rbln::return_borrowed(bid, /*updated=*/false);
+          } catch (...) {
+            // Best-effort: dtor is noexcept by default. Swallow runtime
+            // rejections so we don't escalate one borrow-release failure into
+            // std::terminate; the original exception that triggered cleanup
+            // is more useful for diagnosis.
+          }
+          bid = 0;
+        }
+      }
+      for (auto& bids : tensorlist_borrow_ids) {
+        for (auto& bid : bids) {
+          if (bid != 0) {
+            try {
+              c10::rbln::return_borrowed(bid, /*updated=*/false);
+            } catch (...) {
+            }
+            bid = 0;
+          }
+        }
+      }
+    }
+  } _borrow_guard{borrow_ids, tensorlist_borrow_ids};
+
   for (size_t i = 0; i < tensor_args.size(); ++i) {
     // Skip the borrow fast path for write-alias outputs (`out=`): from_blob's
     // fixed-size storage can't be resized, so the CPU op's resize path (wrong-shape
@@ -483,43 +521,6 @@ void cpu_fallback_rbln(
   // the borrowed out buffer, and replaces the stack; on no-match it returns
   // false and we fall through to the boxed dispatcher.
   //
-  // If Step 2/3 throws (e.g. dtype-mismatched or wrong-device out=), the borrows
-  // above must still be released — else the next free on a still-borrowed vaddr
-  // fails, and since c10::rbln::free throws from a ~TensorImpl (noexcept) deleter
-  // that escalates to std::terminate. The RAII guard releases any still-live
-  // borrow (updated=false) on destruction; Step 4 zeroes borrow_ids on the happy
-  // path, so the guard is then a no-op.
-  struct BorrowReleaseGuard {
-    std::vector<uint64_t>& borrow_ids;
-    std::vector<std::vector<uint64_t>>& tensorlist_borrow_ids;
-    ~BorrowReleaseGuard() {
-      for (auto& bid : borrow_ids) {
-        if (bid != 0) {
-          try {
-            c10::rbln::return_borrowed(bid, /*updated=*/false);
-          } catch (...) {
-            // Best-effort: dtor is noexcept by default. Swallow runtime
-            // rejections so we don't escalate one borrow-release failure into
-            // std::terminate; the original exception that triggered cleanup
-            // is more useful for diagnosis.
-          }
-          bid = 0;
-        }
-      }
-      for (auto& bids : tensorlist_borrow_ids) {
-        for (auto& bid : bids) {
-          if (bid != 0) {
-            try {
-              c10::rbln::return_borrowed(bid, /*updated=*/false);
-            } catch (...) {
-            }
-            bid = 0;
-          }
-        }
-      }
-    }
-  } _borrow_guard{borrow_ids, tensorlist_borrow_ids};
-
   // A pure-out borrow wraps the rbln out in a non-resizable from_blob view, so an
   // undersized out= the CPU kernel tries to GROW throws "not resizable" (shrink is
   // metadata-only and already handled in Step 3). Catch that one error, swap the

--- a/aten/src/ATen/native/rbln/RBLNCPUFallback.cpp
+++ b/aten/src/ATen/native/rbln/RBLNCPUFallback.cpp
@@ -9,6 +9,7 @@
 #include <ATen/native/rbln/RBLNTensorUtils.h>
 
 #include <c10/rbln/RBLNFunctions.h>
+#include <c10/rbln/RBLNGenerator.h>
 #include <c10/util/SmallVector.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
@@ -45,6 +46,7 @@ enum class CpuFbArgKind : uint8_t {
   TensorList,
   OptionalTensorList,
   Device,
+  OptionalGenerator,
 };
 
 struct CpuFbSchemaInfo {
@@ -94,11 +96,18 @@ const CpuFbSchemaInfo& get_or_populate_schema_info(const c10::FunctionSchema& sc
       info.arg_kind[i] = CpuFbArgKind::TensorList;
     } else if (type->isSubtypeOf(*ListType::ofOptionalTensors())) {
       info.arg_kind[i] = CpuFbArgKind::OptionalTensorList;
-    } else if (auto opt = type->cast<OptionalType>(); opt && opt->getElementType()->isSubtypeOf(*TensorType::get())) {
-      info.arg_kind[i] = CpuFbArgKind::OptionalTensor;
     } else if (type->kind() == TypeKind::DeviceObjType) {
       info.arg_kind[i] = CpuFbArgKind::Device;
+    } else if (type->kind() == TypeKind::OptionalType) {
+      auto opt = type->cast<OptionalType>();
+      auto elem_type = opt->getElementType();
+      if (elem_type->isSubtypeOf(*TensorType::get())) {
+        info.arg_kind[i] = CpuFbArgKind::OptionalTensor;
+      } else if (elem_type->kind() == TypeKind::GeneratorType) {
+        info.arg_kind[i] = CpuFbArgKind::OptionalGenerator;
+      }
     }
+
     const auto* alias = a.alias_info();
     const bool is_w = (alias != nullptr && alias->isWrite());
     info.is_write_alias[i] = is_w;
@@ -343,6 +352,13 @@ void cpu_fallback_rbln(
         tgt_device = ivalue.toDevice();
         (*stack)[arguments_begin + idx] = c10::IValue(c10::Device(kCPU));
         break;
+      case CpuFbArgKind::OptionalGenerator: {
+        if (ivalue.isGenerator()) {
+          auto g = static_cast<RBLNGeneratorImpl*>(ivalue.toGenerator().unsafeGetGeneratorImpl());
+          (*stack)[arguments_begin + idx] = c10::IValue(g->get_fallback_generator());
+        }
+        break;
+      }
       case CpuFbArgKind::Other:
         break; // unreachable — gated above
     }

--- a/aten/src/ATen/native/rbln/RBLNCPUFallback.cpp
+++ b/aten/src/ATen/native/rbln/RBLNCPUFallback.cpp
@@ -303,6 +303,7 @@ void cpu_fallback_rbln(
   // wrapped via the v-mem borrow path; zeros indicate the legacy `to_cpu`
   // fallback (used for non-rbln tensors, contiguity-guard skips, etc.).
   std::vector<std::vector<uint64_t>> tensorlist_borrow_ids;
+  std::optional<size_t> generator_arg_idx = std::nullopt;
 
   // Step 1: convert all non-CPU tensor inputs into CPU tensors and stage them on
   // the stack at the correct indices, switching on the cached per-arg schema kind.
@@ -353,10 +354,7 @@ void cpu_fallback_rbln(
         (*stack)[arguments_begin + idx] = c10::IValue(c10::Device(kCPU));
         break;
       case CpuFbArgKind::OptionalGenerator: {
-        const at::Generator arg_or_default_generator =
-            ivalue.isGenerator() ? ivalue.toGenerator() : c10::rbln::get_default_rbln_generator(-1);
-        auto g = check_generator<RBLNGeneratorImpl>(arg_or_default_generator);
-        (*stack)[arguments_begin + idx] = c10::IValue(g->get_fallback_generator());
+        generator_arg_idx = idx;
         break;
       }
       case CpuFbArgKind::Other:
@@ -443,6 +441,38 @@ void cpu_fallback_rbln(
   for (const auto i : c10::irange(tensor_args_indices.size())) {
     auto idx = tensor_args_indices[i];
     (*stack)[arguments_begin + idx] = c10::IValue(cpu_tensors[i]);
+  }
+
+  if (generator_arg_idx.has_value()) {
+    if (tgt_device == std::nullopt) {
+      tgt_device = compute_target_device(tensor_args, tensorlist_args);
+    }
+
+    c10::DeviceIndex tgt_index = tgt_device.has_value() ? tgt_device->index() : static_cast<c10::DeviceIndex>(-1);
+    if (tgt_index == -1) {
+      tgt_index = c10::rbln::get_device_index();
+    }
+
+    const auto& ivalue = arguments[generator_arg_idx.value()];
+    RBLNGeneratorImpl* arg_or_default_generator_ptr = nullptr;
+    if (ivalue.isGenerator()) {
+      arg_or_default_generator_ptr = check_generator<RBLNGeneratorImpl>(ivalue.toGenerator());
+      const auto gen_index = arg_or_default_generator_ptr->device().index();
+      TORCH_CHECK(
+          gen_index == tgt_index,
+          "Expected a generator on device rbln:",
+          static_cast<int>(tgt_index),
+          " for operator ",
+          op.schema().operator_name(),
+          ", but got a generator on device rbln:",
+          static_cast<int>(gen_index));
+    } else {
+      arg_or_default_generator_ptr =
+          check_generator<RBLNGeneratorImpl>(c10::rbln::get_default_rbln_generator(tgt_index));
+    }
+
+    (*stack)[arguments_begin + generator_arg_idx.value()] =
+        c10::IValue(arg_or_default_generator_ptr->get_fallback_generator());
   }
 
   // Step 2: call the underlying CPU implementation.

--- a/aten/src/ATen/native/rbln/RBLNCPUFallback.cpp
+++ b/aten/src/ATen/native/rbln/RBLNCPUFallback.cpp
@@ -353,10 +353,10 @@ void cpu_fallback_rbln(
         (*stack)[arguments_begin + idx] = c10::IValue(c10::Device(kCPU));
         break;
       case CpuFbArgKind::OptionalGenerator: {
-        if (ivalue.isGenerator()) {
-          auto g = static_cast<RBLNGeneratorImpl*>(ivalue.toGenerator().unsafeGetGeneratorImpl());
-          (*stack)[arguments_begin + idx] = c10::IValue(g->get_fallback_generator());
-        }
+        const at::Generator arg_or_default_generator =
+            ivalue.isGenerator() ? ivalue.toGenerator() : c10::rbln::get_default_rbln_generator(-1);
+        auto g = check_generator<RBLNGeneratorImpl>(arg_or_default_generator);
+        (*stack)[arguments_begin + idx] = c10::IValue(g->get_fallback_generator());
         break;
       }
       case CpuFbArgKind::Other:

--- a/c10/rbln/RBLNGenerator.cpp
+++ b/c10/rbln/RBLNGenerator.cpp
@@ -6,6 +6,15 @@
 #include <c10/rbln/RBLNGenerator.h>
 #include <c10/rbln/RBLNLogging.h>
 
+namespace {
+
+int64_t fallback_state_size() {
+  static const int64_t size = at::CPUGeneratorImpl().get_state()->numel();
+  return size;
+}
+
+} // namespace
+
 namespace at {
 
 RBLNGeneratorImpl::RBLNGeneratorImpl(DeviceIndex device_index)
@@ -46,9 +55,21 @@ uint64_t RBLNGeneratorImpl::seed() {
 }
 
 void RBLNGeneratorImpl::set_state(const c10::TensorImpl& new_state) {
+  const int64_t expected_size = fallback_state_size() + static_cast<int64_t>(sizeof(seed_));
+
   TORCH_CHECK(new_state.device().is_cpu(), "RBLN generator state must be a CPU tensor, but got ", new_state.device());
 
   TORCH_CHECK(new_state.dtype() == at::kByte, "RBLN generator state must be a ByteTensor, but got ", new_state.dtype());
+
+  TORCH_CHECK(new_state.is_contiguous(), "RBLN generator state must be contiguous");
+
+  TORCH_CHECK(
+      new_state.numel() == expected_size,
+      "RBLN generator state has invalid size: expected ",
+      expected_size,
+      " bytes, but got ",
+      new_state.numel(),
+      " bytes");
 
   std::lock_guard<std::mutex> lock(cpu_generator_->mutex_);
 

--- a/c10/rbln/RBLNGenerator.cpp
+++ b/c10/rbln/RBLNGenerator.cpp
@@ -20,6 +20,7 @@ at::Generator RBLNGeneratorImpl::get_fallback_generator() const {
 }
 
 void RBLNGeneratorImpl::set_current_seed(uint64_t seed) {
+  std::lock_guard<std::mutex> lock(cpu_generator_->mutex_);
   seed_ = seed;
   cpu_generator_->set_current_seed(seed);
 }
@@ -33,10 +34,12 @@ uint64_t RBLNGeneratorImpl::get_offset() const {
 }
 
 uint64_t RBLNGeneratorImpl::current_seed() const {
+  std::lock_guard<std::mutex> lock(cpu_generator_->mutex_);
   return seed_;
 }
 
 uint64_t RBLNGeneratorImpl::seed() {
+  std::lock_guard<std::mutex> lock(cpu_generator_->mutex_);
   auto random_seed = cpu_generator_->seed();
   seed_ = random_seed;
   return seed_;
@@ -46,6 +49,8 @@ void RBLNGeneratorImpl::set_state(const c10::TensorImpl& new_state) {
   TORCH_CHECK(new_state.device().is_cpu(), "RBLN generator state must be a CPU tensor, but got ", new_state.device());
 
   TORCH_CHECK(new_state.dtype() == at::kByte, "RBLN generator state must be a ByteTensor, but got ", new_state.dtype());
+
+  std::lock_guard<std::mutex> lock(cpu_generator_->mutex_);
 
   const auto* state_ptr = static_cast<const uint8_t*>(new_state.data());
 
@@ -60,6 +65,8 @@ void RBLNGeneratorImpl::set_state(const c10::TensorImpl& new_state) {
 }
 
 c10::intrusive_ptr<c10::TensorImpl> RBLNGeneratorImpl::get_state() const {
+  std::lock_guard<std::mutex> lock(cpu_generator_->mutex_);
+
   auto fallback_state = cpu_generator_->get_state();
 
   TORCH_INTERNAL_ASSERT(fallback_state->device().is_cpu(), "CPU fallback generator state must be on CPU");

--- a/c10/rbln/RBLNGenerator.cpp
+++ b/c10/rbln/RBLNGenerator.cpp
@@ -80,7 +80,8 @@ void RBLNGeneratorImpl::set_state(const c10::TensorImpl& new_state) {
 
   const auto* state_ptr = static_cast<const uint8_t*>(new_state.data());
 
-  std::memcpy(&seed_, state_ptr, sizeof(seed_));
+  uint64_t new_seed;
+  std::memcpy(&new_seed, state_ptr, sizeof(new_seed));
 
   auto fallback_state = at::empty(
       {static_cast<int64_t>(new_state.numel() - sizeof(seed_))}, at::TensorOptions().dtype(at::kByte).device(at::kCPU));
@@ -88,6 +89,7 @@ void RBLNGeneratorImpl::set_state(const c10::TensorImpl& new_state) {
   std::memcpy(fallback_state.data_ptr<uint8_t>(), state_ptr + sizeof(seed_), fallback_state.numel());
 
   cpu_generator_->set_state(*fallback_state.unsafeGetTensorImpl());
+  seed_ = new_seed;
 }
 
 c10::intrusive_ptr<c10::TensorImpl> RBLNGeneratorImpl::get_state() const {

--- a/c10/rbln/RBLNGenerator.cpp
+++ b/c10/rbln/RBLNGenerator.cpp
@@ -1,3 +1,4 @@
+#include <ATen/ATen.h>
 #include <ATen/Utils.h>
 #include <ATen/core/GeneratorForPrivateuseone.h>
 #include <ATen/detail/PrivateUse1HooksInterface.h>
@@ -8,10 +9,14 @@ namespace at {
 RBLNGeneratorImpl::RBLNGeneratorImpl(DeviceIndex device_index)
     : GeneratorImpl(Device(DeviceType::PrivateUse1, device_index), DispatchKeySet(c10::DispatchKey::PrivateUse1)),
       seed_(0),
-      offset_(0) {}
+      offset_(0),
+      cpu_generator_(make_intrusive<CPUGeneratorImpl>()) {
+  cpu_generator_->set_current_seed(seed_);
+}
 
 void RBLNGeneratorImpl::set_current_seed(uint64_t seed) {
   seed_ = seed;
+  cpu_generator_->set_current_seed(seed);
 }
 
 void RBLNGeneratorImpl::set_offset(uint64_t offset) {
@@ -30,22 +35,52 @@ uint64_t RBLNGeneratorImpl::seed() {
   return seed_;
 }
 
-void RBLNGeneratorImpl::set_state(const c10::TensorImpl& new_state) {}
+void RBLNGeneratorImpl::set_state(const c10::TensorImpl& new_state) {
+  TORCH_CHECK(new_state.device().is_cpu(), "RBLN generator state must be a CPU tensor, but got ", new_state.device());
+
+  TORCH_CHECK(new_state.dtype() == at::kByte, "RBLN generator state must be a ByteTensor, but got ", new_state.dtype());
+
+  const auto* state_ptr = new_state.data();
+
+  std::memcpy(&seed_, state_ptr, sizeof(seed_));
+
+  std::memcpy(&offset_, state_ptr + sizeof(seed_), sizeof(offset_));
+
+  auto fallback_state = at::empty(
+      {static_cast<int64_t>(new_state.numel() - (sizeof(seed_) + sizeof(offset_)))},
+      at::TensorOptions().dtype(at::kByte).device(at::kCPU));
+
+  std::memcpy(fallback_state.data_ptr<uint8_t>(), state_ptr + sizeof(seed_) + sizeof(offset_), fallback_state.numel());
+
+  cpu_generator_->set_state(*fallback_state.unsafeGetTensorImpl());
+}
 
 c10::intrusive_ptr<c10::TensorImpl> RBLNGeneratorImpl::get_state() const {
-  static const size_t seed_size = sizeof(uint64_t);
-  static const size_t offset_size = sizeof(uint64_t);
-  static const size_t total_size = seed_size + offset_size;
+  auto fallback_state = cpu_generator_->get_state();
 
-  auto state_tensor = at::detail::empty_cpu(
-      {static_cast<int64_t>(total_size)}, ScalarType::Byte, std::nullopt, std::nullopt, std::nullopt, std::nullopt);
-  return state_tensor.getIntrusivePtr();
+  TORCH_INTERNAL_ASSERT(fallback_state->device().is_cpu(), "CPU fallback generator state must be on CPU");
+
+  TORCH_INTERNAL_ASSERT(fallback_state->dtype() == at::kByte, "CPU fallback generator state must be a ByteTensor");
+
+  const auto fallback_state_numel = fallback_state->numel();
+
+  auto state = at::empty(
+      {static_cast<int64_t>(sizeof(seed_) + sizeof(offset_) + fallback_state_numel)},
+      at::TensorOptions().dtype(at::kByte).device(at::kCPU));
+
+  auto* state_ptr = state.data_ptr<uint8_t>();
+
+  std::memcpy(state_ptr, &seed_, sizeof(seed_));
+
+  std::memcpy(state_ptr + sizeof(seed_), &offset_, sizeof(offset_));
+
+  std::memcpy(state_ptr + sizeof(seed_) + sizeof(offset_), fallback_state->data(), fallback_state_numel);
+
+  return state.getIntrusivePtr();
 }
 
 RBLNGeneratorImpl* RBLNGeneratorImpl::clone_impl() const {
   auto gen = new RBLNGeneratorImpl(device().index());
-  gen->set_offset(offset_);
-  gen->set_current_seed(seed_);
   gen->set_state(*get_state());
   return gen;
 }

--- a/c10/rbln/RBLNGenerator.cpp
+++ b/c10/rbln/RBLNGenerator.cpp
@@ -93,6 +93,10 @@ RBLNGeneratorImpl* RBLNGeneratorImpl::clone_impl() const {
   return gen;
 }
 
+DeviceType RBLNGeneratorImpl::device_type() {
+  return DeviceType::PrivateUse1;
+}
+
 } // namespace at
 
 namespace c10::rbln {

--- a/c10/rbln/RBLNGenerator.cpp
+++ b/c10/rbln/RBLNGenerator.cpp
@@ -48,7 +48,7 @@ void RBLNGeneratorImpl::set_state(const c10::TensorImpl& new_state) {
 
   TORCH_CHECK(new_state.dtype() == at::kByte, "RBLN generator state must be a ByteTensor, but got ", new_state.dtype());
 
-  const auto* state_ptr = new_state.data();
+  const auto* state_ptr = static_cast<const uint8_t*>(new_state.data());
 
   std::memcpy(&seed_, state_ptr, sizeof(seed_));
 

--- a/c10/rbln/RBLNGenerator.cpp
+++ b/c10/rbln/RBLNGenerator.cpp
@@ -14,6 +14,10 @@ RBLNGeneratorImpl::RBLNGeneratorImpl(DeviceIndex device_index)
   cpu_generator_->set_current_seed(seed_);
 }
 
+at::Generator RBLNGeneratorImpl::get_fallback_generator() const {
+  return at::Generator(cpu_generator_);
+}
+
 void RBLNGeneratorImpl::set_current_seed(uint64_t seed) {
   seed_ = seed;
   cpu_generator_->set_current_seed(seed);

--- a/c10/rbln/RBLNGenerator.cpp
+++ b/c10/rbln/RBLNGenerator.cpp
@@ -13,12 +13,18 @@ int64_t fallback_state_size() {
   return size;
 }
 
+c10::DeviceIndex resolve_device_index(c10::DeviceIndex device_index) {
+  return device_index == -1 ? c10::rbln::get_device_index() : device_index;
+}
+
 } // namespace
 
 namespace at {
 
 RBLNGeneratorImpl::RBLNGeneratorImpl(DeviceIndex device_index)
-    : GeneratorImpl(Device(DeviceType::PrivateUse1, device_index), DispatchKeySet(c10::DispatchKey::PrivateUse1)),
+    : GeneratorImpl(
+          Device(DeviceType::PrivateUse1, resolve_device_index(device_index)),
+          DispatchKeySet(c10::DispatchKey::PrivateUse1)),
       seed_(0),
       cpu_generator_(make_intrusive<CPUGeneratorImpl>()) {
   cpu_generator_->set_current_seed(seed_);

--- a/c10/rbln/RBLNGenerator.cpp
+++ b/c10/rbln/RBLNGenerator.cpp
@@ -11,7 +11,6 @@ namespace at {
 RBLNGeneratorImpl::RBLNGeneratorImpl(DeviceIndex device_index)
     : GeneratorImpl(Device(DeviceType::PrivateUse1, device_index), DispatchKeySet(c10::DispatchKey::PrivateUse1)),
       seed_(0),
-      offset_(0),
       cpu_generator_(make_intrusive<CPUGeneratorImpl>()) {
   cpu_generator_->set_current_seed(seed_);
 }
@@ -26,11 +25,11 @@ void RBLNGeneratorImpl::set_current_seed(uint64_t seed) {
 }
 
 void RBLNGeneratorImpl::set_offset(uint64_t offset) {
-  offset_ = offset;
+  TORCH_CHECK(false, "RBLN Generator does not use offset");
 }
 
 uint64_t RBLNGeneratorImpl::get_offset() const {
-  return offset_;
+  TORCH_CHECK(false, "RBLN Generator does not use offset");
 }
 
 uint64_t RBLNGeneratorImpl::current_seed() const {
@@ -52,13 +51,10 @@ void RBLNGeneratorImpl::set_state(const c10::TensorImpl& new_state) {
 
   std::memcpy(&seed_, state_ptr, sizeof(seed_));
 
-  std::memcpy(&offset_, state_ptr + sizeof(seed_), sizeof(offset_));
-
   auto fallback_state = at::empty(
-      {static_cast<int64_t>(new_state.numel() - (sizeof(seed_) + sizeof(offset_)))},
-      at::TensorOptions().dtype(at::kByte).device(at::kCPU));
+      {static_cast<int64_t>(new_state.numel() - sizeof(seed_))}, at::TensorOptions().dtype(at::kByte).device(at::kCPU));
 
-  std::memcpy(fallback_state.data_ptr<uint8_t>(), state_ptr + sizeof(seed_) + sizeof(offset_), fallback_state.numel());
+  std::memcpy(fallback_state.data_ptr<uint8_t>(), state_ptr + sizeof(seed_), fallback_state.numel());
 
   cpu_generator_->set_state(*fallback_state.unsafeGetTensorImpl());
 }
@@ -73,16 +69,14 @@ c10::intrusive_ptr<c10::TensorImpl> RBLNGeneratorImpl::get_state() const {
   const auto fallback_state_numel = fallback_state->numel();
 
   auto state = at::empty(
-      {static_cast<int64_t>(sizeof(seed_) + sizeof(offset_) + fallback_state_numel)},
+      {static_cast<int64_t>(sizeof(seed_) + fallback_state_numel)},
       at::TensorOptions().dtype(at::kByte).device(at::kCPU));
 
   auto* state_ptr = state.data_ptr<uint8_t>();
 
   std::memcpy(state_ptr, &seed_, sizeof(seed_));
 
-  std::memcpy(state_ptr + sizeof(seed_), &offset_, sizeof(offset_));
-
-  std::memcpy(state_ptr + sizeof(seed_) + sizeof(offset_), fallback_state->data(), fallback_state_numel);
+  std::memcpy(state_ptr + sizeof(seed_), fallback_state->data(), fallback_state_numel);
 
   return state.getIntrusivePtr();
 }

--- a/c10/rbln/RBLNGenerator.cpp
+++ b/c10/rbln/RBLNGenerator.cpp
@@ -80,7 +80,7 @@ void RBLNGeneratorImpl::set_state(const c10::TensorImpl& new_state) {
 
   const auto* state_ptr = static_cast<const uint8_t*>(new_state.data());
 
-  uint64_t new_seed;
+  uint64_t new_seed = 0;
   std::memcpy(&new_seed, state_ptr, sizeof(new_seed));
 
   auto fallback_state = at::empty(

--- a/c10/rbln/RBLNGenerator.cpp
+++ b/c10/rbln/RBLNGenerator.cpp
@@ -2,7 +2,9 @@
 #include <ATen/Utils.h>
 #include <ATen/core/GeneratorForPrivateuseone.h>
 #include <ATen/detail/PrivateUse1HooksInterface.h>
+#include <c10/rbln/RBLNFunctions.h>
 #include <c10/rbln/RBLNGenerator.h>
+#include <c10/rbln/RBLNLogging.h>
 
 namespace at {
 
@@ -90,3 +92,38 @@ RBLNGeneratorImpl* RBLNGeneratorImpl::clone_impl() const {
 }
 
 } // namespace at
+
+namespace c10::rbln {
+
+at::Generator make_rbln_generator(c10::DeviceIndex device_index) {
+  RBLN_LOG_DEBUG("device_index={}", static_cast<int>(device_index));
+  return at::make_generator<at::RBLNGeneratorImpl>(device_index);
+}
+
+const at::Generator& get_default_rbln_generator(c10::DeviceIndex device_index) {
+  static const std::vector<at::Generator> generators = [] {
+    const auto device_count = get_device_count();
+
+    std::vector<at::Generator> result;
+    result.reserve(device_count);
+
+    for (c10::DeviceIndex i = 0; i < device_count; ++i) {
+      auto generator = make_rbln_generator(i);
+      generator.seed();
+      result.emplace_back(std::move(generator));
+    }
+
+    return result;
+  }();
+
+  auto idx = device_index;
+  if (idx == -1) {
+    idx = get_device_index();
+  }
+
+  TORCH_CHECK(idx >= 0 && idx < static_cast<c10::DeviceIndex>(generators.size()), "Invalid RBLN device index: ", idx);
+
+  return generators[idx];
+}
+
+} // namespace c10::rbln

--- a/c10/rbln/RBLNGenerator.cpp
+++ b/c10/rbln/RBLNGenerator.cpp
@@ -38,6 +38,8 @@ uint64_t RBLNGeneratorImpl::current_seed() const {
 }
 
 uint64_t RBLNGeneratorImpl::seed() {
+  auto random_seed = cpu_generator_->seed();
+  seed_ = random_seed;
   return seed_;
 }
 

--- a/c10/rbln/RBLNGenerator.cpp
+++ b/c10/rbln/RBLNGenerator.cpp
@@ -48,9 +48,8 @@ uint64_t RBLNGeneratorImpl::current_seed() const {
 }
 
 uint64_t RBLNGeneratorImpl::seed() {
-  std::lock_guard<std::mutex> lock(cpu_generator_->mutex_);
-  auto random_seed = cpu_generator_->seed();
-  seed_ = random_seed;
+  auto random_seed = c10::detail::getNonDeterministicRandom();
+  this->set_current_seed(random_seed);
   return seed_;
 }
 

--- a/c10/rbln/RBLNGenerator.h
+++ b/c10/rbln/RBLNGenerator.h
@@ -10,6 +10,8 @@ struct C10_RBLN_API RBLNGeneratorImpl : public GeneratorImpl {
   RBLNGeneratorImpl(DeviceIndex device_index = -1);
   ~RBLNGeneratorImpl() override = default;
 
+  at::Generator get_fallback_generator() const;
+
  private:
   // Overridden from GeneratorImpl:
   void set_current_seed(uint64_t seed) override;

--- a/c10/rbln/RBLNGenerator.h
+++ b/c10/rbln/RBLNGenerator.h
@@ -23,6 +23,7 @@ struct C10_RBLN_API RBLNGeneratorImpl : public GeneratorImpl {
 
   uint64_t seed_;
   uint64_t offset_;
+  c10::intrusive_ptr<GeneratorImpl> cpu_generator_;
 };
 
 } // namespace at

--- a/c10/rbln/RBLNGenerator.h
+++ b/c10/rbln/RBLNGenerator.h
@@ -25,7 +25,6 @@ struct C10_RBLN_API RBLNGeneratorImpl : public GeneratorImpl {
   RBLNGeneratorImpl* clone_impl() const override;
 
   uint64_t seed_;
-  uint64_t offset_;
   c10::intrusive_ptr<GeneratorImpl> cpu_generator_;
 };
 

--- a/c10/rbln/RBLNGenerator.h
+++ b/c10/rbln/RBLNGenerator.h
@@ -29,3 +29,31 @@ struct C10_RBLN_API RBLNGeneratorImpl : public GeneratorImpl {
 };
 
 } // namespace at
+
+namespace c10::rbln {
+
+/**
+ * @brief Creates a new generator for the specified RBLN device.
+ *
+ * The returned generator is independent of the device's default generator
+ * and can be explicitly passed to random-number-generating operators.
+ *
+ * @param device_index The RBLN device index.
+ * @return A newly created RBLN generator associated with `device_index`.
+ */
+C10_RBLN_API at::Generator make_rbln_generator(c10::DeviceIndex device_index);
+
+/**
+ * @brief Returns the persistent default generator for the specified RBLN
+ * device.
+ *
+ * The same generator is returned for subsequent calls with the same device
+ * index. If `device_index` is `-1`, the generator for the current RBLN device
+ * is returned.
+ *
+ * @param device_index The RBLN device index, or `-1` to use the current device.
+ * @return The default generator associated with the requested RBLN device.
+ */
+C10_RBLN_API const at::Generator& get_default_rbln_generator(c10::DeviceIndex device_index);
+
+} // namespace c10::rbln

--- a/c10/rbln/RBLNGenerator.h
+++ b/c10/rbln/RBLNGenerator.h
@@ -11,6 +11,7 @@ struct C10_RBLN_API RBLNGeneratorImpl : public GeneratorImpl {
   ~RBLNGeneratorImpl() override = default;
 
   at::Generator get_fallback_generator() const;
+  static c10::DeviceType device_type();
 
  private:
   // Overridden from GeneratorImpl:

--- a/c10/rbln/RBLNHooksInterface.cpp
+++ b/c10/rbln/RBLNHooksInterface.cpp
@@ -104,6 +104,7 @@ at::Generator RBLNHooksInterface::getNewGenerator(c10::DeviceIndex device_index)
 }
 
 const at::Generator& RBLNHooksInterface::getDefaultGenerator(c10::DeviceIndex device_index) const {
+  RBLN_LOG_DEBUG("device_index={}", static_cast<int>(device_index));
   return c10::rbln::get_default_rbln_generator(device_index);
 }
 

--- a/c10/rbln/RBLNHooksInterface.cpp
+++ b/c10/rbln/RBLNHooksInterface.cpp
@@ -103,6 +103,10 @@ at::Generator RBLNHooksInterface::getNewGenerator(c10::DeviceIndex device_index)
   return at::make_generator<at::RBLNGeneratorImpl>(device_index);
 }
 
+const at::Generator& RBLNHooksInterface::getDefaultGenerator(c10::DeviceIndex device_index) const {
+  return c10::rbln::get_default_rbln_generator(device_index);
+}
+
 at::PrivateUse1HooksInterface* get_rbln_hooks() {
   static const std::unique_ptr<at::PrivateUse1HooksInterface> rbln_hooks = []() {
     // Called from shared-library registration during dlopen(). Avoid logging here:

--- a/c10/rbln/RBLNHooksInterface.h
+++ b/c10/rbln/RBLNHooksInterface.h
@@ -82,6 +82,14 @@ struct C10_RBLN_API RBLNHooksInterface : public at::PrivateUse1HooksInterface {
    * @return A new generator instance for the specified device index.
    */
   at::Generator getNewGenerator(c10::DeviceIndex device_index) const override;
+
+  /**
+   * @brief Returns the default generator for the specified RBLN device.
+   *
+   * @param device_index The RBLN device index.
+   * @return The default generator associated with the device.
+   */
+  const at::Generator& getDefaultGenerator(c10::DeviceIndex device_index) const override;
 };
 
 struct C10_RBLN_API RBLNHooksArgs : public at::PrivateUse1HooksArgs {};

--- a/test/rbln/test_generator_reproducibility.py
+++ b/test/rbln/test_generator_reproducibility.py
@@ -1,0 +1,66 @@
+# Owner(s): ["module: PrivateUse1"]
+
+"""Unit tests for the RBLN Generator initial implementation.
+
+Coverage:
+  1. Seed initialization — ``manual_seed`` correctly sets the generator's
+     initial seed, which is observable through ``initial_seed``.
+
+  2. State save and restore — the generator state can be saved and restored
+     to reproduce the same random number sequence.
+
+  3. Reproducibility — an RBLN generator initialized with the same seed as a
+     CPU generator produces the same random sequence for the tested random
+     operation.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+import torch_rbln  # noqa: F401  (registers the rbln backend)
+
+
+@pytest.mark.test_set_ci
+class TestGeneratorBasic(TestCase):
+    """Basic tests for the RBLN ``torch.Generator`` implementation."""
+
+    def test_manual_seed(self):
+        torch.manual_seed(42)
+
+        self.assertEqual(torch_rbln._C.get_default_generator().initial_seed(), 42)
+
+    def test_generator_set_seed(self):
+        g = torch.Generator(device="rbln").manual_seed(4242)
+
+        self.assertEqual(g.initial_seed(), 4242)
+
+    def test_generator_get_and_set_state(self):
+        g0 = torch.Generator(device="rbln").manual_seed(424242)
+        initial_state = g0.get_state()
+        x = torch.randint(1024, (10,), device="rbln", generator=g0)
+
+        g1 = torch.Generator(device="rbln")
+        g1.set_state(initial_state)
+        y = torch.randint(1024, (10,), device="rbln", generator=g1)
+
+        self.assertEqual(x.cpu(), y.cpu())
+
+    def test_generator_reproducibility(self):
+        rbln_g = torch.Generator(device="rbln").manual_seed(42424242)
+        cpu_g = torch.Generator(device="cpu").manual_seed(42424242)
+
+        rbln_x = torch.randint(1024, (10,), device="rbln", generator=rbln_g)
+        cpu_x = torch.randint(1024, (10,), device="cpu", generator=cpu_g)
+
+        self.assertEqual(rbln_x.cpu(), cpu_x)
+
+
+instantiate_device_type_tests(TestGeneratorBasic, globals(), only_for="privateuse1")
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/rbln/test_generator_reproducibility.py
+++ b/test/rbln/test_generator_reproducibility.py
@@ -19,7 +19,8 @@ Coverage:
   4. Isolation — RBLN random ops do not consume the global CPU RNG stream,
      and CPU random ops do not consume the RBLN default generator stream.
 
-  5. Validation — generators from another backend are rejected with a clear
+  5. Validation — generators from another backend or wrong device index are
+     rejected with a clear
      error; malformed RNG state blobs (wrong device, wrong dtype, too short,
      wrong size, non-contiguous) are rejected, and a failed ``set_state``
      leaves the generator unmodified.
@@ -256,6 +257,27 @@ class TestGeneratorValidation(TestCase):
         h = torch.Generator(device="rbln").manual_seed(13)
         self.assertEqual(_sample(generator=g).cpu(), _sample(generator=h).cpu())
 
+    def test_set_state_rejects_non_cpu_state(self):
+        # set_state consumes a CPU ByteTensor; a device-resident state blob
+        # must be rejected before any header reads.
+        g = torch.Generator(device="rbln")
+        good_numel = g.get_state().numel()
+        rbln_state = torch.zeros(good_numel, dtype=torch.uint8, device="rbln")
+
+        with self.assertRaisesRegex(RuntimeError, "(?i)cpu|device"):
+            g.set_state(rbln_state)
+
+    def test_get_state_contract(self):
+        # The blob round-tripped by get/set_state and torch.random.fork_rng
+        # must be a contiguous CPU ByteTensor of a stable size.
+        g = torch.Generator(device="rbln").manual_seed(7)
+        state = g.get_state()
+
+        self.assertEqual(state.device.type, "cpu")
+        self.assertEqual(state.dtype, torch.uint8)
+        self.assertTrue(state.is_contiguous())
+        self.assertEqual(state.numel(), torch.Generator(device="rbln").get_state().numel())
+
 
 @pytest.mark.test_set_ci
 @unittest.skipUnless(RBLN_DEVICE_COUNT >= 2, "requires at least 2 RBLN devices")
@@ -314,6 +336,15 @@ class TestMultiDeviceGenerator(TestCase):
 
         for x, y in zip(xs, ys):
             self.assertEqual(x.cpu(), y.cpu())
+
+    def test_rejects_wrong_device_index_generator(self):
+        # Wrong-index rejection is a distinct check from wrong-backend
+        # rejection: check_generator passes (it IS an RBLNGeneratorImpl),
+        # and the device-index TORCH_CHECK must fire instead.
+        g1 = torch.Generator(device="rbln:1").manual_seed(1234)
+
+        with self.assertRaisesRegex(RuntimeError, "(?i)device|rbln"):
+            _sample(device="rbln:0", generator=g1)
 
 
 @pytest.mark.test_set_ci
@@ -404,6 +435,167 @@ class TestGeneratorThreadSafety(TestCase):
         g.manual_seed(42)
         h = torch.Generator(device="rbln").manual_seed(42)
         self.assertEqual(_sample(generator=g).cpu(), _sample(generator=h).cpu())
+
+
+@pytest.mark.test_set_ci
+class TestFallbackBorrowSafety(TestCase):
+    """Regression tests for borrow release when generator validation throws.
+
+    The CPU fallback borrows tensor args off the stack before the generator
+    argument is validated. If check_generator / the device-index TORCH_CHECK
+    throws, the BorrowReleaseGuard must release those borrows; otherwise the
+    next free on a still-borrowed vaddr throws from a noexcept ~TensorImpl
+    deleter and terminates the process. A factory op like randint carries no
+    tensor inputs and cannot exercise this path, so these tests use in-place
+    ops whose `self` is borrowed at the time of the throw.
+    """
+
+    def _assert_tensor_still_healthy(self, x):
+        # The failed call must not have leaked x's borrow: x must remain
+        # readable and writable, and freeing it (plus fresh alloc/free
+        # churn) must not crash the process.
+        x.fill_(0)
+        self.assertEqual(x.cpu(), torch.zeros_like(x, device="cpu"))
+        del x
+        for _ in range(4):
+            t = torch.empty(1024, device="rbln")
+            del t
+
+    def test_failed_generator_check_releases_borrows(self):
+        x = torch.empty(64, device="rbln")
+        cpu_g = torch.Generator(device="cpu").manual_seed(1234)
+
+        with self.assertRaisesRegex(RuntimeError, "(?i)rbln|privateuse"):
+            x.uniform_(generator=cpu_g)
+
+        self._assert_tensor_still_healthy(x)
+
+    def test_failed_generator_check_releases_tensorlist_borrows(self):
+        # Same throw point, but with additional borrowed tensor args in the
+        # stack (weights input to multinomial) beyond the output.
+        weights = torch.ones(32, device="rbln")
+        cpu_g = torch.Generator(device="cpu").manual_seed(1234)
+
+        with self.assertRaises(RuntimeError):
+            torch.multinomial(weights, 8, replacement=True, generator=cpu_g)
+
+        self._assert_tensor_still_healthy(weights)
+
+    @unittest.skipUnless(RBLN_DEVICE_COUNT >= 2, "requires at least 2 RBLN devices")
+    def test_failed_device_index_check_releases_borrows(self):
+        # The second throw site in the generator block: an RBLN generator
+        # whose device index does not match the op's target device.
+        x = torch.empty(64, device="rbln:0")
+        g1 = torch.Generator(device="rbln:1").manual_seed(1234)
+
+        with self.assertRaises(RuntimeError):
+            x.uniform_(generator=g1)
+
+        self._assert_tensor_still_healthy(x)
+
+
+@pytest.mark.test_set_ci
+class TestGeneratorCoverageBreadth(TestCase):
+    """Broader op coverage and mid-stream state semantics."""
+
+    # Generator-consuming fallback ops beyond randint. Each entry must hit
+    # the OptionalGenerator path in get_or_populate_schema_info for its own
+    # schema. Factory-style and in-place ops are both represented.
+    _OPS = {
+        "rand": lambda device, g: torch.rand(64, device=device, generator=g),
+        "randperm": lambda device, g: torch.randperm(64, device=device, generator=g),
+        "uniform_": lambda device, g: torch.empty(64, device=device).uniform_(generator=g),
+        "normal_": lambda device, g: torch.empty(64, device=device).normal_(generator=g),
+        "multinomial": lambda device, g: torch.multinomial(
+            torch.ones(64, device=device), 16, replacement=True, generator=g
+        ),
+    }
+
+    def test_ops_reproducible_with_same_seed(self):
+        for name, op in self._OPS.items():
+            with self.subTest(op=name):
+                g0 = torch.Generator(device="rbln").manual_seed(1234)
+                g1 = torch.Generator(device="rbln").manual_seed(1234)
+
+                self.assertEqual(op("rbln", g0).cpu(), op("rbln", g1).cpu())
+
+    def test_ops_match_cpu_stream_with_same_seed(self):
+        # The fallback runs the CPU kernel against the associated fallback
+        # CPU generator, so an equally seeded pure-CPU run must match.
+        for name, op in self._OPS.items():
+            with self.subTest(op=name):
+                rbln_g = torch.Generator(device="rbln").manual_seed(4242)
+                cpu_g = torch.Generator(device="cpu").manual_seed(4242)
+
+                self.assertEqual(op("rbln", rbln_g).cpu(), op("cpu", cpu_g))
+
+    def test_ops_reproducible_via_default_generator(self):
+        for name, op in self._OPS.items():
+            with self.subTest(op=name):
+                torch.rbln.manual_seed(31337)
+                x = op("rbln", None)
+
+                torch.rbln.manual_seed(31337)
+                y = op("rbln", None)
+
+                self.assertEqual(x.cpu(), y.cpu())
+
+    def test_mid_stream_state_transplant(self):
+        # Snapshot a generator mid-stream (not at its initial state) and
+        # transplant it into a fresh generator: the continuation must match.
+        # This is the case that actually verifies the fallback CPU state is
+        # captured, not just the seed header.
+        g0 = torch.Generator(device="rbln").manual_seed(2718)
+        _ = _sample(generator=g0, n=100)  # advance past the initial state
+        snapshot = g0.get_state()
+        x = _sample(generator=g0, n=50)
+
+        g1 = torch.Generator(device="rbln")  # different seed, different state
+        g1.set_state(snapshot)
+        y = _sample(generator=g1, n=50)
+
+        self.assertEqual(x.cpu(), y.cpu())
+
+    def test_mid_stream_default_rng_state_transplant(self):
+        # Same mid-stream semantics through the module-level default path.
+        torch.rbln.manual_seed(1618)
+        _ = _sample(n=100)
+        snapshot = torch.rbln.get_rng_state()
+        x = _sample(n=50)
+
+        torch.rbln.manual_seed(0)  # deliberately clobber
+        torch.rbln.set_rng_state(snapshot)
+        y = _sample(n=50)
+
+        self.assertEqual(x.cpu(), y.cpu())
+
+    def test_concurrent_generators_are_independent(self):
+        # Two threads sampling from two distinct generators must each
+        # reproduce their own serial sequence: the shared-mutex fix must
+        # provide correctness without cross-generator interference.
+        results = {}
+
+        def worker(tag, seed):
+            g = torch.Generator(device="rbln").manual_seed(seed)
+            results[tag] = [torch.rand(256, device="rbln", generator=g).cpu() for _ in range(50)]
+
+        threads = [
+            threading.Thread(target=worker, args=("a", 111)),
+            threading.Thread(target=worker, args=("b", 222)),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        for tag, seed in (("a", 111), ("b", 222)):
+            g = torch.Generator(device="rbln").manual_seed(seed)
+            for step, expected in enumerate(results[tag]):
+                self.assertEqual(
+                    torch.rand(256, device="rbln", generator=g).cpu(),
+                    expected,
+                    msg=f"thread {tag} diverged from serial replay at step {step}",
+                )
 
 
 instantiate_device_type_tests(TestGeneratorBasic, globals(), only_for="privateuse1")

--- a/test/rbln/test_generator_reproducibility.py
+++ b/test/rbln/test_generator_reproducibility.py
@@ -7,14 +7,34 @@ Coverage:
      initial seed, which is observable through ``initial_seed``.
 
   2. State save and restore — the generator state can be saved and restored
-     to reproduce the same random number sequence.
+     to reproduce the same random number sequence, both through explicit
+     ``Generator`` objects and through the per-device default generators
+     (``torch.rbln.get_rng_state`` / ``torch.rbln.set_rng_state``).
 
   3. Reproducibility — an RBLN generator initialized with the same seed as a
      CPU generator produces the same random sequence for the tested random
-     operation.
+     operation; default-generator ops (``generator=None``) reproduce after
+     ``torch.rbln.manual_seed``.
+
+  4. Isolation — RBLN random ops do not consume the global CPU RNG stream,
+     and CPU random ops do not consume the RBLN default generator stream.
+
+  5. Validation — generators from another backend are rejected with a clear
+     error; malformed RNG state blobs (wrong device, wrong dtype, too short,
+     wrong size, non-contiguous) are rejected, and a failed ``set_state``
+     leaves the generator unmodified.
+
+  6. Multi-device — per-device default generators are independent, and
+     ``manual_seed_all`` seeds every device.
+
+  7. Integration — ``torch.random.fork_rng(device_type="rbln")`` saves and
+     restores the default generator state.
 """
 
 from __future__ import annotations
+
+import threading
+import unittest
 
 import pytest
 import torch
@@ -22,6 +42,14 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 import torch_rbln  # noqa: F401  (registers the rbln backend)
+
+
+RBLN_DEVICE_COUNT = torch_rbln._C.device_count()
+
+
+def _sample(device="rbln", generator=None, n=16):
+    """One canonical fallback-path random op used across the tests."""
+    return torch.randint(0, 1024, (n,), device=device, generator=generator)
 
 
 @pytest.mark.test_set_ci
@@ -41,11 +69,11 @@ class TestGeneratorBasic(TestCase):
     def test_generator_get_and_set_state(self):
         g0 = torch.Generator(device="rbln").manual_seed(424242)
         initial_state = g0.get_state()
-        x = torch.randint(1024, (10,), device="rbln", generator=g0)
+        x = _sample(generator=g0, n=10)
 
         g1 = torch.Generator(device="rbln")
         g1.set_state(initial_state)
-        y = torch.randint(1024, (10,), device="rbln", generator=g1)
+        y = _sample(generator=g1, n=10)
 
         self.assertEqual(x.cpu(), y.cpu())
 
@@ -53,10 +81,329 @@ class TestGeneratorBasic(TestCase):
         rbln_g = torch.Generator(device="rbln").manual_seed(42424242)
         cpu_g = torch.Generator(device="cpu").manual_seed(42424242)
 
-        rbln_x = torch.randint(1024, (10,), device="rbln", generator=rbln_g)
-        cpu_x = torch.randint(1024, (10,), device="cpu", generator=cpu_g)
+        rbln_x = _sample(device="rbln", generator=rbln_g, n=10)
+        cpu_x = _sample(device="cpu", generator=cpu_g, n=10)
 
         self.assertEqual(rbln_x.cpu(), cpu_x)
+
+    def test_set_state_restores_initial_seed(self):
+        g0 = torch.Generator(device="rbln").manual_seed(987654321)
+        state = g0.get_state()
+
+        g1 = torch.Generator(device="rbln")
+        g1.set_state(state)
+
+        self.assertEqual(g1.initial_seed(), 987654321)
+
+    def test_generator_device(self):
+        g = torch.Generator(device="rbln")
+        self.assertEqual(g.device.type, "rbln")
+
+        default_gen = torch_rbln._C.get_default_generator()
+        self.assertEqual(default_gen.device.type, "rbln")
+
+    def test_seed_randomizes(self):
+        # Generator.seed() must draw a fresh nondeterministic seed and use it,
+        # not merely return the current one.
+        g = torch.Generator(device="rbln").manual_seed(0)
+        new_seed = g.seed()
+        self.assertEqual(g.initial_seed(), new_seed)
+
+
+@pytest.mark.test_set_ci
+class TestDefaultGenerator(TestCase):
+    """Default (generator=None) path: seeding, reproducibility, isolation."""
+
+    def test_manual_seed_reproducibility_without_explicit_generator(self):
+        # The reviewer's original repro: default-generator ops must be
+        # reproducible after torch.rbln.manual_seed().
+        torch.rbln.manual_seed(1234)
+        x = _sample()
+
+        torch.rbln.manual_seed(1234)
+        y = _sample()
+
+        self.assertEqual(x.cpu(), y.cpu())
+
+    def test_default_and_explicit_generator_streams_match(self):
+        # generator=None must consume the *default* generator's stream, so it
+        # should produce the same sequence as an explicit generator with the
+        # same seed.
+        torch.rbln.manual_seed(5678)
+        x = _sample()
+
+        g = torch.Generator(device="rbln").manual_seed(5678)
+        y = _sample(generator=g)
+
+        self.assertEqual(x.cpu(), y.cpu())
+
+    def test_rbln_ops_do_not_consume_cpu_rng(self):
+        cpu_state_before = torch.get_rng_state()
+
+        _ = _sample(n=1024)
+
+        self.assertEqual(torch.get_rng_state(), cpu_state_before)
+
+    def test_cpu_ops_do_not_consume_rbln_rng(self):
+        torch.rbln.manual_seed(31337)
+        rbln_state_before = torch.rbln.get_rng_state()
+
+        _ = torch.randint(0, 1024, (1024,), device="cpu")
+
+        self.assertEqual(torch.rbln.get_rng_state(), rbln_state_before)
+
+    def test_cpu_rng_interleaving_does_not_break_rbln_reproducibility(self):
+        torch.rbln.manual_seed(2024)
+        x = _sample()
+
+        torch.rbln.manual_seed(2024)
+        _ = torch.rand(4096)  # perturb the global CPU stream in between
+        y = _sample()
+
+        self.assertEqual(x.cpu(), y.cpu())
+
+    def test_default_rng_state_round_trip(self):
+        torch.rbln.manual_seed(4321)
+        state = torch.rbln.get_rng_state()
+        x = _sample()
+
+        torch.rbln.set_rng_state(state)
+        y = _sample()
+
+        self.assertEqual(x.cpu(), y.cpu())
+
+    def test_get_rng_state_does_not_advance_stream(self):
+        torch.rbln.manual_seed(999)
+        _ = torch.rbln.get_rng_state()
+        _ = torch.rbln.get_rng_state()
+        x = _sample()
+
+        torch.rbln.manual_seed(999)
+        y = _sample()
+
+        self.assertEqual(x.cpu(), y.cpu())
+
+
+@pytest.mark.test_set_ci
+class TestGeneratorValidation(TestCase):
+    """Rejection of foreign generators and malformed state blobs."""
+
+    def test_rejects_cpu_generator_for_rbln_op(self):
+        cpu_g = torch.Generator(device="cpu").manual_seed(1234)
+
+        with self.assertRaisesRegex(RuntimeError, "(?i)rbln|privateuse"):
+            _sample(generator=cpu_g)
+
+    def test_rejects_rbln_generator_for_cpu_op(self):
+        rbln_g = torch.Generator(device="rbln").manual_seed(1234)
+
+        with self.assertRaises(RuntimeError):
+            _sample(device="cpu", generator=rbln_g)
+
+    def test_set_state_rejects_empty_state(self):
+        g = torch.Generator(device="rbln")
+
+        with self.assertRaisesRegex(RuntimeError, "size"):
+            g.set_state(torch.empty(0, dtype=torch.uint8))
+
+    def test_set_state_rejects_short_state(self):
+        g = torch.Generator(device="rbln")
+
+        # Shorter than the seed header alone.
+        with self.assertRaisesRegex(RuntimeError, "size"):
+            g.set_state(torch.zeros(4, dtype=torch.uint8))
+
+    def test_set_state_rejects_wrong_size_state(self):
+        g = torch.Generator(device="rbln")
+        good_numel = g.get_state().numel()
+
+        for bad_numel in (good_numel - 1, good_numel + 1):
+            with self.assertRaisesRegex(RuntimeError, "size"):
+                g.set_state(torch.zeros(bad_numel, dtype=torch.uint8))
+
+    def test_set_state_rejects_non_contiguous_state(self):
+        g = torch.Generator(device="rbln")
+        good = g.get_state()
+        non_contiguous = good.repeat(2)[::2]
+        self.assertFalse(non_contiguous.is_contiguous())
+
+        with self.assertRaisesRegex(RuntimeError, "contiguous"):
+            g.set_state(non_contiguous)
+
+    def test_set_state_rejects_wrong_dtype_state(self):
+        g = torch.Generator(device="rbln")
+        good_numel = g.get_state().numel()
+
+        with self.assertRaisesRegex(RuntimeError, "ByteTensor"):
+            g.set_state(torch.zeros(good_numel, dtype=torch.float32))
+
+    def test_failed_set_state_leaves_generator_unmodified(self):
+        g = torch.Generator(device="rbln").manual_seed(13)
+        before = g.get_state()
+
+        for bad in (
+            torch.empty(0, dtype=torch.uint8),
+            torch.zeros(before.numel() - 1, dtype=torch.uint8),
+            before.repeat(2)[::2],
+        ):
+            with self.assertRaises(RuntimeError):
+                g.set_state(bad)
+
+        self.assertEqual(g.get_state(), before)
+        self.assertEqual(g.initial_seed(), 13)
+
+        # The generator must still be usable and on the original stream.
+        h = torch.Generator(device="rbln").manual_seed(13)
+        self.assertEqual(_sample(generator=g).cpu(), _sample(generator=h).cpu())
+
+
+@pytest.mark.test_set_ci
+@unittest.skipUnless(RBLN_DEVICE_COUNT >= 2, "requires at least 2 RBLN devices")
+class TestMultiDeviceGenerator(TestCase):
+    """Per-device default generator independence."""
+
+    def test_default_generators_are_distinct_objects(self):
+        g0 = torch_rbln._C.get_default_generator(0)
+        g1 = torch_rbln._C.get_default_generator(1)
+
+        g0.manual_seed(111)
+        g1.manual_seed(222)
+
+        self.assertEqual(g0.initial_seed(), 111)
+        self.assertEqual(g1.initial_seed(), 222)
+
+    def test_sampling_on_one_device_does_not_advance_another(self):
+        torch.rbln.manual_seed_all(1234)
+        state1_before = torch.rbln.get_rng_state(1)
+
+        _ = _sample(device="rbln:0", n=1024)
+
+        self.assertEqual(torch.rbln.get_rng_state(1), state1_before)
+
+    def test_same_seed_gives_same_stream_on_each_device(self):
+        torch.rbln.manual_seed_all(4242)
+
+        x0 = _sample(device="rbln:0")
+        x1 = _sample(device="rbln:1")
+
+        print(x0, x1)
+
+        self.assertEqual(x0.cpu(), x1.cpu())
+
+    def test_manual_seed_all_reproducibility(self):
+        torch.rbln.manual_seed_all(31415)
+        x0 = _sample(device="rbln:0")
+        x1 = _sample(device="rbln:1")
+
+        torch.rbln.manual_seed_all(31415)
+        y0 = _sample(device="rbln:0")
+        y1 = _sample(device="rbln:1")
+
+        self.assertEqual(x0.cpu(), y0.cpu())
+        self.assertEqual(x1.cpu(), y1.cpu())
+
+    def test_per_device_rng_state_round_trip(self):
+        torch.rbln.manual_seed_all(2718)
+        states = [torch.rbln.get_rng_state(i) for i in range(RBLN_DEVICE_COUNT)]
+
+        xs = [_sample(device=f"rbln:{i}") for i in range(RBLN_DEVICE_COUNT)]
+
+        for i, state in enumerate(states):
+            torch.rbln.set_rng_state(state, i)
+        ys = [_sample(device=f"rbln:{i}") for i in range(RBLN_DEVICE_COUNT)]
+
+        for x, y in zip(xs, ys):
+            self.assertEqual(x.cpu(), y.cpu())
+
+
+@pytest.mark.test_set_ci
+class TestForkRng(TestCase):
+    """torch.random.fork_rng integration through get/set_rng_state."""
+
+    def test_fork_rng_restores_default_state(self):
+        torch.rbln.manual_seed(1234)
+        before = torch.rbln.get_rng_state()
+
+        with torch.random.fork_rng(device_type="rbln"):
+            _ = torch.rand(10, device="rbln")
+            # The op inside the block must have consumed the *RBLN* default
+            # stream (not the global CPU stream); otherwise this save/restore
+            # would be vacuous.
+            self.assertNotEqual(torch.rbln.get_rng_state(), before)
+
+        self.assertEqual(torch.rbln.get_rng_state(), before)
+
+    def test_fork_rng_replays_same_sequence(self):
+        torch.rbln.manual_seed(5678)
+
+        with torch.random.fork_rng(device_type="rbln"):
+            x = _sample()
+
+        y = _sample()
+
+        self.assertEqual(x.cpu(), y.cpu())
+
+    def test_fork_rng_restores_on_exception(self):
+        torch.rbln.manual_seed(4321)
+        before = torch.rbln.get_rng_state()
+
+        with self.assertRaises(ValueError):
+            with torch.random.fork_rng(device_type="rbln"):
+                _ = torch.rand(10, device="rbln")
+                raise ValueError("boom")
+
+        self.assertEqual(torch.rbln.get_rng_state(), before)
+
+    def test_fork_rng_explicit_device_list(self):
+        torch.rbln.manual_seed(8888)
+        before = torch.rbln.get_rng_state(0)
+
+        with torch.random.fork_rng(devices=[0], device_type="rbln"):
+            _ = torch.rand(10, device="rbln:0")
+
+        self.assertEqual(torch.rbln.get_rng_state(0), before)
+
+
+@pytest.mark.test_set_ci
+class TestGeneratorThreadSafety(TestCase):
+    """Smoke test for concurrent seeding vs. fallback sampling.
+
+    This cannot prove the absence of a data race (run under TSan for that),
+    but it crashes or corrupts state loudly if the state APIs and the CPU
+    fallback sampling path do not synchronize on the same mutex.
+    """
+
+    def test_concurrent_seed_and_sample(self):
+        g = torch.Generator(device="rbln").manual_seed(1234)
+        errors = []
+
+        def seeder():
+            try:
+                for i in range(200):
+                    g.manual_seed(i)
+                    _ = g.get_state()
+            except Exception as e:  # noqa: BLE001
+                errors.append(e)
+
+        def sampler():
+            try:
+                for _ in range(200):
+                    _ = torch.rand(256, device="rbln", generator=g)
+            except Exception as e:  # noqa: BLE001
+                errors.append(e)
+
+        threads = [threading.Thread(target=seeder), threading.Thread(target=sampler)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        self.assertEqual(errors, [])
+
+        # The generator must still be in a coherent, usable state.
+        g.manual_seed(42)
+        h = torch.Generator(device="rbln").manual_seed(42)
+        self.assertEqual(_sample(generator=g).cpu(), _sample(generator=h).cpu())
 
 
 instantiate_device_type_tests(TestGeneratorBasic, globals(), only_for="privateuse1")

--- a/torch_rbln/csrc/rbln/Module.cpp
+++ b/torch_rbln/csrc/rbln/Module.cpp
@@ -5,6 +5,7 @@
 #include <c10/rbln/DeviceMappingManager.h>
 #include <c10/rbln/RBLNFallbackConfig.h>
 #include <c10/rbln/RBLNFunctions.h>
+#include <c10/rbln/RBLNGenerator.h>
 #include <c10/rbln/RBLNLogging.h>
 #include <c10/rbln/RBLNProfiler.h>
 #include <c10/rbln/RBLNSupportedDtypes.h>
@@ -108,6 +109,13 @@ void register_public_device_api(py::module_& module) {
       "_get_device_topology",
       []() -> c10::rbln::DeviceTopology { return c10::rbln::DeviceMappingManager::getInstance().getDeviceTopology(); },
       "Get the complete device topology.");
+
+  // Reproducibility
+  module.def(
+      "get_default_generator",
+      &c10::rbln::get_default_rbln_generator,
+      py::arg("device_index") = -1,
+      "get the default generator for an RBLN device.");
 }
 
 // set_device_layout_like operates on a whole tensor allocation, so a view

--- a/torch_rbln/device/__init__.py
+++ b/torch_rbln/device/__init__.py
@@ -2,3 +2,4 @@ from torch_rbln.device.device import *  # noqa: F403`
 from torch_rbln.device.device_tensor_utils import *  # noqa: F403`
 from torch_rbln.memory import *  # noqa: F403`
 from torch_rbln.profiler import *  # noqa: F403`
+from torch_rbln.random import *  # noqa: F403`

--- a/torch_rbln/device/__init__.py
+++ b/torch_rbln/device/__init__.py
@@ -1,5 +1,5 @@
-from torch_rbln.device.device import *  # noqa: F403`
-from torch_rbln.device.device_tensor_utils import *  # noqa: F403`
-from torch_rbln.memory import *  # noqa: F403`
-from torch_rbln.profiler import *  # noqa: F403`
-from torch_rbln.random import *  # noqa: F403`
+from torch_rbln.device.device import *  # noqa: F403
+from torch_rbln.device.device_tensor_utils import *  # noqa: F403
+from torch_rbln.memory import *  # noqa: F403
+from torch_rbln.profiler import *  # noqa: F403
+from torch_rbln.random import *  # noqa: F403

--- a/torch_rbln/device/device.py
+++ b/torch_rbln/device/device.py
@@ -16,6 +16,7 @@ from torch_rbln._internal.ops_utils import SupportedDtypes
 
 
 __all__ = [
+    "_is_in_bad_fork",
     "current_device",
     "device_count",
     "physical_device_count",
@@ -34,6 +35,15 @@ __all__ = [
 # Whether this process has selected an RBLN device (torch.cuda-style lazy-init
 # flag). DeviceMesh reads it to decide whether to auto-select a per-rank device.
 _initialized: bool = False
+
+
+def _is_in_bad_fork():
+    """Return whether the current process is in a bad fork state.
+
+    RBLN does not currently maintain fork-specific accelerator state, so this
+    always returns False.
+    """
+    return False
 
 
 def current_device() -> int:

--- a/torch_rbln/random.py
+++ b/torch_rbln/random.py
@@ -1,0 +1,32 @@
+"""torch_rbln Python bindings for random number generation.
+
+This module provides functions for managing random number generators on RBLN
+devices and integrates with PyTorch's accelerator random-seeding interface.
+"""
+
+import torch_rbln._C
+
+
+__all__ = [
+    "manual_seed",
+    "manual_seed_all",
+]
+
+
+def manual_seed(seed: int) -> None:
+    """Set the seed for the current RBLN device.
+
+    Args:
+        seed (int): The seed to set.
+    """
+    torch_rbln._C.get_default_generator(torch_rbln._C.current_device()).manual_seed(int(seed))
+
+
+def manual_seed_all(seed: int) -> None:
+    """Set the seed for all RBLN devices.
+
+    Args:
+        seed (int): The seed to set.
+    """
+    for device_index in range(torch_rbln._C.device_count()):
+        torch_rbln._C.get_default_generator(device_index).manual_seed(int(seed))

--- a/torch_rbln/random.py
+++ b/torch_rbln/random.py
@@ -4,12 +4,18 @@ This module provides functions for managing random number generators on RBLN
 devices and integrates with PyTorch's accelerator random-seeding interface.
 """
 
+from typing import Union
+
+import torch
+
 import torch_rbln._C
 
 
 __all__ = [
     "manual_seed",
     "manual_seed_all",
+    "get_rng_state",
+    "set_rng_state",
 ]
 
 
@@ -30,3 +36,41 @@ def manual_seed_all(seed: int) -> None:
     """
     for device_index in range(torch_rbln._C.device_count()):
         torch_rbln._C.get_default_generator(device_index).manual_seed(int(seed))
+
+
+def _get_device_index(device: Union[int, str, torch.device]) -> int:
+    """Normalize a device argument to an RBLN device index."""
+
+    if isinstance(device, str):
+        device = torch.device(device)
+    if isinstance(device, torch.device):
+        if device.type != "rbln":
+            raise ValueError(f"Expected an RBLN device, but got: {device}")
+        device = device.index if device.index is not None else -1
+    if not isinstance(device, int):
+        raise TypeError(f"Expected an int, str, or torch.device, but got: {type(device)}")
+    if device == -1:
+        device = torch_rbln._C.current_device()
+    return device
+
+
+def get_rng_state(device: Union[int, str, torch.device] = "rbln") -> torch.Tensor:
+    """Return the RNG state of the specified RBLN device as a ByteTensor.
+
+    Args:
+        device (int, str, or torch.device, optional): The device whose RNG
+            state to return. Default: ``"rbln"`` (the current RBLN device).
+    """
+    return torch_rbln._C.get_default_generator(_get_device_index(device)).get_state()
+
+
+def set_rng_state(new_state: torch.Tensor, device: Union[int, str, torch.device] = "rbln") -> None:
+    """Set the RNG state of the specified RBLN device.
+
+    Args:
+        new_state (torch.Tensor): The desired state.
+        device (int, str, or torch.device, optional): The device whose RNG
+            state to set. Default: ``"rbln"`` (the current RBLN device).
+    """
+    new_state_copy = new_state.clone(memory_format=torch.contiguous_format)
+    torch_rbln._C.get_default_generator(_get_device_index(device)).set_state(new_state_copy)


### PR DESCRIPTION
# Summary

Added initial generator support for the RBLN device.

This PR implements `set_state` and `get_state` for `RBLNGenerator`. Since generator-consuming operators that are currently supported through the CPU fallback path require a CPU generator, each RBLN generator now maintains an associated CPU generator for fallback execution. The CPU fallback logic was also extended to recognize optional generator arguments and replace an RBLN generator with its corresponding fallback CPU generator.

Additionally, this PR adds persistent per-device default generators and exposes the necessary generator and fork-safety APIs through the RBLN device module.

# What's implemented

* Added `OptionalGenerator` to `CpuFbArgKind`.
* Added handling for `TypeKind::OptionalType` → `TypeKind::GeneratorType` in `get_or_populate_schema_info`.
* Added `OptionalGenerator` IValue handling in `cpu_fallback_rbln`, using `RBLNGenerator::get_fallback_generator()`.
* Implemented `set_state` and `get_state` for `RBLNGenerator`.
* Added an associated CPU generator to `RBLNGenerator` for use in the CPU fallback path.
* Implemented persistent per-device default RBLN generators.
* Added `manual_seed` and `manual_seed_all` to the RBLN device module.
* Added `_is_in_bad_fork` to the RBLN device module.
* Fixed `RBLNGenerator::seed` to properly set random seed instead of returning current seed.

# Tests

`test/rbln/test_generator_reproducibility.py`

# Notes

* This PR refines the approach proposed in [this issue](https://github.com/rebellions-sw/torch-rbln-internal/issues/46#issuecomment-4451294841).
* The generator-related logic introduced in this PR should be revisited once operators such as `aten::uniform_` and `aten::normal_ `can be handled natively without falling back to the CPU path.