### PR TITLE
build: cap hatchling below 1.32 so wheels stay on metadata 2.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,10 @@ dependencies = [
 
 [build-system]
 requires = [
-  "hatchling>=1.25.0",
+  # Upper bound: hatchling 1.32 emits Metadata-Version 2.5, which the twine that
+  # publishes these wheels (6.1.0) rejects as invalid. Lift once the publisher
+  # understands 2.5.
+  "hatchling>=1.25.0,<1.32",
   "setuptools-scm>=8.0",
   "PyYAML>=6,<7",
   "cmake>=3.18,<4.0",
@@ -150,7 +153,7 @@ build = [
   "editables>=0.5",
   "rebel-compiler>=0.11.1,<0.20.0",
   "setuptools-scm>=8.0",
-  "hatchling>=1.25",
+  "hatchling>=1.25,<1.32",  # see the build-system pin
   "mypy>=1.13.0,<1.14.0",
   "ninja>=1.11",
   "pip>=24.3.1,<24.4"


### PR DESCRIPTION
## Summary of Changes

CI cannot publish any branch right now. The build succeeds and the upload fails:

```
Uploading distributions to https://pypi.rebellions.in/simple
ERROR InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

`hatchling` 1.32.0 raised the metadata version it writes, and the build-system requirement had no upper bound, so CI picked it up the moment it was released:

```
hatchling 1.31.0   DEFAULT_METADATA_VERSION = '2.4'
hatchling 1.32.0   DEFAULT_METADATA_VERSION = '2.5'
```

The publisher pins `twine<7,>=6.0` and resolves 6.1.0, which validates metadata versions and only knows up to 2.4. So a wheel built by 1.32.0 is rejected.

This caps `hatchling<1.32` in both places it is required, which puts the emitted metadata back at 2.4. The cap belongs here rather than in the publisher because the build backend is ours, and leaving its upper bound open is what let a release change the artifact format without a single change in this repository. Lift it once the publisher understands 2.5 — `twine` 6.2.0 and 7.0.0 exist and are worth checking on that side.

Not related to any code change: the same failure hits `dev`-based branches and PRs alike, and the last green `dev` run predates the hatchling release.

---

## Type of Change

- [x] `other` — Other (describe below)

Build/publish infrastructure only; no runtime code is touched.

---

## Affected Modules

- [x] Build/Tools

---

## How to Test

1. `pip download --no-deps "hatchling>=1.25.0,<1.32"` resolves to 1.31.0, whose `DEFAULT_METADATA_VERSION` is `2.4`.
2. Any CI run on this branch reaching "Upload torch-rbln package to internal PyPI" — it should complete instead of failing on the metadata version.

---

## Checklist

* [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
* [x] Linting passes — see [Linting](docs/LINTING.md)
* [ ] All CI tests pass — see [CI/CD Workflows](docs/WORKFLOWS.md)
* [x] The test method is described, and the expected result is clearly stated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
