### PR TITLE
fix(torch.compile): skip tensor-value repr in Dynamo ID_MATCH guard build

### DIFF
--- a/test/rbln/test_torch_compile_patch.py
+++ b/test/rbln/test_torch_compile_patch.py
@@ -1205,6 +1205,119 @@ class TestTorchCompileMonkeyPatch(TestCase):
         self.assertEqual(result.tolist(), [2, 4, 6])
 
 
+@pytest.mark.test_set_ci
+class TestDynamoGuardReprPatch(TestCase):
+    """Guard build must not materialize tensor values via ``repr``, and
+    user-facing ``repr(tensor)`` must stay unchanged. See fsw-inference#413."""
+
+    def setUp(self):
+        from torch._dynamo.guards import GuardBuilder
+
+        import torch_rbln._internal.monkey_patches as mp
+
+        # apply_all_patches() ran at torch_rbln import; pull the true originals
+        # from module state rather than the already-wrapped current values.
+        self._orig_repr = mp._original_tensor_repr if mp._original_tensor_repr is not None else torch.Tensor.__repr__
+        self._orig_id_match = (
+            mp._original_id_match_unchecked
+            if mp._original_id_match_unchecked is not None
+            else GuardBuilder.id_match_unchecked
+        )
+
+    def tearDown(self):
+        from torch._dynamo.guards import GuardBuilder
+
+        import torch_rbln._internal.monkey_patches as mp
+
+        # Restore bare originals, then re-apply from a clean slate so later tests
+        # on the same worker keep the patch (mirrors TestTorchCompileMonkeyPatch).
+        torch.Tensor.__repr__ = self._orig_repr
+        GuardBuilder.id_match_unchecked = self._orig_id_match
+        mp._dynamo_guard_repr_patched = False
+        mp.apply_all_patches()
+
+    def test_patch_is_idempotent(self):
+        import torch_rbln._internal.monkey_patches as mp
+
+        mp.patch_dynamo_guard_repr()
+        first = torch.Tensor.__repr__
+        mp.patch_dynamo_guard_repr()
+        self.assertIs(first, torch.Tensor.__repr__)
+
+    def test_user_repr_is_unchanged(self):
+        """Outside guard build, repr must be the untouched value repr."""
+        import torch_rbln._internal.monkey_patches as mp
+
+        mp.patch_dynamo_guard_repr()
+        t = torch.arange(6.0).reshape(2, 3)
+        self.assertEqual(repr(t), self._orig_repr(t))
+        self.assertIn("1.", repr(t))
+
+    def test_guard_scope_returns_type_not_value(self):
+        """With the guard-build flag set, repr must return the type (no value)."""
+        import torch_rbln._internal.monkey_patches as mp
+
+        mp.patch_dynamo_guard_repr()
+        t = torch.arange(6.0).reshape(2, 3)
+        mp._guard_repr_tls.active = True
+        try:
+            self.assertEqual(repr(t), repr(type(t)))
+        finally:
+            mp._guard_repr_tls.active = False
+        # Flag restored -> value repr again.
+        self.assertEqual(repr(t), self._orig_repr(t))
+
+    def test_remove_all_patches_restores(self):
+        from torch._dynamo.guards import GuardBuilder
+
+        import torch_rbln._internal.monkey_patches as mp
+
+        mp.patch_dynamo_guard_repr()
+        self.assertIsNot(torch.Tensor.__repr__, self._orig_repr)
+        self.assertIsNot(GuardBuilder.id_match_unchecked, self._orig_id_match)
+
+        remove_all_patches()
+
+        self.assertIs(torch.Tensor.__repr__, self._orig_repr)
+        self.assertIs(GuardBuilder.id_match_unchecked, self._orig_id_match)
+        self.assertFalse(mp._dynamo_guard_repr_patched)
+
+    def test_compile_does_not_repr_param_value_during_guard_build(self) -> None:
+        """End-to-end: compiling a fn that guards on a Parameter must not
+        materialize the Parameter value, and output must stay correct."""
+        import torch_rbln._internal.monkey_patches as mp
+
+        mp.patch_dynamo_guard_repr()
+
+        real_repr = mp._original_tensor_repr  # wrapper delegates here when flag off
+        assert real_repr is not None
+        value_repr_ids: list[int] = []
+
+        def repr_spy(tensor: torch.Tensor, *args: object, **kwargs: object) -> str:
+            value_repr_ids.append(id(tensor))
+            return real_repr(tensor, *args, **kwargs)
+
+        base_compile = mp._original_torch_compile or torch.compile
+        base_reset = mp._original_dynamo_reset or torch._dynamo.reset
+        param = torch.nn.Parameter(torch.randn(16, 16))
+        x = torch.randn(16, 16)
+
+        def fn(inp: torch.Tensor) -> torch.Tensor:
+            return inp @ param
+
+        mp._original_tensor_repr = repr_spy
+        try:
+            base_reset()
+            out = base_compile(fn, backend="eager", fullgraph=True)(x)
+        finally:
+            mp._original_tensor_repr = real_repr
+            base_reset()
+
+        self.assertEqual(out, fn(x))
+        # The guard on `param` must never materialize its value during guard build.
+        self.assertNotIn(id(param), value_repr_ids)
+
+
 instantiate_device_type_tests(TestTorchCompilePatchHelpers, globals(), only_for="privateuse1")
 instantiate_device_type_tests(TestTensorParallelFunctions, globals(), only_for="privateuse1")
 instantiate_device_type_tests(TestCompiledFunctionWrapper, globals(), only_for="privateuse1")

