### PR TITLE
perf(copy): describe non-contiguous host copies instead of staging them

### DIFF
--- a/aten/src/ATen/native/rbln/RBLNCopy.cpp
+++ b/aten/src/ATen/native/rbln/RBLNCopy.cpp
@@ -13,10 +13,12 @@
 #include <c10/rbln/RBLNHostBatch.h>
 #include <c10/rbln/RBLNLogging.h>
 #include <c10/rbln/RBLNPinnedAllocator.h>
+
 #include <c10/rbln/RBLNProfiler.h>
 #include <rebel/runtime/api/rbln_runtime_api.h>
 
 #include <cstddef>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -37,6 +39,144 @@ struct IndirectD2DGuard {
     --g_indirect_d2d_depth;
   }
 };
+
+// Measured crossover where descriptors beat the host gather pass: 8-16 KiB (h2v),
+// 1-8 KiB (v2h), moving with the host thread count. 16 KiB sits above both because
+// the errors are asymmetric: staging a slab descriptors would have won costs ~1.3x,
+// descriptors on element-sized slabs 130x.
+constexpr size_t kMinStridedHostCopyBytes = 16 * 1024;
+
+// Byte-level description of one strided pair. `inner_block_bytes` is the largest
+// run contiguous in both tensors; the outer vectors describe the iteration above
+// it. Empty `outer_sizes` means a single slab.
+struct StridedPlan {
+  size_t inner_block_bytes = 0;
+  std::vector<int64_t> outer_sizes;
+  std::vector<int64_t> src_byte_strides;
+  std::vector<int64_t> dst_byte_strides;
+};
+
+// How to describe the pair for the batch engines, or nothing if staging keeps it.
+// The stride arithmetic is strided_v2v_copy's — which side is host memory does not
+// enter it. The suffix scan decides eligibility and feeds the plan, so it runs once.
+std::optional<StridedPlan> make_strided_host_plan(const at::Tensor& dst, const at::Tensor& src) {
+  if (dst.sizes() != src.sizes() || dst.scalar_type() != src.scalar_type() || dst.numel() == 0) {
+    return std::nullopt;
+  }
+  if (dst.is_contiguous() && src.is_contiguous()) {
+    return std::nullopt; // a single bulk transfer already, nothing to describe
+  }
+  // Descriptors within one submit are unordered, so a destination that writes an
+  // address twice has no defined result. Staging writes it serially, as copy_
+  // does everywhere else.
+  if (at::has_internal_overlap(dst) != at::MemOverlap::No && view_may_self_overlap(dst.sizes(), dst.strides())) {
+    return std::nullopt;
+  }
+
+  const auto sizes = dst.sizes();
+  const auto src_strides = src.strides();
+  const auto dst_strides = dst.strides();
+  const int64_t rank = dst.dim();
+  const auto elm = static_cast<size_t>(dst.element_size());
+  const int64_t inner_start = common_inner_start(sizes, src_strides, dst_strides);
+
+  // Inner block = product of dims [inner_start, rank). One element when no joint
+  // contiguous suffix exists, which the threshold then sends back to staging.
+  int64_t inner_block_elems = 1;
+  for (int64_t i = inner_start; i < rank; ++i) {
+    inner_block_elems *= sizes[i];
+  }
+  StridedPlan plan;
+  plan.inner_block_bytes = static_cast<size_t>(inner_block_elems) * elm;
+  if (plan.inner_block_bytes < kMinStridedHostCopyBytes) {
+    return std::nullopt;
+  }
+
+  // Byte strides over dims [0, inner_start). A stride of 0 (broadcast) is kept
+  // verbatim so the same source bytes replicate instead of collapsing into one.
+  const int64_t elm_signed = static_cast<int64_t>(elm);
+  plan.outer_sizes.assign(sizes.begin(), sizes.begin() + inner_start);
+  plan.src_byte_strides.resize(static_cast<size_t>(inner_start));
+  plan.dst_byte_strides.resize(static_cast<size_t>(inner_start));
+  for (int64_t i = 0; i < inner_start; ++i) {
+    plan.src_byte_strides[static_cast<size_t>(i)] = src_strides[i] * elm_signed;
+    plan.dst_byte_strides[static_cast<size_t>(i)] = dst_strides[i] * elm_signed;
+  }
+  return plan;
+}
+
+// Shape / dtype / numel, shared by the contiguous and strided entry points.
+size_t payload_bytes(const at::Tensor& t) {
+  return static_cast<size_t>(t.numel()) * static_cast<size_t>(t.element_size());
+}
+
+// Which end of a host copy is device memory.
+enum class HostDir { kH2V, kV2H };
+
+// Roles are the caller's contract, checked here because a swapped pair would DMA
+// a host address as a device vaddr. Shape and dtype must match — the entrypoints
+// move bytes, they do not convert.
+template <HostDir kDir>
+void check_host_pair(const at::Tensor& dst, const at::Tensor& src, const char* who) {
+  const at::Tensor& dev = (kDir == HostDir::kH2V) ? dst : src;
+  const at::Tensor& host = (kDir == HostDir::kH2V) ? src : dst;
+  RBLN_CHECK(
+      dev.device().is_privateuseone(),
+      "{}: device side must be on an RBLN device, got {}",
+      who,
+      c10::str(dev.device()));
+  RBLN_CHECK(host.device().is_cpu(), "{}: host side must be on CPU, got {}", who, c10::str(host.device()));
+  RBLN_CHECK(
+      dst.scalar_type() == src.scalar_type(),
+      "{}: dtype mismatch (dst={} src={})",
+      who,
+      c10::str(dst.scalar_type()),
+      c10::str(src.scalar_type()));
+  RBLN_CHECK(
+      dst.sizes() == src.sizes(),
+      "{}: shape mismatch (dst={} src={})",
+      who,
+      c10::str(dst.sizes()),
+      c10::str(src.sizes()));
+  RBLN_CHECK(dst.numel() > 0, "{}: numel must be > 0", who);
+}
+
+// One descriptor per pair. The runtime reads the host side during submit, which
+// happens later, so both tensors must outlive the batch.
+template <HostDir kDir, typename Batch>
+void host_copy(const at::Tensor& dst, const at::Tensor& src, Batch& batch, const char* who) {
+  RBLN_SCOPE_GUARD();
+  check_host_pair<kDir>(dst, src, who);
+  RBLN_CHECK(dst.is_contiguous() && src.is_contiguous(), "{}: both tensors must be contiguous", who);
+  batch.enqueue(dst.data_ptr(), src.data_ptr(), payload_bytes(dst));
+}
+
+void h2v_copy(const at::Tensor& dst, const at::Tensor& src, c10::rbln::H2VBatch& batch) {
+  host_copy<HostDir::kH2V>(dst, src, batch, "h2v_copy");
+}
+
+void v2h_copy(const at::Tensor& dst, const at::Tensor& src, c10::rbln::V2HBatch& batch) {
+  host_copy<HostDir::kV2H>(dst, src, batch, "v2h_copy");
+}
+
+// Describe a non-contiguous pair as descriptors instead of staging it.
+template <HostDir kDir, typename Batch>
+void strided_host_copy(
+    const at::Tensor& dst,
+    const at::Tensor& src,
+    const StridedPlan& plan,
+    Batch& batch,
+    const char* who) {
+  RBLN_SCOPE_GUARD();
+  check_host_pair<kDir>(dst, src, who);
+  batch.enqueue_strided(
+      dst.data_ptr(),
+      src.data_ptr(),
+      plan.inner_block_bytes,
+      c10::IntArrayRef(plan.outer_sizes),
+      c10::IntArrayRef(plan.src_byte_strides),
+      c10::IntArrayRef(plan.dst_byte_strides));
+}
 
 bool is_direct_copy(const at::Tensor& src, const at::Tensor& dst) {
   const bool same_sizes = (src.sizes() == dst.sizes());
@@ -59,6 +199,15 @@ void tensor_copy_from_cpu_to_rbln(const at::Tensor& cpu_src, const at::Tensor& r
     const auto nbytes = at::detail::computeStorageNbytes(cpu_src.sizes(), cpu_src.strides(), cpu_src.element_size());
     c10::rbln::memcpy_h2v(dst_data, src_data, nbytes);
   } else {
+    // Describing the copy replaces a host gather pass, and for a non-contiguous
+    // destination a read-modify-write of the whole range.
+    if (const auto plan = make_strided_host_plan(rbln_dst, cpu_src)) {
+      RBLN_LOG_DEBUG("Strided h2v copy (no staging)");
+      c10::rbln::H2VBatch batch;
+      strided_host_copy<HostDir::kH2V>(rbln_dst, cpu_src, *plan, batch, "copy_");
+      batch.submit();
+      return;
+    }
     if (rbln_dst.is_contiguous()) {
       const auto dst_sizes = rbln_dst.sizes();
       const auto dst_dtype = rbln_dst.scalar_type();
@@ -131,6 +280,13 @@ void tensor_copy_from_rbln_to_cpu(const at::Tensor& rbln_src, const at::Tensor& 
     const auto nbytes = at::detail::computeStorageNbytes(rbln_src.sizes(), rbln_src.strides(), rbln_src.element_size());
     c10::rbln::memcpy_v2h(dst_data, src_data, nbytes);
   } else {
+    if (const auto plan = make_strided_host_plan(cpu_dst, rbln_src)) {
+      RBLN_LOG_DEBUG("Strided v2h copy (no staging)");
+      c10::rbln::V2HBatch batch;
+      strided_host_copy<HostDir::kV2H>(cpu_dst, rbln_src, *plan, batch, "copy_");
+      batch.submit();
+      return;
+    }
     RBLN_LOG_DEBUG("Creating CPU copy of RBLN src");
     const auto cpu_src = at::native::rbln::get_cpu_copy_of_rbln_tensor(rbln_src);
 
@@ -493,54 +649,6 @@ bool foreach_copy_reorder_unsafe(at::TensorList self, at::TensorList src) {
     }
   }
   return false;
-}
-
-// ---- host-direction copy primitives ----------------------------------------
-
-// Contiguous pairs only: one descriptor per pair, which is what makes batching
-// N pairs a submit-count win with no size threshold. The caller sends fan-out
-// pairs to copy_ instead.
-void check_host_pair(const at::Tensor& dst, const at::Tensor& src, const char* who) {
-  RBLN_CHECK(
-      dst.scalar_type() == src.scalar_type(),
-      "{}: dtype mismatch (dst={} src={}) — this primitive does not convert",
-      who,
-      c10::str(dst.scalar_type()),
-      c10::str(src.scalar_type()));
-  RBLN_CHECK(
-      dst.sizes() == src.sizes(),
-      "{}: shape mismatch (dst={} src={})",
-      who,
-      c10::str(dst.sizes()),
-      c10::str(src.sizes()));
-  RBLN_CHECK(dst.is_contiguous() && src.is_contiguous(), "{}: both tensors must be contiguous", who);
-  RBLN_CHECK(dst.numel() > 0, "{}: numel must be > 0", who);
-}
-
-size_t payload_bytes(const at::Tensor& t) {
-  return static_cast<size_t>(t.numel()) * static_cast<size_t>(t.element_size());
-}
-
-// The runtime reads src during submit, which happens later, so src must outlive
-// the batch.
-void h2v_copy(const at::Tensor& dst, const at::Tensor& src, c10::rbln::H2VBatch& batch) {
-  RBLN_SCOPE_GUARD();
-  RBLN_CHECK(
-      dst.device().is_privateuseone(), "h2v_copy: dst must be on an RBLN device, got {}", c10::str(dst.device()));
-  RBLN_CHECK(src.device().is_cpu(), "h2v_copy: src must be on CPU, got {}", c10::str(src.device()));
-  check_host_pair(dst, src, "h2v_copy");
-  batch.enqueue(dst.data_ptr(), src.data_ptr(), payload_bytes(dst));
-}
-
-// Mirror of h2v_copy. Sources may repeat across the batch (pure reads);
-// destinations may not. Lifetime applies to dst here.
-void v2h_copy(const at::Tensor& dst, const at::Tensor& src, c10::rbln::V2HBatch& batch) {
-  RBLN_SCOPE_GUARD();
-  RBLN_CHECK(dst.device().is_cpu(), "v2h_copy: dst must be on CPU, got {}", c10::str(dst.device()));
-  RBLN_CHECK(
-      src.device().is_privateuseone(), "v2h_copy: src must be on an RBLN device, got {}", c10::str(src.device()));
-  check_host_pair(dst, src, "v2h_copy");
-  batch.enqueue(dst.data_ptr(), src.data_ptr(), payload_bytes(dst));
 }
 
 } // namespace

--- a/c10/rbln/RBLNHostBatch.cpp
+++ b/c10/rbln/RBLNHostBatch.cpp
@@ -151,6 +151,17 @@ void H2VBatch::enqueue(void* dst, const void* src, size_t nbytes) {
   detail::enqueue_one<H2VCopyOp, detail::DeviceAnchor::kDstOnly>(impl_->st, kH2VWho, dst, src, nbytes);
 }
 
+void H2VBatch::enqueue_strided(
+    void* dst,
+    const void* src,
+    size_t inner_block_bytes,
+    c10::IntArrayRef outer_sizes,
+    c10::IntArrayRef src_byte_strides,
+    c10::IntArrayRef dst_byte_strides) {
+  detail::enqueue_strided_impl<H2VCopyOp, detail::DeviceAnchor::kDstOnly>(
+      impl_->st, kH2VWho, dst, src, inner_block_bytes, outer_sizes, src_byte_strides, dst_byte_strides);
+}
+
 void H2VBatch::submit() {
   if (!impl_ || impl_->st.pending.empty()) {
     return;
@@ -190,6 +201,17 @@ V2HBatch::~V2HBatch() {
 
 void V2HBatch::enqueue(void* dst, const void* src, size_t nbytes) {
   detail::enqueue_one<V2HCopyOp, detail::DeviceAnchor::kSrcOnly>(impl_->st, kV2HWho, dst, src, nbytes);
+}
+
+void V2HBatch::enqueue_strided(
+    void* dst,
+    const void* src,
+    size_t inner_block_bytes,
+    c10::IntArrayRef outer_sizes,
+    c10::IntArrayRef src_byte_strides,
+    c10::IntArrayRef dst_byte_strides) {
+  detail::enqueue_strided_impl<V2HCopyOp, detail::DeviceAnchor::kSrcOnly>(
+      impl_->st, kV2HWho, dst, src, inner_block_bytes, outer_sizes, src_byte_strides, dst_byte_strides);
 }
 
 void V2HBatch::submit() {

--- a/c10/rbln/RBLNHostBatch.h
+++ b/c10/rbln/RBLNHostBatch.h
@@ -46,6 +46,21 @@ class C10_RBLN_API H2VBatch {
    */
   void enqueue(void* dst, const void* src, size_t nbytes);
 
+  /**
+   * @brief Enqueue `prod(outer_sizes)` copies of `inner_block_bytes`, row-major.
+   *
+   * Entry k at outer index idx[] is offset sum_d idx[d]*{dst,src}_byte_strides[d].
+   * The three arrays must have equal length; length 0 degenerates to enqueue(). A
+   * src stride of 0 is preserved, so a broadcast host source replicates.
+   */
+  void enqueue_strided(
+      void* dst,
+      const void* src,
+      size_t inner_block_bytes,
+      c10::IntArrayRef outer_sizes,
+      c10::IntArrayRef src_byte_strides,
+      c10::IntArrayRef dst_byte_strides);
+
   /** @brief Flush pending entries, one bulk call per device. Idempotent. */
   void submit();
 
@@ -83,6 +98,15 @@ class C10_RBLN_API V2HBatch {
    * @param nbytes Slab size in bytes; 0 is a no-op.
    */
   void enqueue(void* dst, const void* src, size_t nbytes);
+
+  /** @brief Enqueue a strided range. See H2VBatch::enqueue_strided. */
+  void enqueue_strided(
+      void* dst,
+      const void* src,
+      size_t inner_block_bytes,
+      c10::IntArrayRef outer_sizes,
+      c10::IntArrayRef src_byte_strides,
+      c10::IntArrayRef dst_byte_strides);
 
   /** @brief Flush pending entries, one bulk call per device. Idempotent. */
   void submit();

--- a/c10/rbln/RBLNV2VBatch.cpp
+++ b/c10/rbln/RBLNV2VBatch.cpp
@@ -14,88 +14,6 @@ namespace {
 // Both ends of a v2v copy are device memory, so both must agree on the device.
 constexpr auto kAnchor = detail::DeviceAnchor::kBothEnds;
 constexpr const char* kWho = "V2VBatch";
-
-// Walk a multi-index in row-major order. Returns false when wrapping back to
-// all zeros (iteration exhausted).
-inline bool advance_index(std::vector<int64_t>& idx, c10::IntArrayRef sizes) {
-  for (int64_t d = static_cast<int64_t>(sizes.size()) - 1; d >= 0; --d) {
-    if (++idx[d] < sizes[d]) {
-      return true;
-    }
-    idx[d] = 0;
-  }
-  return false;
-}
-
-/**
- * @brief Expand a strided description into `prod(outer_sizes)` flat entries.
- *
- * For outer iteration index `idx[]` the k-th entry has:
- *   dst_off = sum_d idx[d] * dst_byte_strides[d]
- *   src_off = sum_d idx[d] * src_byte_strides[d]
- *
- * A stride of 0 is preserved verbatim, which is what makes a broadcast source
- * replicate correctly instead of collapsing to its first slab.
- *
- * The IntArrayRefs are read during this call only.
- */
-inline void enqueue_strided_v2v(
-    detail::BatchState<V2VCopyOp>& st,
-    const char* who,
-    void* dst,
-    const void* src,
-    size_t inner_block_bytes,
-    c10::IntArrayRef outer_sizes,
-    c10::IntArrayRef src_byte_strides,
-    c10::IntArrayRef dst_byte_strides) {
-  RBLN_CHECK(dst != nullptr, "{}::enqueue_strided: dst is nullptr", who);
-  RBLN_CHECK(src != nullptr, "{}::enqueue_strided: src is nullptr", who);
-  RBLN_CHECK(
-      outer_sizes.size() == src_byte_strides.size() && outer_sizes.size() == dst_byte_strides.size(),
-      "{}::enqueue_strided: size/stride length mismatch (outer={}, src={}, dst={})",
-      who,
-      outer_sizes.size(),
-      src_byte_strides.size(),
-      dst_byte_strides.size());
-
-  if (inner_block_bytes == 0) {
-    return;
-  }
-
-  // Degenerate: no outer dims → single slab.
-  if (outer_sizes.empty()) {
-    detail::enqueue_one<V2VCopyOp, kAnchor>(st, who, dst, src, inner_block_bytes);
-    return;
-  }
-
-  // Reject zero-extent outer dims (would yield zero work but a 0 in sizes
-  // means the caller produced a 0-numel tensor — they should have early-returned).
-  int64_t outer_count = 1;
-  for (int64_t s : outer_sizes) {
-    RBLN_CHECK(s > 0, "{}::enqueue_strided: outer_sizes must be all positive, got {}", who, c10::str(outer_sizes));
-    outer_count *= s;
-  }
-
-  st.pending.reserve(st.pending.size() + static_cast<size_t>(outer_count));
-
-  // All N expanded entries share the same base pointers — one lookup suffices.
-  detail::update_homogeneity<kAnchor>(st.homogeneous, st.anchor, src, dst);
-
-  auto* dst_base = static_cast<uint8_t*>(dst);
-  const auto* src_base = static_cast<const uint8_t*>(src);
-
-  std::vector<int64_t> idx(outer_sizes.size(), 0);
-  for (int64_t o = 0; o < outer_count; ++o) {
-    int64_t src_off = 0;
-    int64_t dst_off = 0;
-    for (size_t d = 0; d < outer_sizes.size(); ++d) {
-      src_off += idx[d] * src_byte_strides[d];
-      dst_off += idx[d] * dst_byte_strides[d];
-    }
-    st.pending.push_back({dst_base + dst_off, src_base + src_off, inner_block_bytes});
-    advance_index(idx, outer_sizes);
-  }
-}
 } // namespace
 
 struct V2VBatch::Impl {
@@ -121,7 +39,8 @@ void V2VBatch::enqueue_strided(
     c10::IntArrayRef outer_sizes,
     c10::IntArrayRef src_byte_strides,
     c10::IntArrayRef dst_byte_strides) {
-  enqueue_strided_v2v(impl_->st, kWho, dst, src, inner_block_bytes, outer_sizes, src_byte_strides, dst_byte_strides);
+  detail::enqueue_strided_impl<V2VCopyOp, kAnchor>(
+      impl_->st, kWho, dst, src, inner_block_bytes, outer_sizes, src_byte_strides, dst_byte_strides);
 }
 
 void V2VBatch::submit() {

--- a/c10/rbln/detail/RBLNCopyBatchImpl.h
+++ b/c10/rbln/detail/RBLNCopyBatchImpl.h
@@ -4,8 +4,9 @@
 // outside c10/rbln/*.cpp: it exposes the pending storage the public headers hide
 // behind a pimpl.
 //
-// Only the mechanical part of a batch is shared — pending storage, device
-// homogeneity, reset and destructor behaviour. submit() is not: v2v drops to
+// Only the mechanical part of a batch is shared — pending storage, the row-major
+// expansion of a strided description, device homogeneity, reset and destructor
+// behaviour. submit() is not: v2v drops to
 // per-entry (host-bouncing) copies once entries span devices and carries a
 // runtime-rejection retry, while h2v/v2h split into one bulk submit per device.
 
@@ -86,6 +87,18 @@ inline void update_homogeneity(bool& homogeneous, c10::DeviceIndex& anchor, cons
   }
 }
 
+// Walk a multi-index in row-major order. Returns false when wrapping back to
+// all zeros (iteration exhausted).
+inline bool advance_index(std::vector<int64_t>& idx, c10::IntArrayRef sizes) {
+  for (int64_t d = static_cast<int64_t>(sizes.size()) - 1; d >= 0; --d) {
+    if (++idx[d] < sizes[d]) {
+      return true;
+    }
+    idx[d] = 0;
+  }
+  return false;
+}
+
 /** @brief Record one contiguous slab copy. nbytes == 0 is a no-op. */
 template <typename Desc, DeviceAnchor kAnchor>
 inline void enqueue_one(BatchState<Desc>& st, const char* who, void* dst, const void* src, size_t nbytes) {
@@ -96,6 +109,73 @@ inline void enqueue_one(BatchState<Desc>& st, const char* who, void* dst, const 
   }
   update_homogeneity<kAnchor>(st.homogeneous, st.anchor, src, dst);
   st.pending.push_back({dst, src, nbytes});
+}
+
+/**
+ * @brief Expand a strided description into `prod(outer_sizes)` flat entries.
+ *
+ * Entry k at outer index idx[] has dst_off = sum_d idx[d]*dst_byte_strides[d] and
+ * likewise for src. A stride of 0 is preserved, which is what makes a broadcast
+ * source replicate instead of collapsing to its first slab. The IntArrayRefs are
+ * read during this call only.
+ */
+template <typename Desc, DeviceAnchor kAnchor>
+inline void enqueue_strided_impl(
+    BatchState<Desc>& st,
+    const char* who,
+    void* dst,
+    const void* src,
+    size_t inner_block_bytes,
+    c10::IntArrayRef outer_sizes,
+    c10::IntArrayRef src_byte_strides,
+    c10::IntArrayRef dst_byte_strides) {
+  RBLN_CHECK(dst != nullptr, "{}::enqueue_strided: dst is nullptr", who);
+  RBLN_CHECK(src != nullptr, "{}::enqueue_strided: src is nullptr", who);
+  RBLN_CHECK(
+      outer_sizes.size() == src_byte_strides.size() && outer_sizes.size() == dst_byte_strides.size(),
+      "{}::enqueue_strided: size/stride length mismatch (outer={}, src={}, dst={})",
+      who,
+      outer_sizes.size(),
+      src_byte_strides.size(),
+      dst_byte_strides.size());
+
+  if (inner_block_bytes == 0) {
+    return;
+  }
+
+  // Degenerate: no outer dims → single slab.
+  if (outer_sizes.empty()) {
+    enqueue_one<Desc, kAnchor>(st, who, dst, src, inner_block_bytes);
+    return;
+  }
+
+  // Reject zero-extent outer dims (would yield zero work but a 0 in sizes
+  // means the caller produced a 0-numel tensor — they should have early-returned).
+  int64_t outer_count = 1;
+  for (int64_t s : outer_sizes) {
+    RBLN_CHECK(s > 0, "{}::enqueue_strided: outer_sizes must be all positive, got {}", who, c10::str(outer_sizes));
+    outer_count *= s;
+  }
+
+  st.pending.reserve(st.pending.size() + static_cast<size_t>(outer_count));
+
+  // All N expanded entries share the same base pointers — one lookup suffices.
+  update_homogeneity<kAnchor>(st.homogeneous, st.anchor, src, dst);
+
+  auto* dst_base = static_cast<uint8_t*>(dst);
+  const auto* src_base = static_cast<const uint8_t*>(src);
+
+  std::vector<int64_t> idx(outer_sizes.size(), 0);
+  for (int64_t o = 0; o < outer_count; ++o) {
+    int64_t src_off = 0;
+    int64_t dst_off = 0;
+    for (size_t d = 0; d < outer_sizes.size(); ++d) {
+      src_off += idx[d] * src_byte_strides[d];
+      dst_off += idx[d] * dst_byte_strides[d];
+    }
+    st.pending.push_back({dst_base + dst_off, src_base + src_off, inner_block_bytes});
+    advance_index(idx, outer_sizes);
+  }
 }
 
 /**

--- a/test/rbln/test_strided_host_copy.py
+++ b/test/rbln/test_strided_host_copy.py
@@ -1,0 +1,136 @@
+# Owner(s): ["module: PrivateUse1"]
+
+"""The descriptor path in non-contiguous host<->device ``copy_``.
+
+Above a slab-size threshold the slabs go to the runtime as descriptors, skipping
+the host gather pass; below it staging still wins, and on element-sized slabs
+descriptors are catastrophically slower — so the threshold is the point of the
+change and is asserted here, not just the values.
+
+Which path ran is observable through the profiler's host-bounce counters: staging
+records a bounce (it fills a host buffer), the descriptor path records none.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from torch.testing._internal.common_device_type import dtypes, instantiate_device_type_tests
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+from test.utils_v2v import arange as _arange, ENGINE_DTYPES, eq as _eq, to_dev as _to_dev
+
+
+# Slabs comfortably above / below torch_rbln's kMinStridedHostCopyBytes (16 KiB).
+_BIG_SLAB_ELEMS = 32 * 1024  # 64 KiB at float16
+_SMALL_SLAB_ELEMS = 512  # 1 KiB at float16
+
+
+def _bounces(report: dict) -> int:
+    """Total host-bounce incidents recorded in an explain() dump."""
+    return int(report["hidden_host_bounce"]["total_count"])
+
+
+@pytest.mark.test_set_ci
+@pytest.mark.usefixtures("enable_deploy_mode")
+class TestStridedHostCopy(TestCase):
+    """Non-contiguous cpu<->rbln ``copy_`` pairs."""
+
+    # ---- correctness, independent of which path is taken ----
+
+    @dtypes(*ENGINE_DTYPES)
+    def test_non_contiguous_source(self, dtype):
+        src_full = _arange((4, 2 * _BIG_SLAB_ELEMS), dtype)
+        src = src_full[:, :_BIG_SLAB_ELEMS]
+        dst = _to_dev(torch.zeros(4, _BIG_SLAB_ELEMS, dtype=dtype))
+        dst.copy_(src)
+        _eq(dst, src)
+
+    @dtypes(*ENGINE_DTYPES)
+    def test_non_contiguous_device_destination(self, dtype):
+        # The destination view is written in place; the gaps keep their contents.
+        storage = _to_dev(torch.zeros(4, 2 * _BIG_SLAB_ELEMS, dtype=dtype))
+        dst = storage[:, :_BIG_SLAB_ELEMS]
+        src = _arange((4, _BIG_SLAB_ELEMS), dtype) + 1
+        dst.copy_(src)
+        _eq(dst, src)
+        _eq(storage[:, _BIG_SLAB_ELEMS:], torch.zeros(4, _BIG_SLAB_ELEMS, dtype=dtype))
+
+    @dtypes(*ENGINE_DTYPES)
+    def test_non_contiguous_host_destination(self, dtype):
+        storage = torch.zeros(4, 2 * _BIG_SLAB_ELEMS, dtype=dtype)
+        dst = storage[:, :_BIG_SLAB_ELEMS]
+        src = _to_dev(_arange((4, _BIG_SLAB_ELEMS), dtype) + 1)
+        dst.copy_(src)
+        self.assertTrue(torch.equal(dst, src.cpu()))
+        self.assertTrue(torch.equal(storage[:, _BIG_SLAB_ELEMS:], torch.zeros(4, _BIG_SLAB_ELEMS, dtype=dtype)))
+
+    def test_transposed_source(self):
+        src = _arange((256, 256), torch.float32).t()
+        dst = _to_dev(torch.zeros(256, 256, dtype=torch.float32))
+        dst.copy_(src)
+        _eq(dst, src.contiguous())
+
+    def test_broadcast_source_is_expanded_not_repeated(self):
+        src = _arange((4, 1), torch.float32).expand(4, _BIG_SLAB_ELEMS)
+        dst = _to_dev(torch.zeros(4, _BIG_SLAB_ELEMS, dtype=torch.float32))
+        dst.copy_(src)
+        _eq(dst, src.contiguous())
+
+    def test_storage_offset_is_honoured(self):
+        src_full = _arange((4, 2 * _BIG_SLAB_ELEMS), torch.float32)
+        src = src_full[:, _BIG_SLAB_ELEMS:]
+        self.assertNotEqual(src.storage_offset(), 0)
+        dst = _to_dev(torch.zeros(4, _BIG_SLAB_ELEMS, dtype=torch.float32))
+        dst.copy_(src)
+        _eq(dst, src)
+
+    def test_dtype_cast_still_converts(self):
+        # The entrypoints move bytes, so a cast has to keep taking the host path.
+        src = _arange((4, _BIG_SLAB_ELEMS), torch.float32)[:, : _BIG_SLAB_ELEMS // 2]
+        dst = _to_dev(torch.zeros(4, _BIG_SLAB_ELEMS // 2, dtype=torch.float16))
+        dst.copy_(src)
+        _eq(dst, src.to(torch.float16))
+
+    # ---- the threshold ----
+
+    def test_large_slabs_skip_the_host_staging_pass(self):
+        src = _arange((4, 2 * _BIG_SLAB_ELEMS), torch.float16)[:, :_BIG_SLAB_ELEMS]
+        dst = _to_dev(torch.zeros(4, _BIG_SLAB_ELEMS, dtype=torch.float16))
+        with torch.rbln.explain() as p:
+            dst.copy_(src)
+        self.assertEqual(_bounces(p.dump()), 0, "slabs above the threshold must not stage")
+        _eq(dst, src)
+
+    def test_small_slabs_keep_staging(self):
+        # Descriptors lose here: the fixed cost per slab exceeds the host pass.
+        src = _arange((256, 2 * _SMALL_SLAB_ELEMS), torch.float16)[:, :_SMALL_SLAB_ELEMS]
+        dst = _to_dev(torch.zeros(256, _SMALL_SLAB_ELEMS, dtype=torch.float16))
+        with torch.rbln.explain() as p:
+            dst.copy_(src)
+        self.assertGreater(_bounces(p.dump()), 0, "slabs below the threshold must stage")
+        _eq(dst, src)
+
+    def test_element_sized_slabs_keep_staging(self):
+        # The pathological shape: one descriptor per element is ~130x slower.
+        src = _arange((512, 512), torch.float32).t()
+        dst = _to_dev(torch.zeros(512, 512, dtype=torch.float32))
+        with torch.rbln.explain() as p:
+            dst.copy_(src)
+        self.assertGreater(_bounces(p.dump()), 0, "element-sized slabs must stage")
+        _eq(dst, src.contiguous())
+
+    def test_device_to_host_large_slabs_skip_staging(self):
+        src = _to_dev(_arange((4, _BIG_SLAB_ELEMS), torch.float16))
+        storage = torch.zeros(4, 2 * _BIG_SLAB_ELEMS, dtype=torch.float16)
+        dst = storage[:, :_BIG_SLAB_ELEMS]
+        with torch.rbln.explain() as p:
+            dst.copy_(src)
+        self.assertEqual(_bounces(p.dump()), 0, "slabs above the threshold must not stage")
+        self.assertTrue(torch.equal(dst, src.cpu()))
+
+
+instantiate_device_type_tests(TestStridedHostCopy, globals(), only_for="privateuse1")
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
## Summary of Changes

A non-contiguous `cpu↔rbln` `copy_` never reaches the device directly. A strided source is gathered into a host temporary before the DMA; a strided destination is worse — the whole range is read back to host, merged there, and written again. `lmcache-rbln`'s KV restore lands on exactly this: `scatter_headmajor_to_full_blocks` writes `[H, block_size, D]` views taken from a wider chunk, so for any multi-block chunk the source is strided.

The runtime takes a list of slab descriptors, so the copy can be *described* instead — no host pass, no temporary. This PR adds `H2VBatch::enqueue_strided` / `V2HBatch::enqueue_strided` (#197 added the batches themselves) and routes plain `copy_` through them when it pays.

**Eligibility and geometry come from one suffix scan.** `make_strided_host_plan` returns a plan or nothing: a pair stays on the staging path unless its jointly contiguous inner block clears the threshold, and the scan that decided that is what gets enqueued, so the two cannot drift apart. A destination that may write the same address twice also stays on staging — descriptors within a submit are unordered, so its result would be undefined.

**The threshold is set where descriptors stop paying, deliberately on the safe side.** Measured crossover is 8–16 KiB (h2v) and 1–8 KiB (v2h), moving with the host thread count. 16 KiB sits above both because the errors are asymmetric: staging a slab that descriptors would have won costs ~1.3x, while descriptors on element-sized slabs cost **130x** — a transposed 1024×1024 upload is 1M four-byte descriptors, 0.68 ms → 89.9 ms.

`_foreach_copy_` is untouched: same contiguity rule, same `h2v_copy` / `v2h_copy` call sites as rebellions-sw/vllm-rbln-internal#30. A fan-out pair there falls to `copy_`, which this PR makes fast, so the descriptor threshold exists in exactly one place. No shared headers change — nothing outside `RBLNCopy.cpp` and the two batch classes moves.

### Results

Restore path (`scatter_headmajor_to_full_blocks`, host→device), L=62 H=8 D=128 block_size=512 bf16, median of 3 runs, spread ±0.2 ms:

| chunk | pairs | dev | this PR | |
|---|---|---|---|---|
| 1024 | 248 | 84.3 ms (3.1 GB/s) | **22.4 ms (11.6 GB/s)** | 3.76x |
| 2048 | 496 | 167.0 ms (3.1 GB/s) | **45.0 ms (11.6 GB/s)** | 3.71x |

The store path is unchanged — its pairs are already contiguous and rebellions-sw/vllm-rbln-internal#30 batches them.

Measured with pageable host memory. Production routes LMCache's slab through `allocate_huge_host_memory`, where the staging path may be faster, so 3.7x is an upper bound on this shape.

---

## Related Issues / Tickets

* Related to rebellions-sw/torch-rbln-internal#30 — payoffs (a)(b)(c)
* Stacked on rebellions-sw/vllm-rbln-internal#30 (`feat/h2v-v2h-multi`)

---

## Type of Change

- [ ] `feature` — New capability or functionality
- [x] `core` — Changes to RBLN backend, device layer, C++ extension, op registration, or `torch.compile` integration
- [ ] `fix` — Bug fix
- [x] `perf` — Performance improvement
- [ ] `refactor` — Code improvement without behavior change
- [ ] `docs` — Documentation only
- [ ] `other` — Other (describe below)

---

## Affected Modules

- [x] Backend
- [ ] Device
- [ ] Ops/Kernels
- [ ] `torch.compile`
- [x] C++ extension (`torch_rbln/csrc`)
- [x] Memory
- [ ] Build/Tools
- [ ] Docs

---

## How to Test

1. `python -m pytest test/rbln/test_strided_host_copy.py -q`
   - Expect **23 passed**: non-contiguous source, device destination and host destination,
     transpose, broadcast, storage offset, dtype cast — values against a `copy_` reference,
     and *which path ran* asserted through the profiler's host-bounce counters above the
     threshold, below it, and on element-sized slabs.
2. `python -m pytest test/rbln/*copy*.py test/rbln/test_profiler.py -q`
   - Expect **1213 passed, 6 skipped**.
3. `./build/bin/test_cpp_RBLNHostBatchTest && ./build/bin/test_cpp_RBLNV2VBatchTest`
   - Expect **19 + 18 passed**. The V2V binary is the check on moving the row-major
     expansion into the shared header, now that all three batches use it.
4. To re-derive the threshold on another host, vary `kMinStridedHostCopyBytes` over a
   strided copy and find where the two paths cross.

---

## Notes

* The row-major descriptor expansion moved out of `RBLNV2VBatch.cpp` into
  `detail/RBLNCopyBatchImpl.h` (−85/+84): all three directions share one implementation, and
  `RBLNV2VBatchTest` is the check that v2v behaviour is unchanged.
* The stack's payoff is here — rebellions-sw/vllm-rbln-internal#30 buys the store path and the classes, the restore path is
  3.7x in this PR.

---

## Checklist

* [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
* [ ] This PR is linked to a corresponding issue — see [Contributing to torch-rbln](docs/CONTRIBUTING.md)
* [x] Linting passes — see [Linting](docs/LINTING.md)
* [ ] All CI tests pass — see [CI/CD Workflows](docs/WORKFLOWS.md)
* [x] The test method is described, and the expected result is clearly stated (if applicable)
* [ ] Relevant documentation has been updated (if applicable)
