### PR TITLE
test: stop tying device-free tests to device availability

### DIFF
--- a/docs/TEST_GUIDE.md
+++ b/docs/TEST_GUIDE.md
@@ -291,10 +291,14 @@ The PyTorch test framework (`torch.testing._internal`) automatically generates d
 2. Call `instantiate_device_type_tests(TestClass, globals(), only_for="privateuse1")` at module scope.
 3. The framework generates concrete classes like `TestFooPRIVATEUSE1` with methods suffixed `_rbln`.
 
-**All test files in this project use `only_for="privateuse1"`** to generate tests exclusively for the RBLN backend, avoiding unnecessary CPU/CUDA variants.
+**Device-type tests in this project always use `only_for="privateuse1"`** to generate tests exclusively for the RBLN backend, avoiding unnecessary CPU/CUDA variants.
+
+Since that leaves exactly one device type, the instantiation earns its keep through the axes it expands — `@dtypes`, `@parametrize`, or a `device` argument — and it is required for any test that uses one.
+
+**Do not wrap a test that never touches a device.** The call deletes the template class and rebuilds it per device type, and the RBLN base is only in that list when `torch.rbln.is_available()` is true. On a host without an NPU the template is gone and nothing replaces it, so the file collects zero tests — no failure, no skip, just absent. That costs nothing for a test that needs hardware anyway, but it hides pure-logic tests exactly where they could still run: ABI window checks, library resolution, arch predicates, and anything asserting behaviour with no device present (`test_dummy_device.py`, `test_no_device.py`) or through a subprocess (`test_import_rbln_devices_seal.py`). Those are plain `TestCase`.
 
 ```python
-# This call at the bottom of every test file:
+# This call at the bottom of a device-type test file:
 instantiate_device_type_tests(TestRegisteredNativeOps, globals(), only_for="privateuse1")
 
 # Generates: TestRegisteredNativeOpsPRIVATEUSE1

--- a/docs/TEST_GUIDE.md
+++ b/docs/TEST_GUIDE.md
@@ -295,7 +295,7 @@ The PyTorch test framework (`torch.testing._internal`) automatically generates d
 
 Since that leaves exactly one device type, the instantiation earns its keep through the axes it expands — `@dtypes`, `@parametrize`, or a `device` argument — and it is required for any test that uses one.
 
-**Do not wrap a test that never touches a device.** The call deletes the template class and rebuilds it per device type, and the RBLN base is only in that list when `torch.rbln.is_available()` is true. On a host without an NPU the template is gone and nothing replaces it, so the file collects zero tests — no failure, no skip, just absent. That costs nothing for a test that needs hardware anyway, but it hides pure-logic tests exactly where they could still run: ABI window checks, library resolution, arch predicates, and anything asserting behaviour with no device present (`test_dummy_device.py`, `test_no_device.py`) or through a subprocess (`test_import_rbln_devices_seal.py`). Those are plain `TestCase`.
+**Do not wrap a test that never touches a device.** The call deletes the template class and rebuilds it per device type, and the RBLN base is only in that list when `torch.rbln.is_available()` is true. On a host without an NPU the template is gone and nothing replaces it, so the file collects zero tests — no failure, no skip. A test that needs hardware loses nothing by that; a pure-logic test loses the ability to run where it still could. Tests asserting behavior with no device present (`test_dummy_device.py`, `test_no_device.py`) or through a subprocess (`test_import_rbln_devices_seal.py`) are plain `TestCase`.
 
 ```python
 # This call at the bottom of a device-type test file:

--- a/test/internal/test_device_arch.py
+++ b/test/internal/test_device_arch.py
@@ -3,7 +3,6 @@
 from unittest.mock import patch
 
 import pytest
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 from test.utils import xfail_atom, xfail_rebel
@@ -78,11 +77,6 @@ class TestArchXfailMarkers(TestCase):
         with patch("torch_rbln._internal.device_arch_utils.get_device_arch", return_value="rebel"):
             mark = xfail_atom("ATOM: feature not yet supported")
         self.assertFalse(mark.mark.kwargs["condition"])