--- a/torch_rbln/_internal/monkey_patches.py
+++ b/torch_rbln/_internal/monkey_patches.py
@@ -1,5 +1,6 @@
 """Monkey patches applied to PyTorch to enable RBLN functionality."""
 
+import threading
 import warnings
 
 from torch_rbln._internal.compile_cache import clear_rbln_compile_cache
@@ -12,6 +13,10 @@ _torch_dynamo_reset_patched: bool = False
 _rbln_backend_registered: bool = False
 _original_torch_compile = None
 _original_dynamo_reset = None
+_dynamo_guard_repr_patched: bool = False
+_original_id_match_unchecked = None
+_original_tensor_repr = None
+_guard_repr_tls = threading.local()
 
 
 def _is_backend_registered(backend_name: str) -> bool:
@@ -141,9 +146,56 @@ def patch_torch_compile() -> None:
         _torch_dynamo_reset_patched = True
 
 
+def patch_dynamo_guard_repr() -> None:
+    """Keep Dynamo guard build from materializing tensor values via ``repr``.
+
+    Substitute value->type only during guard build; user ``repr(tensor)`` is
+    unchanged. Backport of the pytorch-main fix; a no-op on torch >= 2.13.
+    See rebellions-sw/fsw-inference#413.
+    """
+    global _original_id_match_unchecked, _original_tensor_repr, _dynamo_guard_repr_patched
+    if _dynamo_guard_repr_patched:
+        return
+
+    import torch
+
+    # Fixed upstream in torch 2.13 (id_match_unchecked reprs the type, not the
+    # value), so there is nothing to patch there. 2.11 and 2.12 still repr(val).
+    if torch.__version__ >= (2, 13):
+        return
+
+    try:
+        from torch._dynamo.guards import GuardBuilder
+    except Exception as e:  # pragma: no cover
+        warnings.warn(f"Could not patch Dynamo guard repr: {e}", stacklevel=2)
+        return
+
+    _original_id_match_unchecked = GuardBuilder.id_match_unchecked
+    _original_tensor_repr = torch.Tensor.__repr__
+
+    def _id_match_unchecked(self, guard, recompile_hint=None):
+        prev = getattr(_guard_repr_tls, "active", False)
+        _guard_repr_tls.active = True
+        try:
+            return _original_id_match_unchecked(self, guard, recompile_hint)
+        finally:
+            _guard_repr_tls.active = prev
+
+    def _tensor_repr(self, *args, **kwargs):
+        # Guard build only needs the type; avoid materializing the tensor.
+        if getattr(_guard_repr_tls, "active", False):
+            return repr(type(self))
+        return _original_tensor_repr(self, *args, **kwargs)
+
+    GuardBuilder.id_match_unchecked = _id_match_unchecked
+    torch.Tensor.__repr__ = _tensor_repr
+    _dynamo_guard_repr_patched = True
+
+
 def apply_all_patches() -> None:
     """Apply all RBLN monkey patches. Idempotent."""
     patch_torch_compile()
