### PR TITLE
feat(memory): add torch.rbln.release_offload_temp_storage()

### DIFF
--- a/c10/rbln/RBLNFunctions.cpp
+++ b/c10/rbln/RBLNFunctions.cpp
@@ -1018,4 +1018,16 @@ void set_file_offloading_enabled(bool enabled) {
       enabled);
 }
 
+uint64_t release_offload_temp_storage() {
+  RBLN_LOG_DEBUG("Calling rbln_release_offload_temp_storage");
+  // Shutdown-path call, so gated the same way as the offload toggle above.
+  if (!runtime_available()) {
+    return 0;
+  }
+  uint64_t num_files_removed = 0;
+  RBLN_CHECK(
+      !::rbln::rbln_release_offload_temp_storage(&num_files_removed), "rbln_release_offload_temp_storage failed");
+  return num_files_removed;
+}
+
 } // namespace c10::rbln

--- a/c10/rbln/RBLNFunctions.h
+++ b/c10/rbln/RBLNFunctions.h
@@ -494,6 +494,16 @@ C10_RBLN_API void reset_peak_memory_stats(const c10::Device& device);
 C10_RBLN_API void set_file_offloading_enabled(bool enabled);
 
 /**
+ * @brief Removes this process's file-offloading temp files and directories.
+ *
+ * Runtime teardown does this too, so call it only when shutdown may be killed first. Offloaded
+ * RBLN tensors must not be used afterwards.
+ *
+ * @return The number of temp files removed; 0 when the runtime is unavailable.
+ */
+C10_RBLN_API uint64_t release_offload_temp_storage();
+
+/**
  * @brief Diagnostic: time spent inside librbln boundary calls (borrow / v2v /
  * h2v / ...), so a profiler can split host overhead into "rebel runtime" vs
  * "torch-side dispatch". Gated: when disabled each boundary call pays only one

--- a/test/rbln/test_file_offloading.py
+++ b/test/rbln/test_file_offloading.py
@@ -22,6 +22,8 @@ The flag and the depth counter are both process-local, so each pytest-xdist
 worker is isolated; the class does not need ``single_worker``.
 """
 
+from unittest.mock import patch
+
 import pytest
 import torch
 from torch.testing._internal.common_utils import run_tests, TestCase
@@ -107,6 +109,13 @@ class TestFileOffloading(TestCase):
         num_removed = torch.rbln.release_offload_temp_storage()
         self.assertIsInstance(num_removed, int)
         self.assertGreaterEqual(num_removed, 0)
+
+    def test_release_offload_temp_storage_returns_binding_count(self):
+        """The wrapper is a pass-through: the binding's count is returned unchanged."""
+        with patch.object(torch_rbln_C, "_release_offload_temp_storage", return_value=7) as mock_release:
+            self.assertEqual(torch.rbln.release_offload_temp_storage(), 7)
+
+        mock_release.assert_called_once_with()
 
     def test_release_offload_temp_storage_is_idempotent(self):
         """Releasing twice is safe; the second call has nothing left to remove."""

--- a/test/rbln/test_file_offloading.py
+++ b/test/rbln/test_file_offloading.py
@@ -94,6 +94,34 @@ class TestFileOffloading(TestCase):
 
         self.assertEqual(torch_rbln_memory._offload_depth, 0)
 
+    # ------------------------------------------------------------------
+    # Temp storage release
+    # ------------------------------------------------------------------
+    def test_release_offload_temp_storage_surface(self):
+        """``release_offload_temp_storage`` is exposed and reports a file count."""
+        from torch_rbln.memory import release_offload_temp_storage  # noqa: F401
+
+        self.assertIn("release_offload_temp_storage", torch_rbln_memory.__all__)
+        self.assertTrue(hasattr(torch.rbln, "release_offload_temp_storage"))
+
+        num_removed = torch.rbln.release_offload_temp_storage()
+        self.assertIsInstance(num_removed, int)
+        self.assertGreaterEqual(num_removed, 0)
+
+    def test_release_offload_temp_storage_is_idempotent(self):
+        """Releasing twice is safe; the second call has nothing left to remove."""
+        torch.rbln.release_offload_temp_storage()
+        self.assertEqual(torch.rbln.release_offload_temp_storage(), 0)
+
+    def test_offload_usable_after_release(self):
+        """A release does not wedge the flag: offload() still works afterwards."""
+        torch.rbln.release_offload_temp_storage()
+
+        with torch.rbln.offload():
+            self.assertEqual(torch_rbln_memory._offload_depth, 1)
+
+        self.assertEqual(torch_rbln_memory._offload_depth, 0)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/test/rbln/test_runtime_unavailable.py
+++ b/test/rbln/test_runtime_unavailable.py
@@ -141,6 +141,21 @@ class TestRuntimeUnavailable(TestCase):
         )
         _assert_ok(self, result, "OFFLOAD_OK")
 
+    def test_release_offload_temp_storage_no_ops_when_runtime_unavailable(self):
+        """torch.rbln.release_offload_temp_storage() runs on the shutdown path, after the
+        runtime may already be gone, so it is gated like the offload toggle: it reports 0
+        files removed instead of dereferencing a dead runtime handle."""
+        result = _run_subprocess(
+            """
+            C._set_runtime_shutting_down(True)
+            assert C.runtime_available() is False
+            assert torch.rbln.release_offload_temp_storage() == 0
+            assert C._release_offload_temp_storage() == 0
+            print("RELEASE_OK")
+            """
+        )
+        _assert_ok(self, result, "RELEASE_OK")
+
     def test_flag_toggles_runtime_available(self):
         """Setting / clearing the shutdown flag flips runtime_available() and restores it."""
         result = _run_subprocess(

--- a/torch_rbln/csrc/rbln/Module.cpp
+++ b/torch_rbln/csrc/rbln/Module.cpp
@@ -455,6 +455,11 @@ void register_internal_api(py::module_& module) {
       &c10::rbln::set_file_offloading_enabled,
       "Internal: enable or disable process-wide RBLN vmemory file offloading.");
 
+  module.def(
+      "_release_offload_temp_storage",
+      &c10::rbln::release_offload_temp_storage,
+      "Internal: remove this process's file offloading temp files and directories.");
+
   // torch.profiler (kineto) integration
   module.def(
       "_register_kineto_profiler",

--- a/torch_rbln/memory.py
+++ b/torch_rbln/memory.py
@@ -22,6 +22,7 @@ __all__ = [
     "memory_reserved",
     "memory_stats",
     "offload",
+    "release_offload_temp_storage",
     "reset_accumulated_memory_stats",
     "reset_peak_memory_stats",
 ]
@@ -283,3 +284,17 @@ def offload() -> Iterator[None]:
             _offload_depth -= 1
             if _offload_depth == 0:
                 torch_rbln._C._set_file_offloading_enabled(False)
+
+
+def release_offload_temp_storage() -> int:
+    """
+    Remove this process's file offloading temp files and directories.
+
+    :func:`offload` writes into a per-process directory under ``RBLN_OFFLOAD_DIR`` (default
+    ``$HOME/.cache/rbln_cache/offload``) that the runtime removes on teardown. Call this on a
+    shutdown path that may be killed first. Offloaded tensors must not be used afterwards.
+
+    Returns:
+        int: The number of temp files removed.
+    """
+    return torch_rbln._C._release_offload_temp_storage()


### PR DESCRIPTION
## What

Adds `torch.rbln.release_offload_temp_storage() -> int`, which removes the file-offloading temp
files and per-process directory this process created, returning the number of files removed.

## Why

`torch.rbln.offload()` writes into a per-process dir under `RBLN_OFFLOAD_DIR` (default
`$HOME/.cache/rbln_cache/offload`). The rebel runtime removes that dir on teardown, but the
teardown hangs off a Python `atexit` hook — the last thing to run. vLLM escalates to SIGKILL a few
seconds after asking a worker to stop, so a worker killed mid-shutdown never reaches it and leaves
the dir behind; one DP4 run left 4.7 GB. This gives a shutdown path a way to reclaim the space up
front instead of waiting for teardown.

## How

Thin wrapper over rebel's `rbln_release_offload_temp_storage`, bound as
`_C._release_offload_temp_storage`. Gated on `runtime_available()` like the offload toggle, so it
is a no-op when there is no runtime.

Contract: offloaded tensors must not be used afterwards — their vmemory entries survive but the
on-disk backing is gone. A later offload write allocates a fresh dir, so the manager stays usable.
Only this process's own dir is touched; dirs left by a killed run are still reclaimed lazily by the
sweep the runtime does when it creates the next offload dir.

## Tests

Three tests in `test_file_offloading.py`: exposed in `__all__` and on `torch.rbln`, idempotent, and
`offload()` still usable after a release. The mechanism itself is covered by rebel-compiler's
`vmem_file_offloading_test.cc`.

## Related

* rebel-compiler: rebellions-sw/rebel_compiler#12421 — adds `rbln_release_offload_temp_storage`
* vllm-rbln: RBLN-SW/vllm-rbln#836 — the consumer, calls this from `RBLNWorker.shutdown()`

Merge order is bottom-up: rebel-compiler first, then this PR once a rebel-compiler wheel carrying
the new symbol is pinned in `constraints-build-dev.txt`, then vllm-rbln. CI here fails until then —
`FindRebel` takes headers from the installed wheel, which does not declare the symbol yet.
