### PR TITLE
refactor(codegen): drop two category tables nothing reads

### DIFF
--- a/tools/codegen/config.py
+++ b/tools/codegen/config.py
@@ -33,7 +33,6 @@ class OpCategories:
 
     # TODO: need to make automatically fill 'Ops' if it figure out
     REDUCTION_OPS: Set[str] = {"sum", "mean"}
-    UNARY_OPS: Set[str] = {"silu", "rsqrt", "neg", "ceil", "abs", "log", "floor", "trunc"}
     BROADCASTABLE_OPS: Set[str] = {
         "add",
         "sub",
@@ -185,14 +184,6 @@ class OpCategories:
         ({"where"}, "where"),
         ({"addmm"}, "addmm"),
         ({"linear"}, "linear"),
-    ]
-
-    # Dtype validation mapping: (category_set, template_method_name)
-    # Maps category Set -> template method name in Validation class
-    # Order matters: checked in sequence, first match wins
-    DTYPE_VALIDATION_MAP: List[Tuple[Set[str], str]] = [  # noqa: UP035
-        (REDUCTION_OPS, "dtype_reduction"),
-        (COMPARE_OPS, "dtype_compare"),
     ]
 
     # Special out parameter names for operations that don't use standard 'out' kwarg


### PR DESCRIPTION
## Summary of Changes

`UNARY_OPS` and `DTYPE_VALIDATION_MAP` in `tools/codegen/config.py` have no reader anywhere in `tools/codegen`, and neither is waiting for one — each was superseded and left behind.

Dtype validation is inlined: `_generate_dtype_validation` in `generators/variants.py` tests `REDUCTION_OPS` and `COMPARE_OPS` directly, and applies reduction *and* compare-or-default, which is not the "first match wins" the map documents. The unary categorization moved to `SHIM_UNARY_POINTWISE`, keyed by overload (`rsqrt.out`) rather than root name.

---

## Related Issues / Tickets

* Related to #

---

## Type of Change

- [x] `refactor` — Code improvement without behavior change

---

## Affected Modules

- [x] Build/Tools

---

## How to Test

Regenerate the dispatch shims and compare against the file produced before the change:

```bash
uv run --no-sync python tools/run_codegen.py \
  aten/src/ATen/native/native_functions.yaml \
  aten/src/ATen/native/tags.yaml \
  torch_rbln/_internal/register_ops.py
```

The output is byte-identical, so nothing downstream sees this.

---

## Checklist

* [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
* [ ] This PR is linked to a corresponding issue
* [x] The test method is described, and the expected result is clearly stated
* [x] Relevant documentation has been updated (if applicable)

---

## Notes

Both `typing` names they used (`List`, `Tuple`) are still needed by other tables, so the import is unchanged.
