### PR TITLE
ci: add nightly workflow building against PyTorch nightly

### DIFF
--- a/.github/workflows/nightly-torch.yaml
+++ b/.github/workflows/nightly-torch.yaml
@@ -62,17 +62,21 @@ jobs:
         run: |
           set -euo pipefail
 
+          requirement=torch
           if [[ -n "${TORCH_VERSION}" ]]; then
-            target_version="${TORCH_VERSION}"
-          else
-            target_version="$(printf 'torch\n' \
-              | uv pip compile - --no-config --no-deps --no-header --no-annotate \
-                  --prerelease allow --default-index "${PYTORCH_NIGHTLY_INDEX_URL}" \
-              | sed -n 's/^torch==//p')"
-            if [[ -z "${target_version}" ]]; then
-              echo "::error::Failed to resolve torch from ${PYTORCH_NIGHTLY_INDEX_URL}"
-              exit 1
-            fi
+            requirement="torch==${TORCH_VERSION}"
+          fi
+
+          # Resolving even an explicit version normalizes it to what the index actually
+          # serves (`2.14.0.dev20260810` -> `2.14.0.dev20260810+cpu`), which the smoke
+          # test compares against `torch.__version__`.
+          target_version="$(printf '%s\n' "${requirement}" \
+            | uv pip compile - --no-config --no-deps --no-header --no-annotate \
+                --prerelease allow --default-index "${PYTORCH_NIGHTLY_INDEX_URL}" \
+            | sed -n 's/^torch==//p')"
+          if [[ -z "${target_version}" ]]; then
+            echo "::error::Failed to resolve ${requirement} from ${PYTORCH_NIGHTLY_INDEX_URL}"
+            exit 1
           fi
 
           echo "target_version=${target_version}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/nightly-torch.yaml
+++ b/.github/workflows/nightly-torch.yaml
@@ -110,7 +110,6 @@ jobs:
           UV_INDEX_RBLN_USERNAME: ${{ secrets.INTERNAL_INDEX_USERNAME }}
           UV_INDEX_RBLN_PASSWORD: ${{ secrets.INTERNAL_INDEX_PASSWORD }}
           UV_BUILD_CONSTRAINT: constraints-build-dev.txt
-          UV_PRERELEASE: allow
         run: |
           set -euo pipefail
 
@@ -149,7 +148,6 @@ jobs:
           UV_INDEX_STRATEGY: unsafe-best-match
           UV_INDEX_RBLN_USERNAME: ${{ secrets.INTERNAL_INDEX_USERNAME }}
           UV_INDEX_RBLN_PASSWORD: ${{ secrets.INTERNAL_INDEX_PASSWORD }}
-          UV_PRERELEASE: allow
         run: |
           set -euo pipefail
 

