### PR TITLE
ci: standardize repository owner conditions

### DIFF
--- a/.github/workflows/_build-wheel.yaml
+++ b/.github/workflows/_build-wheel.yaml
@@ -39,7 +39,7 @@ defaults:
 jobs:
   build:
     name: Build wheel
-    if: ${{ github.repository_owner == vars.TORCH_RBLN_REPO_OWNER }}
+    if: ${{ github.repository_owner == 'RBLN-SW' }}
     runs-on: ${{ vars.TORCH_RBLN_RUNNER_CPU_LARGE }}
     env:
       GIT_CONFIG_COUNT: '1'

--- a/.github/workflows/_dispatch-event.yaml
+++ b/.github/workflows/_dispatch-event.yaml
@@ -30,7 +30,7 @@ permissions:
 jobs:
   dispatch_event:
     name: Dispatch event for ${{ inputs.event_type }}
-    if: ${{ github.repository_owner == vars.TORCH_RBLN_REPO_OWNER }}
+    if: ${{ github.repository_owner == 'RBLN-SW' }}
     runs-on: ${{ vars.TORCH_RBLN_RUNNER_CPU_SMALL }}
     timeout-minutes: 60
     container:

--- a/.github/workflows/_lint-source.yaml
+++ b/.github/workflows/_lint-source.yaml
@@ -40,7 +40,7 @@ defaults:
 jobs:
   lint_source:
     name: Lint source (py${{ inputs.python_version }})
-    if: ${{ github.repository_owner == vars.TORCH_RBLN_REPO_OWNER }}
+    if: ${{ github.repository_owner == 'RBLN-SW' }}
     runs-on: ${{ vars.TORCH_RBLN_RUNNER_CPU_SMALL }}
     env:
       GIT_CONFIG_COUNT: '1'

--- a/.github/workflows/_lint-workflows.yaml
+++ b/.github/workflows/_lint-workflows.yaml
@@ -22,7 +22,7 @@ defaults:
 jobs:
   lint_workflows:
     name: Lint workflows
-    if: ${{ github.repository_owner == vars.TORCH_RBLN_REPO_OWNER }}
+    if: ${{ github.repository_owner == 'RBLN-SW' }}
     runs-on: ${{ vars.TORCH_RBLN_RUNNER_CPU_SMALL }}
     env:
       GIT_CONFIG_COUNT: '1'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,6 @@ concurrency:
 
 jobs:
   build:
-    if: ${{ github.repository_owner == vars.TORCH_RBLN_REPO_OWNER }}
     strategy:
       matrix:
         python_version: ${{ fromJSON(github.event_name == 'workflow_dispatch' && inputs.python_versions || '["3.12"]') }}

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -13,7 +13,6 @@ concurrency:
 
 jobs:
   dispatch_torch_rbln_cd:
-    if: ${{ github.repository_owner == vars.TORCH_RBLN_REPO_OWNER }}
     uses: ./.github/workflows/_dispatch-event.yaml
     with:
       event_name: ${{ github.event_name }}

--- a/.github/workflows/check-pr-title.yaml
+++ b/.github/workflows/check-pr-title.yaml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   check_pr_title:
     name: Check PR title
-    if: ${{ github.repository_owner == vars.TORCH_RBLN_REPO_OWNER }}
+    if: ${{ github.repository_owner == 'RBLN-SW' }}
     runs-on: ${{ vars.TORCH_RBLN_RUNNER_CPU_SMALL }}
     timeout-minutes: 10
     container:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,6 @@ concurrency:
 
 jobs:
   dispatch_torch_rbln_ci:
-    if: ${{ github.repository_owner == vars.TORCH_RBLN_REPO_OWNER }}
     uses: ./.github/workflows/_dispatch-event.yaml
     with:
       event_name: ${{ github.event_name }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -44,7 +44,7 @@ jobs:
 
   lint_gate:
     name: Lint
-    if: ${{ always() && github.repository_owner == vars.TORCH_RBLN_REPO_OWNER }}
+    if: ${{ always() && github.repository_owner == 'RBLN-SW' }}
     needs: [lint_source, lint_workflows]
     runs-on: ${{ vars.TORCH_RBLN_RUNNER_CPU_SMALL }}
     timeout-minutes: 10

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,6 @@ concurrency:
 
 jobs:
   dispatch_torch_rbln_release:
-    if: ${{ github.repository_owner == vars.TORCH_RBLN_REPO_OWNER }}
     uses: ./.github/workflows/_dispatch-event.yaml
     with:
       event_name: ${{ github.event_name }}

--- a/.github/workflows/update-rebel-compiler-dependency.yaml
+++ b/.github/workflows/update-rebel-compiler-dependency.yaml
@@ -26,7 +26,7 @@ defaults:
 jobs:
   update_rebel_compiler_dependency:
     name: Update rebel-compiler dependency
-    if: ${{ github.repository_owner == vars.TORCH_RBLN_REPO_OWNER }}
+    if: ${{ github.repository_owner == 'RBLN-SW' }}
     runs-on: ${{ vars.TORCH_RBLN_RUNNER_CPU_SMALL }}
     timeout-minutes: 15
     container:


### PR DESCRIPTION
## Summary of Changes

Replaces the configuration variable in the repository owner conditions with the owner name itself.

Also drops the redundant conditions from the workflows whose only job calls a reusable workflow, since that workflow already carries the condition on its single job.

---

## Type of Change

- [x] `other` — Other (describe below)

CI infrastructure change only.

---

## Affected Modules

- [x] Build/Tools

---

## Checklist

* [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
* [x] Linting passes — see [Linting](docs/LINTING.md)
* [x] All CI tests pass — see [CI/CD Workflows](docs/WORKFLOWS.md)
* [x] Relevant documentation has been updated (if applicable)

---
