### PR TITLE
docs: absolute image URLs in README for PyPI rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # PyTorch RBLN
 <div align="center">
 <picture>
-  <source srcset="docs/img/torch-rbln-white.png" media="(prefers-color-scheme: dark)">
-  <source srcset="docs/img/torch-rbln-black.png" media="(prefers-color-scheme: light)">
-  <img src="docs/img/torch-rbln-black.png" alt="PyTorch RBLN" width="90%">
+  <source srcset="https://raw.githubusercontent.com/RBLN-SW/torch-rbln/main/docs/img/torch-rbln-white.png" media="(prefers-color-scheme: dark)">
+  <source srcset="https://raw.githubusercontent.com/RBLN-SW/torch-rbln/main/docs/img/torch-rbln-black.png" media="(prefers-color-scheme: light)">
+  <img src="https://raw.githubusercontent.com/RBLN-SW/torch-rbln/main/docs/img/torch-rbln-black.png" alt="PyTorch RBLN" width="90%">
 </picture>
 
 [![PyPI version](https://badge.fury.io/py/torch-rbln.svg)](https://badge.fury.io/py/torch-rbln)


### PR DESCRIPTION
The README logo uses repo-relative paths (`docs/img/*.png`). PyPI renders the description without a base URL, so the logo 404s on the project page:

<img width="1215" height="588" alt="스크린샷 2026-07-30 오후 6 47 45" src="https://github.com/user-attachments/assets/563a4d1c-91c6-4ac1-8afa-66fb7db96636" />

**Fix:** point `<source>`/`<img>` at absolute `raw.githubusercontent.com/.../main/...` URLs, so the logo renders on both GitHub and PyPI. Docs-only, no code/runtime change.

Note: PyPI release metadata is immutable, so this takes effect from the next release.