+    patch_dynamo_guard_repr()
 
 
 def remove_all_patches() -> None:
@@ -153,6 +205,7 @@ def remove_all_patches() -> None:
     WARNING: This function is primarily for testing purposes.
     """
     global _rbln_backend_registered, _torch_compile_patched, _torch_dynamo_reset_patched
+    global _dynamo_guard_repr_patched
 
     import torch
 
@@ -160,6 +213,13 @@ def remove_all_patches() -> None:
         torch.compile = _original_torch_compile
     if _original_dynamo_reset is not None:
         torch._dynamo.reset = _original_dynamo_reset
+
+    if _dynamo_guard_repr_patched:
+        from torch._dynamo.guards import GuardBuilder
+
+        GuardBuilder.id_match_unchecked = _original_id_match_unchecked
+        torch.Tensor.__repr__ = _original_tensor_repr
+        _dynamo_guard_repr_patched = False
 
     clear_rbln_compile_cache()
     # Mirror reset_wrapper's teardown: drop the C++ warm cache's runtime


### PR DESCRIPTION
## Summary
Dynamo's guard build reprs weight `nn.Parameter`s to fill a cosmetic `type=` string. For an rbln weight-free (external-only) weight that reconstructs the whole tensor (D2H) on every repr, so `torch.compile` warm-up floods D2H and hangs. Scope the repr to return the *type* (not the value) only during guard build; user-facing `repr(tensor)` is unchanged.

## Problem
`device_tensor` + weight-free warm-up floods `[rbln_memcpy] copy_type=1` (D2H) and hangs:
```
build_guards → ID_MATCH → repr(weight) → get_cpu_copy_of_rbln_tensor
  → CopyVirtualToHost → ReconstructRegionFromExternalRefs (D2H)
```

## Root cause
`torch/_dynamo/guards.py` `id_match_unchecked` does `type_repr = repr(val)` — but the guard's real check is `id(val)`; `type={type_repr}` is verbose-only. `repr(tensor)` materializes the tensor (fp8/bf16 go through a full `.float()`), and an external-only weight reconstructs from device on each one. Fixed upstream (`repr(type(val))`) as of torch 2.13; 2.11 and 2.12 still `repr(val)`.

## Fix
`patch_dynamo_guard_repr()` in `_internal/monkey_patches.py`, wired into `apply_all_patches()`: wrap `id_match_unchecked` with a thread-local flag and have `Tensor.__repr__` return `repr(type(self))` only while it's set. Guard build never needs the value; the `id()` check and recompile triggers are untouched, and `repr(tensor)` outside guard build is unchanged. Gated on `torch.__version__ >= (2, 13)` so it's a no-op once the fix ships; `remove_all_patches()` restores.

Measured (DeepSeek-V3 fp8 weight-free): `copy_type=1` D2H **6400 → 32**, init engine **~170s → 116s**.

## Testing
`test/rbln/test_torch_compile_patch.py::TestDynamoGuardReprPatch` — idempotency, user repr unchanged, guard-scope returns type (no materialization), `remove_all_patches` restore, and an eager-backend `torch.compile` smoke asserting the guarded Parameter is never value-repr'd during guard build (output stays correct). Python lint clean.

Resolves rebellions-sw/torch-rbln-internal#45