-
-
-instantiate_device_type_tests(TestArchFromNpuName, globals(), only_for="privateuse1")
-instantiate_device_type_tests(TestArchPredicates, globals(), only_for="privateuse1")
-instantiate_device_type_tests(TestArchXfailMarkers, globals(), only_for="privateuse1")
 
 
 if __name__ == "__main__":

--- a/test/rbln/test_abi_check.py
+++ b/test/rbln/test_abi_check.py
@@ -22,7 +22,6 @@ try:
     from unittest.mock import patch
 
     import pytest
-    from torch.testing._internal.common_device_type import instantiate_device_type_tests
     from torch.testing._internal.common_utils import run_tests, TestCase
 
     import torch_rbln  # noqa: F401  -- gated import, keeps the backend from initialising here
@@ -306,14 +305,6 @@ class TestInstalledCombination(TestCase):
             abi_check.abi_mismatch_reason(built, window[0], window[1]),
             f"installed librbln.so accepts {window[0]}..{window[1]} but this build recorded {built}",
         )
-
-
-instantiate_device_type_tests(TestAbiMismatchReason, globals(), only_for="privateuse1")
-instantiate_device_type_tests(TestReadRuntimeAbi, globals(), only_for="privateuse1")
-instantiate_device_type_tests(TestOpenMappedRuntime, globals(), only_for="privateuse1")
-instantiate_device_type_tests(TestGetBuiltAbi, globals(), only_for="privateuse1")
-instantiate_device_type_tests(TestCheckLibrblnAbi, globals(), only_for="privateuse1")
-instantiate_device_type_tests(TestInstalledCombination, globals(), only_for="privateuse1")
 
 
 if __name__ == "__main__":

--- a/test/rbln/test_rbln_runtime_lib.py
+++ b/test/rbln/test_rbln_runtime_lib.py
@@ -13,7 +13,6 @@ import tempfile
 from unittest.mock import patch
 
 import pytest
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 from torch_rbln._internal import rbln_runtime_lib
@@ -219,10 +218,6 @@ class TestRblnRuntimeLibAdopt(TestCase):
         ):
             self.assertEqual(rbln_runtime_lib.load_runtime_library(), "/opt/rebel/librbln.so")
 
-
-instantiate_device_type_tests(TestRblnRuntimeLibResolve, globals(), only_for="privateuse1")
-instantiate_device_type_tests(TestRblnRuntimeLibRecord, globals(), only_for="privateuse1")
-instantiate_device_type_tests(TestRblnRuntimeLibAdopt, globals(), only_for="privateuse1")
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary of Changes

`instantiate_device_type_tests` deletes the template class and rebuilds it per device type, and the RBLN base joins that list only when a device is available. On a host without an NPU the template is gone and nothing replaces it, so the file collects nothing — no failure, no skip.

Three files paid that for nothing. The ABI window checks, the `librbln.so` resolution rules, and the arch predicates use no device and had no axis to expand, so the call only renamed their classes while making them disappear wherever there is no hardware — which is where the ABI and resolution paths most want testing. They are plain `TestCase` now.

`docs/TEST_GUIDE.md` §5 said the call belongs at the bottom of every test file. It now states what the mechanism does and when not to reach for it.

---

## Related Issues / Tickets

* Related to #

---

## Type of Change

- [x] `docs` — Documentation
- [x] `other` — Test-only change (no production code)

---

## Affected Modules

- [x] Docs

---

## How to Test

```bash
uv run --no-sync pytest test/rbln/test_abi_check.py test/rbln/test_rbln_runtime_lib.py test/internal/test_device_arch.py
```

The same tests collect and pass as before the change.

---

## Checklist

* [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
* [ ] This PR is linked to a corresponding issue
* [x] The test method is described, and the expected result is clearly stated
* [x] Relevant documentation has been updated

---

## Notes

No production code changes. The two remaining mixed files (`test_device_mapping.py`, `test_memory_stats.py`) touch a device in part and are left alone; splitting them is a separate change.