--- a/.github/workflows/nightly-torch.yaml
+++ b/.github/workflows/nightly-torch.yaml
@@ -1,0 +1,245 @@
+name: Nightly PyTorch
+
+on:
+  schedule:
+    # Daily 14:00 KST (05:00 UTC)
+    - cron: 0 5 * * *
+  workflow_dispatch:
+    inputs:
+      python_version:
+        description: Python version (3.10-3.13)
+        type: string
+        required: false
+        default: '3.12'
+      torch_version:
+        description: PyTorch nightly version to pin (leave empty to resolve the latest nightly)
+        type: string
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  PYTORCH_NIGHTLY_INDEX_NAME: pytorch-nightly-cpu
+  PYTORCH_NIGHTLY_INDEX_URL: https://download.pytorch.org/whl/nightly/cpu
+  TEST_VENV: nightly-test/.venv
+
+jobs:
+  nightly_torch:
+    name: Build and test against PyTorch nightly
+    if: ${{ github.repository_owner == 'RBLN-SW' }}
+    runs-on: ${{ vars.TORCH_RBLN_RUNNER_CPU_LARGE }}
+    env:
+      GIT_CONFIG_COUNT: '1'
+      GIT_CONFIG_KEY_0: safe.directory
+      GIT_CONFIG_VALUE_0: ${{ github.workspace }}
+      RBLN_FORCE_NPU_NAME: RBLN-CA25
+    timeout-minutes: 90
+    container:
+      image: ghcr.io/rebellions-sw/rbln-build:0.11.0-ubi9-py${{ inputs.python_version || '3.12' }}  # zizmor: ignore[unpinned-images]
+      credentials:
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GIT_PAT }}
+    steps:
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
+
+      # Resolved before checkout so the repository's release-pinned uv configuration
+      # cannot influence which wheel is picked.
+      - name: Resolve PyTorch nightly version
+        id: resolve_torch_version
+        env:
+          TORCH_VERSION: ${{ inputs.torch_version }}
+        run: |
+          set -euo pipefail
+
+          if [[ -n "${TORCH_VERSION}" ]]; then
+            target_version="${TORCH_VERSION}"
+          else
+            target_version="$(printf 'torch\n' \
+              | uv pip compile - --no-config --no-deps --no-header --no-annotate \
+                  --prerelease allow --default-index "${PYTORCH_NIGHTLY_INDEX_URL}" \
+              | sed -n 's/^torch==//p')"
+            if [[ -z "${target_version}" ]]; then
+              echo "::error::Failed to resolve torch from ${PYTORCH_NIGHTLY_INDEX_URL}"
+              exit 1
+            fi
+          fi
+
+          echo "target_version=${target_version}" >> "${GITHUB_OUTPUT}"
+          echo "::notice::Testing against torch==${target_version}"
+
+      - name: Check out torch-rbln repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Repoint torch dependency to the nightly wheel
+        env:
+          TORCH_VERSION: ${{ steps.resolve_torch_version.outputs.target_version }}
+        run: |
+          set -euo pipefail
+
+          python3 tools/replace_depends.py \
+            --source torch \
+            --target "torch==${TORCH_VERSION}" \
+            --pyproject-path pyproject.toml \
+            --set-index "${PYTORCH_NIGHTLY_INDEX_NAME}"
+
+          if ! grep -qF "\"torch==${TORCH_VERSION}\"" pyproject.toml; then
+            echo "::error::Failed to repoint the torch dependency to ${TORCH_VERSION}"
+            exit 1
+          fi
+          grep -nE '"torch==|^torch = ' pyproject.toml
+
+      - name: Build wheel
+        env:
+          TORCH_RBLN_BUILD_TYPE: Release
+          UV_INDEX: rbln=${{ secrets.INTERNAL_INDEX_URL }}
+          UV_INDEX_RBLN_USERNAME: ${{ secrets.INTERNAL_INDEX_USERNAME }}
+          UV_INDEX_RBLN_PASSWORD: ${{ secrets.INTERNAL_INDEX_PASSWORD }}
+          UV_BUILD_CONSTRAINT: constraints-build-dev.txt
+          UV_PRERELEASE: allow
+        run: |
+          set -euo pipefail
+
+          [[ -f /etc/os-release ]] && . /etc/os-release
+          case "${ID:-}:${ID_LIKE:-}" in
+            *debian* | *ubuntu*) export CC=gcc-13 CXX=g++-13 ;;
+            *) source /opt/rh/gcc-toolset-13/enable ;;
+          esac
+          cxx="${CXX:-g++}"
+          echo "::notice::C++ compiler: $(command -v "${cxx}")"
+          "${cxx}" --version
+
+          uv build --wheel
+
+      - name: Read built wheel version
+        id: read_version
+        run: |
+          set -euo pipefail
+
+          shopt -s nullglob
+          wheels=(dist/*.whl)
+          shopt -u nullglob
+          if [[ "${#wheels[@]}" -ne 1 ]]; then
+            echo "::error::Expected exactly one wheel in dist/, found ${#wheels[@]}: ${wheels[*]}"
+            exit 1
+          fi
+
+          # Wheel filename fields (PEP 427): {name}-{version}-{python}-{abi}-{platform}.
+          version="$(basename "${wheels[0]}" | cut -d- -f2)"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "::notice::Built torch-rbln==${version}"
+
+      - name: Install the wheel into a clean environment
+        env:
+          UV_INDEX: ${{ env.PYTORCH_NIGHTLY_INDEX_URL }} rbln=${{ secrets.INTERNAL_INDEX_URL }}
+          UV_INDEX_STRATEGY: unsafe-best-match
+          UV_INDEX_RBLN_USERNAME: ${{ secrets.INTERNAL_INDEX_USERNAME }}
+          UV_INDEX_RBLN_PASSWORD: ${{ secrets.INTERNAL_INDEX_PASSWORD }}
+          UV_PRERELEASE: allow
+        run: |
+          set -euo pipefail
+
+          uv venv "${TEST_VENV}"
+          uv pip install \
+            --python "${TEST_VENV}/bin/python" \
+            --constraint constraints-build-dev.txt \
+            rebel-compiler \
+            expecttest \
+            numpy \
+            pytest \
+            pytest-xdist \
+            dist/*.whl
+
+      - name: Smoke-test the installed wheel
+        env:
+          TORCH_RBLN_VERSION: ${{ steps.read_version.outputs.version }}
+          TORCH_VERSION: ${{ steps.resolve_torch_version.outputs.target_version }}
+          RBLN_DUMMY_DEVICE: '1'
+        run: |
+          set -euo pipefail
+
+          # `python -` puts cwd on sys.path; run outside the repository root so the source
+          # tree does not shadow the installed wheel.
+          cd nightly-test
+          .venv/bin/python - <<'PY'
+          import os
+
+          import torch
+
+          import torch_rbln  # noqa: F401
+
+          expected_torch_rbln = os.environ["TORCH_RBLN_VERSION"]
+          expected_torch = os.environ["TORCH_VERSION"]
+          print(f"torch={torch.__version__} torch_rbln={torch_rbln.__version__}")
+
+          assert torch_rbln.__version__ == expected_torch_rbln, (
+              f"torch-rbln version mismatch: expected {expected_torch_rbln}, got {torch_rbln.__version__}"
+          )
+          assert torch.__version__ == expected_torch, (
+              f"torch version mismatch: expected {expected_torch}, got {torch.__version__}"
+          )
+          assert torch.rbln.device_count() == 1, f"expected 1 logical device, got {torch.rbln.device_count()}"
+          assert torch.rbln.physical_device_count() == 0, (
+              f"expected 0 physical devices, got {torch.rbln.physical_device_count()}"
+          )
+
+          cpu_tensor = torch.arange(16, dtype=torch.float32).reshape(4, 4)
+          device_tensor = cpu_tensor.to("rbln")
+          assert device_tensor.device.type == "rbln", device_tensor.device
+          torch.testing.assert_close(device_tensor.cpu(), cpu_tensor)
+          torch.testing.assert_close((device_tensor + device_tensor).cpu(), cpu_tensor * 2)
+
+          print(f"::notice::Smoke test passed: torch-rbln=={torch_rbln.__version__} on torch {torch.__version__}")
+          PY
+
+      # Both suites manage RBLN_DUMMY_DEVICE themselves: test_dummy_device sets it per
+      # subprocess, and test_no_device requires device_count() == 0.
+      - name: Run no-NPU test suites
+        run: |
+          set -euo pipefail
+
+          "${TEST_VENV}/bin/python" -m pytest \
+            test/rbln/test_dummy_device.py \
+            test/distributed/test_no_device.py \
+            -m test_set_ci \
+            --numprocesses=1
+
+      - name: Report results
+        if: ${{ always() }}
+        env:
+          TORCH_VERSION: ${{ steps.resolve_torch_version.outputs.target_version }}
+          TORCH_RBLN_VERSION: ${{ steps.read_version.outputs.version }}
+          PYTHON_VERSION: ${{ inputs.python_version || '3.12' }}
+          JOB_STATUS: ${{ job.status }}
+        run: |
+          set -euo pipefail
+
+          {
+            echo "## Nightly PyTorch build"
+            echo
+            echo "| Item | Value |"
+            echo "| --- | --- |"
+            echo "| Status | \`${JOB_STATUS}\` |"
+            echo "| torch | \`${TORCH_VERSION:-unresolved}\` |"
+            echo "| torch-rbln | \`${TORCH_RBLN_VERSION:-not built}\` |"
+            echo "| Python | \`${PYTHON_VERSION}\` |"
+            echo "| Commit | \`${GITHUB_SHA}\` |"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+          if [[ "${JOB_STATUS}" != "success" ]]; then
+            echo "::error::torch-rbln failed to build or test against torch ${TORCH_VERSION:-unresolved}"
+          fi

--- a/.github/workflows/nightly-torch.yaml
+++ b/.github/workflows/nightly-torch.yaml
@@ -67,9 +67,8 @@ jobs:
             requirement="torch==${TORCH_VERSION}"
           fi
 
-          # Resolving even an explicit version normalizes it to what the index actually
-          # serves (`2.14.0.dev20260810` -> `2.14.0.dev20260810+cpu`), which the smoke
-          # test compares against `torch.__version__`.
+          # Resolved even when explicit: normalizes `2.14.0.dev20260810` to the
+          # `+cpu` version the smoke test compares against `torch.__version__`.
           target_version="$(printf '%s\n' "${requirement}" \
             | uv pip compile - --no-config --no-deps --no-header --no-annotate \
                 --prerelease allow --default-index "${PYTORCH_NIGHTLY_INDEX_URL}" \
@@ -141,7 +140,6 @@ jobs:
             exit 1
           fi
 
-          # Wheel filename fields (PEP 427): {name}-{version}-{python}-{abi}-{platform}.
           version="$(basename "${wheels[0]}" | cut -d- -f2)"
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
           echo "::notice::Built torch-rbln==${version}"

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -158,7 +158,7 @@ It can also be run manually via `workflow_dispatch`, optionally pinning a specif
 
 Everyday CI builds against the release pin (`torch==2.11.0+cpu`). This workflow additionally builds and smoke-tests `torch-rbln` against the **latest PyTorch nightly CPU wheel** every day at 14:00 KST (05:00 UTC), so an upstream breaking change surfaces within a day instead of at the next `torch` bump. Tracking PyTorch `main` in CI is the outstanding prerequisite for enlisting the repository in PyTorch's Cross-Repository CI Relay (CRCR).
 
-Scheduled runs use the default branch (`dev`); a manual `workflow_dispatch` tests whichever ref it is started from, and can pin an explicit `torch_version` and `python_version` instead of the defaults (latest nightly, Python 3.12).
+Scheduled runs use the default branch (`dev`); a manual `workflow_dispatch` tests whichever ref it is started from, and can pin an explicit `torch_version` and `python_version` instead of the defaults (latest nightly, Python 3.12). An explicit `torch_version` is still resolved against the nightly index, so it may be given with or without the `+cpu` local suffix and fails fast if the index does not serve it.
 
 Steps:
 

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -12,6 +12,7 @@ This document describes the GitHub Actions workflows that power the automated te
 | Build (`build.yaml`)                   | PRs; manual dispatch          | Build and publish the wheel         | —                                                                  |
 | Check PR Title (`check-pr-title.yaml`) | PR opened, edited, or updated | Enforce Conventional Commits format | —                                                                  |
 | Lint (`lint.yaml`)                     | PRs; pushes to `dev`          | Lint the source tree and workflows  | —                                                                  |
+| Nightly PyTorch (`nightly-torch.yaml`) | Daily cron; manual dispatch   | Track the PyTorch nightly wheel     | No-NPU smoke tests (`RBLN_DUMMY_DEVICE=1`)                         |
 
 CI, Release, and CD workflows delegate to a shared [Event Dispatch](#event-dispatch-mechanism) mechanism that sends events to infrastructure with physical RBLN NPU devices.
 
@@ -27,6 +28,7 @@ CI, Release, and CD workflows delegate to a shared [Event Dispatch](#event-dispa
 | Build          | All PRs                         | —                  | PRs only            |
 | Check PR Title | On open, edit, sync, reopen     | —                  | Yes                 |
 | Lint           | To `main` or `dev`              | To `dev`           | Yes                 |
+| Nightly PyTorch| —                               | —                  | **No**              |
 
 CI, Release, and Lint runs are grouped by PR number (or SHA for pushes); a new push cancels the in-progress run. CD runs are never cancelled — once a deployment starts, it runs to completion. Check PR Title runs are grouped by PR number and always cancel the in-progress run. Build also runs on manual `workflow_dispatch`; its PR runs are grouped by PR number and cancel superseded commits, while dispatch runs are grouped by run ID and always complete.
 
@@ -147,6 +149,26 @@ The event is dispatched to a separate repository (configured via `vars.TORCH_RBL
 This workflow runs on a daily schedule and tracks the latest `rebel-compiler` production build. When a newer one is available, it creates or updates a pull request against `dev` for a maintainer to review and merge.
 
 It can also be run manually via `workflow_dispatch`, optionally pinning a specific `rebel_compiler_version` instead of resolving the latest.
+
+---
+
+## Nightly PyTorch Workflow
+
+**File:** [`.github/workflows/nightly-torch.yaml`](../.github/workflows/nightly-torch.yaml)
+
+Everyday CI builds against the release pin (`torch==2.11.0+cpu`). This workflow additionally builds and smoke-tests `torch-rbln` against the **latest PyTorch nightly CPU wheel** every day at 14:00 KST (05:00 UTC), so an upstream breaking change surfaces within a day instead of at the next `torch` bump. Tracking PyTorch `main` in CI is the outstanding prerequisite for enlisting the repository in PyTorch's Cross-Repository CI Relay (CRCR).
+
+Scheduled runs use the default branch (`dev`); a manual `workflow_dispatch` tests whichever ref it is started from, and can pin an explicit `torch_version` and `python_version` instead of the defaults (latest nightly, Python 3.12).
+
+Steps:
+
+1. **Resolve** the latest nightly version from `https://download.pytorch.org/whl/nightly/cpu`, before checkout so the repository's release-pinned uv configuration cannot influence the result.
+2. **Repoint** the `torch` pin via [`tools/replace_depends.py`](../tools/replace_depends.py) — it rewrites `[project].dependencies` and `[build-system].requires`, and points `[tool.uv.sources].torch` at the `pytorch-nightly-cpu` index declared in `pyproject.toml`. The edit is local to the run and never committed.
+3. **Build** the wheel with the same container, compiler setup, and `constraints-build-dev.txt` build constraint as [`_build-wheel.yaml`](../.github/workflows/_build-wheel.yaml), but **without publishing** it to the internal package index.
+4. **Test** on a CPU-only runner with no NPU attached, using `RBLN_DUMMY_DEVICE=1` (see [Configuration](CONFIGURATION.md#rbln_dummy_device)):
+   - a smoke script that installs the built wheel into a clean venv and checks the versions, the dummy device topology, a host↔device round-trip, and one eager op;
+   - the no-NPU test suites `test/rbln/test_dummy_device.py` and `test/distributed/test_no_device.py` (each manages `RBLN_DUMMY_DEVICE` itself, so it is not set for this step).
+5. **Report** the resolved `torch` version, the built `torch-rbln` version, and the outcome to the job summary, with an error annotation on failure.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,7 @@ prerelease = "if-necessary-or-explicit"
 index = [
   { name = "pypi", url = "https://pypi.org/simple/", default = true },
   { name = "pytorch-cpu", url = "https://download.pytorch.org/whl/cpu", explicit = true },
+  { name = "pytorch-nightly-cpu", url = "https://download.pytorch.org/whl/nightly/cpu", explicit = true },
   { name = "rbln", url = "https://pypi.rbln.ai/simple/", explicit = true },
 ]
 


### PR DESCRIPTION
Adds a daily workflow (plus manual dispatch) that resolves the latest PyTorch nightly CPU wheel, repoints the `torch` pin at it, builds the wheel, and smoke-tests it on a host with no NPU via RBLN_DUMMY_DEVICE. This satisfies the outstanding CRCR prerequisite that CI build and test against PyTorch main.

The build steps mirror `_build-wheel.yaml` without publishing to the internal package index. Results are reported to the job summary.

<!--
Thank you for contributing to torch-rbln!
This template will help us understand and review your pull request efficiently.
Please fill out all required sections. You may delete optional ones if not applicable.
see: docs/CONTRIBUTING.md
-->

## Summary of Changes

<!--
**PR Title** uses the **Conventional Commits v1.0** format.
see: https://www.conventionalcommits.org/en/v1.0.0/
-->

<!-- Describe your changes in detail -->

Commit 201ff88 on feat/CRCR-workflow-L1, three files, +268 lines:

**`.github/workflows/nightly-torch.yaml` (new, 245 lines)**
one job, daily at 05:00 UTC plus manual dispatch (python_version, torch_version), TORCH_RBLN_RUNNER_CPU_LARGE in the rbln-build container, owner-gated:

1. Resolve the latest nightly from download.pytorch.org/whl/nightly/cpu, before checkout.
2. Repoint the torch pin with the existing tools/replace_depends.py (no change needed to that script).
3. Build with _build-wheel.yaml's compiler setup and build constraint, without publication.
4. Install the wheel into a clean venv; smoke-test under RBLN_DUMMY_DEVICE=1, then run test_dummy_device.py + test_no_device.py.
5. Report torch / torch-rbln / Python / commit / status to the job summary, with an error annotation on failure.

**`pyproject.toml`**
one line: pytorch-nightly-cpu as an explicit = true index.

**`docs/WORKFLOWS.md`**
table rows plus a section describing the five steps.

## Local test result

Ran the workflow's steps by hand.

| Step | Result |
| --- | --- |
| Resolve latest nightly | ✅ `torch==2.14.0.dev20260809+cpu` |
| Repoint `torch` pin | ✅ both pins + `[tool.uv.sources]` |
| Build against nightly | ❌ 428 compile errors (see below) |
| Build against release pin | ✅ wheel produced |
| Install wheel into clean venv | ✅ |
| Smoke test (`RBLN_DUMMY_DEVICE=1`) | ✅ |

The plumbing works; the nightly build failure is the workflow doing its job. Two causes:

1. `c10/rbln/RBLNPinnedAllocator.cpp:71` uses `std::memcpy` without `<cstring>`, which only compiled because torch 2.11 included it transitively.
2. Nightly headers require C++20, but `CMakeLists.txt:15` sets `CMAKE_CXX_STANDARD 17`. Syntax-only probe of `<torch/library.h>` + `<ATen/ATen.h>`: 16 errors at `-std=c++17`, 0 at `-std=c++20`.

So this workflow will be red until those are fixed.

---

## Related Issues / Tickets

<!--
All pull requests must have a corresponding issue.
Use "Resolves/Fixes/Closes/Related to #<issue_number>" to auto-link or close the issue when merged.
see: docs/CONTRIBUTING.md#pull-request-guidelines
-->

* Resolves #195
* Related to #

---

## Type of Change

<!--
Select the type that best describes your PR. This should match the issue label.
see: docs/CONTRIBUTING.md#development-related-issue
-->

- [x] `feature` — New capability or functionality
- [ ] `core` — Changes to RBLN backend, device layer, C++ extension, op registration, or `torch.compile` integration
- [ ] `fix` — Bug fix
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code improvement without behavior change
- [ ] `docs` — Documentation only
- [ ] `other` — Other (describe below)

---

## Affected Modules

<!--
Check all modules affected by this change.
-->

- [ ] Backend
- [ ] Device
- [ ] Ops/Kernels
- [ ] `torch.compile`
- [ ] C++ extension (`torch_rbln/csrc`)
- [ ] Memory
- [x] Build/Tools
- [x] Docs

## Checklist

<!--
The PR will only be reviewed and considered for merge if the following are satisfied.
-->

* [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
* [x] This PR is linked to a corresponding issue — see [Contributing to torch-rbln](docs/CONTRIBUTING.md)
* [x] Linting passes — see [Linting](docs/LINTING.md)
* [ ] All CI tests pass — see [CI/CD Workflows](docs/WORKFLOWS.md)
* [ ] The test method is described, and the expected result is clearly stated (if applicable)
* [ ] Relevant documentation has been updated (if applicable)