### PR TITLE
docs(agent): write down the conventions for agent-written changes

### DIFF
--- a/.claude/skills/adding-an-op/SKILL.md
+++ b/.claude/skills/adding-an-op/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: adding-an-op
+description: Use when adding, changing, or removing an aten operator on the RBLN backend — the three registration paths, which one a given op belongs on, and what else has to change once you pick.
+---
+
+# Adding an operator
+
+An op reaches the RBLN backend by one of three routes. Picking the wrong one produces code that works locally and then disappears, or an op whose tests never run.
+
+## 1. Pick the path
+
+**Generated shim (default).** Add a `func:` entry with a `PrivateUse1: <name>_rbln` dispatch to `aten/src/ATen/native/native_functions.yaml`. `tools/codegen/` emits the dispatch wrapper into `torch_rbln/_internal/register_ops.py`, which routes the op through `torch.compile` with the rebel backend. Use this whenever the op is a normal tensor computation.
+
+**Hand-written Python kernel.** Same YAML entry, plus the `use_custom_kernel_rbln` tag. Codegen then emits only the registration and you supply the kernel in `torch_rbln/_internal/register_custom_ops.py` or `torch_rbln/_internal/kernels/`. Use this when the op needs a shape rewrite, a fused pattern, or host-side logic before it reaches the compiler — `pow.Tensor_Scalar_out` is the worked example.
+
+**C++ kernel.** Implement under `aten/src/ATen/native/rbln/` and register with `m.impl(...)` inside `TORCH_LIBRARY_IMPL(aten, PrivateUse1, m)` in `aten/src/ATen/native/RBLNRegisterOps.cpp`. Use this for ops that touch storage, strides, device guards, or the allocator — copy, resize, factories, advanced indexing.
+
+Backward is not one of these routes. It is used in a few places only and adding it is not recommended; if a change genuinely needs it, read `torch_rbln/_internal/register_backward_ops.py` first and ask.
+
+Not sure between two? Ask. A misplaced kernel is expensive to move later.
+
+## 2. Never edit `register_ops.py`
+
+It is generated and gitignored. Editing it works until the next build wipes it. The sources are the YAML entry and the generator under `tools/codegen/generators/`.
+
+`tools/codegen/config.py` decides per-op behavior — empty-tensor handling, dtype checks, contiguity, kwarg filtering — from name sets. Membership only matters for a set an accessor actually reads: the entries of `EMPTY_TENSOR_HANDLING_MAP` (`REDUCTION_OPS`, `BROADCASTABLE_OPS`, and the per-op sets), `SKIP_DTYPE_CHECK_OPS`, `SINGLE_MEM_LOC_OUT_VIOLATION_OPS`, `SPECIAL_KWARGS_FILTER_OPS`. Others are defined and never used — `UNARY_OPS` is one, so adding a unary op to it changes nothing. Grep for the set before assuming it does, and add the op only where a reduction or a broadcast really needs different handling.
+
+## 3. What else changes
+
+- **C++-only registration is invisible to op tests.** `test/filters.py` discovers ops by parsing `native_functions.yaml`; an op registered only in `RBLNRegisterOps.cpp` must be added to `_ops_with_rbln_native_kernel` or its upstream OpInfo tests never run.
+- **The dispatch-shim sets in `tools/codegen/config.py`.** `codegen.py:_registration_line` emits `_register_cpp_shim(...)` for an overload listed in one of the `SHIM_*` sets and `aten_impl.impl(...)` for everything else. What the shim buys is that neither hot path enters Python: it runs the pre-check (dtype, all-scalar, contiguity and offset) in C++ and on failure calls `cpu_fallback_rbln` directly, and on a warm-cache hit it drives the rebel runtime from C++ with no pybind crossing. Python is entered only on a cache miss, to compile — see the header comment in `torch_rbln/csrc/rbln/DispatchShim.h`.
+- **Which path your op belongs on follows from that pre-check.** The sets cover the families it can decide — binary and unary pointwise, compare, where, reduction, matmul — 42 of the 50 registrations today. The 8 on the Python path are the ones it cannot: in-place (`masked_fill_`), backward kernels, and fused or custom ops (`_softmax`, SDPA). Add a plain pointwise or reduction op to the matching set; leave an in-place, a backward, or an op with typed non-tensor arguments on the Python path. For a single typed argument — `where`'s bool condition — `CPP_SHIM_SKIP_DTYPE_ARGS` exempts that index instead.
+- **A public API name that differs from the schema name** goes in `_ops_with_public_api_name_mismatch` in the same file.
+- **`native_functions.yaml` is adapted from upstream PyTorch.** Copy the upstream entry and add only the `PrivateUse1` dispatch and RBLN tags. The `NATIVEFUNCTIONS` linter round-trips the file, so reformatting it fails lint.
+- **Every tag must be declared in `tags.yaml`**, which is a trimmed copy of upstream's — so an entry copied verbatim can carry a tag we do not have, and parsing then fails with `illegal tag <name>` before codegen emits anything. Add the tag to `tags.yaml` or drop it from the entry.
+- **Removing an op** means removing its YAML entry, its filter entries, and its tests together. A leftover filter entry keeps a test alive for a kernel that no longer exists.
+
+## 4. Rebuild, then read what was generated
+
+```bash
+uv pip install -e . --no-build-isolation
+```
+
+Codegen runs during the build. Until it does, your YAML change has no effect at all — the shim on disk is still the old one.
+
+For a YAML-path op you can skip the C++ rebuild while iterating and run codegen alone:
+
+```bash
+uv run --no-sync python tools/run_codegen.py aten/src/ATen/native/native_functions.yaml aten/src/ATen/native/tags.yaml torch_rbln/_internal/register_ops.py
+```
+
+That rewrites the generated file in place, so back it up first if the tree is one you care about. A C++-path op still needs the full install. After the build, read the generated function in `torch_rbln/_internal/register_ops.py` and confirm it is what you intended: the wrong category mapping produces a wrapper that compiles and returns wrong results on empty or broadcast inputs.
+
+## 5. Verify
+
+### First: prove it ran on the device
+
+Nothing below means anything until this holds. The failure is silent — an op routed to the host returns the CPU result, so the comparison you were about to trust agrees exactly.
+
+1. **Give it an input the device path accepts: fp16 or bf16, with a last dimension that is a multiple of 64.** `SUPPORTED_DTYPES` is those two only, and `compile_and_run_view_aware` applies its own alignment fallback after `is_cpu_fallback_cases` (see the 64-element alignment comment in `ops_utils.py`). Miss either condition and the op runs on the host however it is registered. Measured on `rsqrt`: `(4, 64)` fp16 and bf16 differed from CPU at the rounding level, while fp32 — and fp16 at `(4, 8)` — matched exactly, because neither reached the kernel. `torch.rand` defaults to fp32, which is how this is usually missed.
+2. **Check the log, not the numbers.** With `TORCH_RBLN_LOG_LEVEL=INFO` every fallback prints ```aten::<op>` op ran on CPU instead of RBLN``. No such line on an aligned input is the proof. `TORCH_RBLN_DISABLE_FALLBACK=compile_error` does not cover the alignment route and will not raise for you.
+3. **Run an established peer on the same input** — a unary against `rsqrt`, a binary against `add`. The same order of difference from CPU says your op took the same path.
+
+### Then: correctness
+
+- Eager and inside `torch.compile(backend="rbln")` produce the same numbers.
+- Every dtype in `SUPPORTED_DTYPES` that the op claims to support.
+- Empty tensors, broadcasting, non-contiguous inputs, and a non-zero storage offset — the four the generated wrappers handle by category and therefore get wrong by category.
+- The `out=` variant writes into the passed tensor.
+- `test/rbln/test_registered_ops.py` and the op tests in `test/ops/test_ops.py` still pass.
+
+Follow `.claude/skills/writing-tests/SKILL.md` for the tests themselves.
+
+## 6. Do not
+
+- Do not route the op to CPU fallback to make it pass. An op that falls back is an op that is not implemented; say so instead.
+- Do not add a special case to `is_cpu_fallback_cases()` for a shape or dtype the kernel gets wrong. That hides a correctness bug behind a performance cliff.
+- Do not widen a tolerance to make a new op's test agree with the CPU reference. Find out why they disagree first.

--- a/.claude/skills/debugging/SKILL.md
+++ b/.claude/skills/debugging/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: debugging
+description: Use when investigating a bug, a failing test, or unexpected behavior in torch-rbln — the build and process-state traps that make a reproduction lie, how to tell a backend defect from a compiler defect, and the evidence rules that stop a wrong cause from looking confirmed.
+---
+
+# Debugging torch-rbln
+
+Two things make a session go wrong here: reproducing something other than the reported bug, and confirming a cause that is not the cause. This skill is about those. It does not restate general debugging method.
+
+## 1. Before you trust the reproduction
+
+Get a reproducer before changing anything, and narrow it to the smallest input that still fails.
+
+**Narrowing has a floor.** Shrink past it and the op stops reaching the device: `SUPPORTED_DTYPES` is fp16 and bf16 only, and a last dimension that is not a multiple of 64 takes the host path. Either way the result then matches CPU exactly, which reads as "the bug went away". Keep the dtype at fp16 or bf16, keep the last dimension aligned, and check after each narrowing step that the op still ran on the device.
+
+**If you cannot reproduce it, stop and report that.** An untested fix for an unverified report costs a reviewer more than no patch.
+
+**The minimal reproducer is a deliverable, not a step.** When the defect goes to another team, it ships as a standalone script that runs without installing a model, a dataset, or the test suite — a reproduction that requires the whole environment will not be run by the people who have to fix it. Keep narrowing until the script is short enough to paste.
+
+**Three things tell you what actually happened**, and none of them are the returned values:
+
+- `TORCH_RBLN_LOG_LEVEL=INFO` prints ```aten::<op>` op ran on CPU instead of RBLN`` for every fallback. This is the only signal that says whether the device path was taken.
+- `torch.rbln.explain()` attributes hidden overhead — dispatch, CPU fallback, host copies — and `with_stack=True` gives the call site. `docs/EXPLAIN.md` is the reference; read it before writing your own instrumentation.
+- `python -m torch_rbln.diagnose` (with `TORCH_RBLN_DIAGNOSE=1`) diagnoses library loading when the failure is `Cannot find libraries` or a missing `librbln.so`, rather than anything about your change.
+
+Each of these makes a run exercise something other than what you think:
+
+- **You are probably running the last build.** Any change under `aten/`, `c10/`, `torch_rbln/csrc/`, or `native_functions.yaml` needs `uv pip install -e . --no-build-isolation` before it means anything. This applies to the reproduction as much as the fix — a "fixed" result from a stale `.so` is the most common false conclusion in this repository.
+- **`torch_rbln/_internal/register_ops.py` is generated.** Reading it is fine and often the fastest way to see what the eager path actually does. Editing it to test a hypothesis works until the next build, so treat any result from an edited copy as provisional and move the change to the YAML or the generator before concluding anything.
+- **A flag may be latched, and the device mapping freezes on first use.** The per-dispatch flags are read live (`DispatchShim.cpp`), but anything cached in `static` or `@lru_cache` state keeps the value it saw first. The device mapping is planned by queries like `device_count()`, which claim nothing, and committed — frozen for the process — by the first real use: an allocation, a `synchronize()`, a collective. Editing `RBLN_DEVICES` after that is ignored. Check how the flag you are toggling is actually read, or use `run_in_isolated_process`.
+- **The test suite is not production.** `test/conftest.py` force-disables the `compile_error` fallback, resets Dynamo between tests, and drains the allocator in teardown. A bug that appears only under pytest, or only outside it, is about that difference.
+- **xdist workers carry state, and share the device.** A failure that appears only in a full run is usually a leak from an earlier test on that worker, but contention for the shared device produces the same shape. Run the suspected pair together in one process to tell them apart; if it is a leak, fix the leak rather than the second test.
+
+## 2. When the log came from somewhere else
+
+If the failure is in a log the user pasted from another machine — CI, a customer setup, a colleague's box — reason from the log and the source. Do not run local probes for host state; this box is not that box, and what they report is unrelated noise. When host-side evidence is genuinely needed, say what command to run there and ask for the output.
+
+## 3. Make the evidence discriminate
+
+Evidence that fits your hypothesis is easy to find and proves nothing — a wrong cause has confirming evidence too. Force the evidence to choose between explanations.
+
+- **State what would be true if you are wrong**, and check that specifically.
+- **Predict the output before you run.** A surprise means your model of the system is wrong, and that is the finding.
+- **The cause must explain every symptom.** A leftover unexplained detail usually means a second cause or the wrong one.
+- **Separate a flake from a regression before chasing it.** Run the same commit three times. If the failing configuration moves between runs — a different matrix leg, a different worker — it is nondeterminism, not your change. Say which one you established, and do not report a fix for a flake you only saw once.
+- **For a numerical bug, compare against CPU before theorizing about the kernel** — at the smallest shape that still reaches the device, not the smallest that still runs. Half the "wrong result" reports are dtype or tolerance, not the op; an exact match is the other half, and it usually means the comparison never left the host.
+
+Report which parts you verified and which you inferred. Never state a hypothesis as a fact.
+
+## 4. Decide which layer owns it
+
+Before writing a fix, place the defect:
+
+1. **torch-rbln Python** — the shim, the device API, a `torch.compile` patch
+2. **torch-rbln C++** — allocator, guard, copy, native kernel, process group
+3. **rebel-compiler / librbln** — the compiler and runtime, a separate repository; the exact build pin is `constraints-build-dev.txt`
+
+Signals for layer 3: the same graph produces different results across compiler versions; an error code from the runtime; a failure that disappears with `TORCH_RBLN_*` knobs that only change how much work is handed to the compiler; a fault inside `librbln`. Confirm by installing a different rebel-compiler version and re-running — a version bisect is worth the time, because it converts a guess into a fact. Install it into the venv; do not commit the pin change. Building against a compiler source checkout, when you need to test a candidate fix, swaps this repository's `pyproject.toml` and rebuilds the venv — ask first and use a throwaway worktree.
+
+**Dump what the external component received before you bisect it.** A bisect tells you which commit flipped the behavior, not why the input it now produces is invalid — and "commit X introduced it" is not a fix you can write. Capture the IR or graph handed to the compiler, from a working build and a failing one, and diff them. The difference is the root cause; the bisect is the shortcut to a pair of builds worth diffing.
+
+The switches that produce those artifacts belong to the runtime, not to this repository, and are not documented here — setting one is not always enough on its own. Ask the compiler team which switch yields the artifact you need on the pinned version rather than guessing at names.
+
+**Check what the runtime already does before you build anything.** rebel-compiler ships its headers and `librbln.so` in the wheel; read its source and the pinned version's changes rather than inferring behavior from symptoms. A gate the runtime already implements, re-implemented here, is machinery that fights a problem that no longer exists — and it is the shape that survives ten review rounds before someone reads the runtime and deletes all of it.
+
+**When the cause is layer 3, do not fix it here.** Reduce it to a minimal reproducer, report it against rebel-compiler, and say so. If the failure is architecture-specific, `xfail_rebel` / `xfail_atom` (`test/utils.py`) mark it strictly so it fails again once the bug is fixed; `_REBEL_XFAILS` in `test/conftest.py` is the table that applies `xfail_rebel` by test name. A failure that is not architecture-specific does not get parked. A guard added in the backend to make a compiler bug invisible removes the only pressure to fix it and stays in this code permanently. If you think a local workaround is warranted anyway, stop and ask.
+
+## 5. Fix the cause, not its surroundings
+
+Change the thing that is wrong — not a caller, not a wrapper, not a guard around the symptom.
+
+Never widen an exception, add a default, route an op to CPU fallback, or loosen a tolerance to make the failure go away. Reaching for any of those means you are fixing without a cause.
+
+## 6. If the fix does not work, discard it
+
+Revert it and form another hypothesis. Do not stack a second patch on a failed first one. A failed fix is information: the cause was probably wrong.
+
+## 7. Verify against the reproducer
+
+Rebuild, run the reproducer again, run the tests around what you touched, and read the output. A fix that has not been run is not a fix. Check both execution paths — eager and `torch.compile(backend="rbln")` — because a fix in a generated shim does not necessarily reach the graph path, and vice versa.
+
+## 8. Report the gaps
+
+State explicitly what you could not build, run, or reproduce; hardware or models you did not have; and anything you inferred rather than verified.
+
+Tests that broke after your change are your regressions. Debug them. Do not stash or revert to check whether they also fail on `dev`.

--- a/.claude/skills/finishing-a-change/SKILL.md
+++ b/.claude/skills/finishing-a-change/SKILL.md
@@ -74,6 +74,7 @@ General:
 - **`else` branches for cases that cannot happen** — should be `raise`, `assert`, or `RBLN_CHECK`
 - **Dead leftovers** — renamed `_var`, unused re-exports, `# removed` comments
 - **Anything not in English**
+- **Absolute measurements** — throughput, latency, memory, or accuracy from an internal run. Take them out; this repository is public. A relative change is fine.
 
 torch-rbln specific:
 
@@ -107,6 +108,7 @@ An empty list is a claim. Only write it if it is true.
 - You are on a feature branch off `dev`, not on `dev` or `main` itself
 - PR title in `type(scope): summary` — CI enforces it. Individual commits only need to be readable (`docs/CONTRIBUTING.md`)
 - Explain intent, not the diff. Symptom, reproducer, where to look, what you verified — the debugging path that got you there is not part of it
+- A perf change may give a relative change, never an absolute measurement
 - Say which layer you changed and which execution paths you exercised — eager, `torch.compile(backend="rbln")`, or both
 - Fill in **Affected Modules** and **How to Test** in the template, and link the issue
 - English

--- a/.claude/skills/finishing-a-change/SKILL.md
+++ b/.claude/skills/finishing-a-change/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: finishing-a-change
+description: Use before claiming a change is done, fixed, ready, or passing, and before writing a commit or PR — rebuilds, runs lint and the tests, states the regression and performance impact, reviews the diff against the repository rules, and reports what was not done.
+---
+
+# Finishing a change
+
+By the time you get here the session is long and the instructions you read at the start have faded. Work through this list rather than from memory.
+
+## 1. Rebuild if you touched the native side
+
+```bash
+uv pip install -e . --no-build-isolation
+```
+
+Required after a change under `aten/`, `c10/`, `torch_rbln/csrc/`, `cmake/`, `CMakeLists.txt`, `hatch_build.py`, `native_functions.yaml`, or `tools/codegen/` — the build runs codegen before compiling, so a generator change takes effect only here. Without it every test result below is about the previous build.
+
+Confirm it took rather than assuming: grep the built artifact for a string only your change introduces. Two error shapes say which side is stale — a link error naming `rbln::` symbols means the installed `rebel-compiler` is older than the pin, an `AttributeError` for a missing `torch_rbln._C` attribute means the built extension is older than the Python tree, and an `RBLN ABI mismatch` at import means the two disagree on the interface contract.
+
+## 2. Run lint
+
+```bash
+uv run --no-sync lintrunner -m origin/dev -a
+```
+
+Read the output. Passing means you saw it pass. C++ linting needs the compile database — see `docs/LINTING.md`. `-a` auto-fixes; re-read the diff afterwards, since it will have edited your files.
+
+Lint against the merge base, not the files you happened to touch. CI lints the whole PR diff, so a file an earlier commit on this branch introduced still has to pass — a missing owner header or formatting drift in one of those is a rejected PR for a file you never opened.
+
+A merge-base run covers uncommitted edits to tracked files but **not files that are still untracked**: a brand-new test lints clean because it was never looked at. `git add -N` the new files first, or pass them explicitly.
+
+`-a` rewrites files in place across that whole range, including unrelated edits you have in the tree. If the tree carries work that is not part of this change, run it without `-a` first and read what it wants to change.
+
+Never run `ruff`, `black`, or `isort` on their own; `.lintrunner.toml` coordinates them with configs that differ from each tool's defaults, so a direct run produces different output than CI. If lint reports a malformed mypy status file, the daemon state is corrupt from an aborted run: `dmypy stop`, remove `.dmypy.json`, and run again.
+
+## 3. Run the tests
+
+Run the narrowest target that covers the change, then the suite around it:
+
+```bash
+uv run --no-sync pytest test/rbln/test_<module>.py -x
+uv run --no-sync python test/run_tests.py --suite=core
+```
+
+Include the command and its result in your reply. "Should pass" is not a result. If you could not run them, say that instead of implying you did.
+
+For a change to an op or a kernel, confirm the tests exercised the device path and not the host fallback — matching numbers alone do not show it. `.claude/skills/writing-tests/SKILL.md` has the check.
+
+## 4. State the regression and performance impact
+
+Say what else takes the path you changed, and what the change costs on it. A copy path, a dispatch shim, or an allocator change is on the hot path for every model; a reviewer will ask, so answer first. If you did not measure, say you did not measure — do not offer "should be negligible" as a result.
+
+## 5. Read your own diff
+
+```bash
+git diff                    # unstaged
+git diff --staged           # staged
+git status --short          # untracked files you may have meant to add
+git diff origin/dev...HEAD  # what the PR will actually show
+```
+
+General:
+
+- **Files nobody asked for** — docs, examples, scripts, changelogs
+- **Scratch files** left over from iterating, anywhere in the tree
+- **Single-use helpers** that should be inlined
+- **Abstractions** built for one call site
+- **Comments that narrate the code**, describe your changes, or address the reader
+- **Comments added to code you did not otherwise change**
+- **Comments your change made stale** — read the ones around every line you touched
+- **Code with no caller** — machinery whose justification is in a later change belongs there
+- **A second tuning constant for a trade-off that already has one**, or a threshold with no measurement behind it
+- **Swallowed failures** — `except Exception`, bare `except`, `except: pass`, an unrequested fallback
+- **`else` branches for cases that cannot happen** — should be `raise`, `assert`, or `RBLN_CHECK`
+- **Dead leftovers** — renamed `_var`, unused re-exports, `# removed` comments
+- **Anything not in English**
+
+torch-rbln specific:
+
+- **No stray dependency pin** — `constraints-build-dev.txt` and the `pyproject.toml` rebel-compiler range are not touched by a change that is about something else.
+- **No edits to generated files** — `torch_rbln/_internal/register_ops.py`, `_abi_snapshot.py`, `torch_rbln/lib/`, `torch_rbln/include/`, `torch_rbln/_C/__init__.pyi`. `git status` will not warn you; they are gitignored.
+- **No new CPU fallback case** added to make something pass, and no `TORCH_RBLN_DISABLE_FALLBACK` category changed to move a test outcome.
+- **No workaround for a rebel-compiler or librbln defect.** If there is one, it is declared in the PR body with the upstream issue, and you asked before writing it.
+- **A new `TORCH_RBLN_*` variable** is read only in `env_utils.py` (or its C++ config object) and is documented in `docs/CONFIGURATION.md`.
+- **An op registered only in C++** is listed in `_ops_with_rbln_native_kernel` in `test/filters.py`.
+- **A skill whose content you changed still matches its `description`** — the frontmatter is the trigger, so anything the description does not mention may never be loaded.
+- **New or changed tests follow `docs/TEST_GUIDE.md`** — placement, template shape, marker, and the existing fixtures and helpers rather than new ones. Re-read the relevant section against your diff; this is checked in review.
+- **New test files** carry `# Owner(s): ["module: PrivateUse1"]` and the `run_tests()` main block, and are marked `test_set_ci` unless you can say why not.
+- **No widened tolerance** without a derivation, and no test made green by re-running it.
+- **Nothing on the import path uses a device** — the first allocation, `synchronize()`, or collective commits the mapping and freezes it for the process.
+- **PR body claims match the diff.** A conditional check is not described as unconditional; a derived set is not described as derived if it is hardcoded.
+- **`native_functions.yaml` and `test/ops/test_ops.py`** stay close to upstream.
+
+## 6. Report what you did not do
+
+State it explicitly, every time:
+
+- Tests you could not run, and why
+- Hardware, devices, or models you did not have
+- Assumptions you could not verify
+- Parts of the request you left out
+
+An empty list is a claim. Only write it if it is true.
+
+## 7. Write the commit and PR
+
+- You are on a feature branch off `dev`, not on `dev` or `main` itself
+- PR title in `type(scope): summary` — CI enforces it. Individual commits only need to be readable (`docs/CONTRIBUTING.md`)
+- Explain intent, not the diff. Symptom, reproducer, where to look, what you verified — the debugging path that got you there is not part of it
+- Say which layer you changed and which execution paths you exercised — eager, `torch.compile(backend="rbln")`, or both
+- Fill in **Affected Modules** and **How to Test** in the template, and link the issue
+- English

--- a/.claude/skills/writing-tests/SKILL.md
+++ b/.claude/skills/writing-tests/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: writing-tests
+description: Use when adding or modifying tests under test/ — where the file goes, the markers that decide whether it runs at all, how to assert an op reached the device rather than the host fallback, the process-state traps in this suite, and how to prove a new test fails before the fix.
+---
+
+# Writing tests in torch-rbln
+
+## 0. Read the guide first
+
+`docs/TEST_GUIDE.md` is the contract for this suite, not background reading. Before writing, read the sections that apply to what you are adding: §2 for where the file goes, §5 for the PrivateUse1 device-type framework, §6 for the templates and parametrization rules, §8 for which marker the test needs. A test that ignores it gets sent back in review even when it passes.
+
+This skill covers what goes wrong on top of that — the traps the guide does not spell out.
+
+## 1. Design before writing
+
+Answer these before writing a line. If you cannot, ask instead of guessing.
+
+1. What is the module under test for?
+2. What is its input/output contract?
+3. What failure is this test guarding against?
+4. What is the cheapest level that catches that failure? Prefer an op-level test over a model-level one.
+
+## 2. Where the file goes
+
+| Directory           | Holds                                                                   |
+| ------------------- | ----------------------------------------------------------------------- |
+| `test/rbln/`        | Backend behavior — ops, device mapping, memory, copies, `torch.compile` |
+| `test/internal/`    | Internal subsystems reached through `torch_rbln._internal`              |
+| `test/ops/`         | Upstream op-compatibility tests. Adapted from PyTorch; change minimally |
+| `test/distributed/` | ProcessGroup, TP/PP                                                     |
+| `test/models/`      | Whole-model integration; needs extra dependencies and model artifacts   |
+| `test/cpp/`         | Google Test, built by CMake                                             |
+
+Extend the nearest existing file before adding a new one. Shared helpers go in `test/utils.py` or the `conftest.py` that already exists — do not add a `helpers_*.py`.
+
+## 3. The file has a required shape
+
+```python
+# Owner(s): ["module: PrivateUse1"]
+...
+instantiate_device_type_tests(TestMyFeature, globals(), only_for="privateuse1")
+
+if __name__ == "__main__":
+    run_tests()
+```
+
+The `TESTOWNERS` and `TEST_HAS_MAIN` linters reject a Python test file missing either end. C++ tests are GTest under `test/cpp/` and none of this applies to them.
+
+**Instantiate only what has an axis.** `instantiate_device_type_tests` expands `@dtypes`, `@parametrize`, or a `device` argument, and is required for a test that uses one. Do not wrap a test that never touches a device: the call deletes the template class and rebuilds it per device type, and on a host with no NPU nothing replaces it — the file then collects zero tests, with no failure and no skip. An import guard, a subprocess check, or a contract assertion is a plain `TestCase`; follow a neighbour like `test_dummy_device.py` or `test_import_rbln_devices_seal.py`. `docs/TEST_GUIDE.md` §5 covers the mechanism.
+
+## 4. Markers decide whether the test runs at all
+
+| Marker                 | Effect                                                                  |
+| ---------------------- | ----------------------------------------------------------------------- |
+| `test_set_ci`          | Runs on every PR to `dev`. **Without it your test runs in no PR check.** |
+| *(none)*               | Release only — PRs to `main`                                            |
+| `test_set_perf`        | Manual only                                                             |
+| `test_set_experimental`| Excluded from release                                                    |
+| `single_worker`        | Runs in the serial pass, which is still xdist at `--numprocesses=1`      |
+| `no_dynamo_reset`      | Opts out of the autouse `torch._dynamo.reset()`                         |
+
+Default to `test_set_ci`. Omit it only for a test too slow for per-commit CI, and say so in the PR.
+
+Mark `single_worker` when the test mutates state shared with other tests on the same worker — device selection, an environment variable, a global cache, or a fixed port. Several dozen tests already carry it; read one near your target before deciding you do not need it.
+
+## 5. Process state leaks between tests
+
+This is where tests in this repository most often lie.
+
+- **A flag read into `static` or `@lru_cache` state latches for the whole process.** A `monkeypatch.setenv` after that first read changes nothing, and the value you did set can outlive the test on an xdist worker and silently change an unrelated later one — that is a real CI flake this suite has already paid for, and `docs/TEST_GUIDE.md` §6 records the rule: such flags are read live. Use `run_in_isolated_process` (`test/utils.py`) whenever the behavior under test depends on an env var, a singleton, or a fresh device count.
+- **The device mapping freezes on first real use.** Queries like `device_count()` only plan it; an allocation, a `synchronize()`, or a collective commits it and later edits to `RBLN_DEVICES` are ignored. So a test that uses a device changes what every later test on that worker sees, and the autouse `restore_current_device` fixture restores the selected index, not that commit.
+- **The suite force-disables the `compile_error` fallback** (`test/conftest.py`), so a compile failure raises here even though it would fall back to CPU in production. Do not re-enable it to make a test pass.
+- **A failed drain poisons the rest of the worker.** Teardown synchronizes every device after each test; if that synchronize raises, your test errors in teardown and every remaining test on that worker skips rather than run against a faulted device. So a `RuntimeError: RBLN device drain failed` plus a wall of skips points at the test that ran before them, not at them. Do not paper over it with a retry.
+
+## 6. Assertions
+
+Assertion rewriting is off (`--assert=plain` in `pyproject.toml`), so a bare `assert a == b` prints no values when it fails. Use `self.assertEqual`, `torch.testing.assert_close`, or pass a message.
+
+**To assert an op ran on the device, assert it — do not infer it from the values.** An input that is not fp16 or bf16, or whose last dimension is not a multiple of 64, takes the host path, and the result then matches the CPU reference exactly; the test passes without ever reaching the kernel. `test/rbln/test_dispatch_shim_precheck.py` is the worked example from both directions: `_C._warmcache_size()` before and after, because a CPU fallback never primes the warm cache. `_C._dispatch_fallback_by_op()` gives per-op fallback counts for the same purpose.
+
+`xfail_strict = true`: an `xfail` that starts passing fails the suite. `xfail_rebel` / `xfail_atom` (`test/utils.py`) are the strict, architecture-conditional markers; `_REBEL_XFAILS` in `test/conftest.py` applies `xfail_rebel` by test name and detects its own stale keys. A failure that is not architecture-specific does not get an xfail.
+
+## 7. Tolerances are derived, not tuned
+
+Comparing against a CPU reference, state where the tolerance comes from: the dtype's mantissa, the accumulation length, the op family. `MATMUL_TOLERANCES` in `test/rbln/test_registered_ops.py` is the worked example. Widening a tolerance until a test passes is how a real numerical regression gets committed.
+
+Exact comparison of generated token IDs is not a numerical test. At bf16, a truncated model produces near-tie logits and ordinary run-to-run nondeterminism flips the argmax, so the test fails on a healthy backend. Compare logits with a tolerance, or compare tokens with a stated allowance.
+
+If a test is flaky, find out what varies. Do not re-run it until it is green.
+
+## 8. Prove the test fails
+
+A test that passes without the change covers nothing.
+
+```bash
+git stash list                              # note what is already there
+git stash push -- <the production files you changed>
+uv run --no-sync pytest <your new test> -x   # must fail
+git stash pop                               # verify it restored what you stashed
+```
+
+Stash only the paths your change touched, and check `git stash list` before and after — the working tree here often carries unrelated edits, and losing one of those costs more than the check is worth. If the tree is dirty enough that this is risky, run the test against the parent commit in a separate worktree instead.
+
+For a C++ change the stash is not enough — rebuild after the stash, and rebuild again after the pop, or you are testing the same binary twice.
+
+Watch it fail and read the failure; a test can fail for the wrong reason. If you cannot run it, say so explicitly instead of assuming it is red.
+
+## 9. Reject these
+
+- **An assertion that a constant would also satisfy.** `assert result >= 0` on a bridged call passes whether the wrapper forwards the runtime's value or returns a hardcoded `0`. Assert the value that distinguishes them.
+- **A counter assertion whose condition the test does not pin.** Asserting that a hidden host copy happened is fine when the test forces it — `test_fallback_with_transfer` in `test/rbln/test_profiler.py` uses a non-contiguous int32 tensor, which cannot be borrowed, so the copy is a consequence of the input and the comment says so. It is wrong when the count depends on a runtime choice the test does not control: the same shape asserted on a fresh contiguous tensor turned into a CI flake once an allocation mode changed, because zero was also correct. Pin the condition, or assert the invariant instead — that every counted event is attributed.
+- **A test that covers less than the change claims.** If the PR body says a capability set is derived, the test derives it; hardcoding the two dtypes you expect proves nothing about the derivation.
+- Asserting a statically defined value against itself
+- Testing that a function was called rather than what it did
+- A negative test for logic that was removed
+- Duplicating the implementation's logic inside the test
+- Mocking a device operation that a real tensor would perform
+- A placeholder test that is skipped
+- A test diff larger than the code change it covers

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,8 @@ venv/
 .cursor/
 .DS_Store
 CLAUDE.local.md
+.claude/settings.local.json
+.claude/*.lock
 
 # Linting & static analysis
 /.lintbin/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,7 +198,7 @@ When you believe a case is a real exception — a comment no naming can replace,
 
 Explain intent; the diff already shows what changed. Claim exactly what the code does — a check that only runs under a condition is not "the index is range-checked". Fill in **Affected Modules** and **How to Test**, link the issue, and name the layer you changed.
 
-- Open PRs as drafts. A feature branch comes from `dev` and targets `dev`; `rc` goes `dev` → `main`; a hotfix comes from `main` and targets `main`. Tags are cut on `main`, and everything is squash-merged (`docs/RELEASE_PROCESS.md`).
+- A feature branch comes from `dev` and targets `dev`; `rc` goes `dev` → `main`; a hotfix comes from `main` and targets `main`. Tags are cut on `main`, and everything is squash-merged (`docs/RELEASE_PROCESS.md`).
 - **A fix for a regression the feature itself introduced belongs in the same PR.** Split it out and whichever lands first puts mainline in the regressed state.
 - **No internal names.** A working label from the conversation that produced the change — a version number, a phase, a step — means nothing later and fossilizes in the history. Name the mechanism.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,14 @@ Read `.claude/skills/adding-an-op/SKILL.md` before starting.
 - Delete removed code completely: no renamed `_var` leftovers, no dead re-exports, no `# removed`.
 - Everything in the repository is English — code, comments, log and error messages, test names, docs, commits, PR titles and bodies. Reply to the user in the language they write in.
 
+## What not to publish
+
+This repository is public. Absolute measurements stay out of it: throughput, latency, memory footprint, and accuracy from an internal run do not belong in code, comments, tests, docs, commit messages, or PR descriptions. Benchmark scripts and `test_set_perf` tests live here; their results do not.
+
+A relative change is fine. Say that something got a third faster, not what the two numbers were, and keep the raw figures to an internal channel.
+
+`docs/CONTRIBUTING.md` asks a `perf` change for "benchmarks or measurement methodology". The methodology and the harness belong in the PR; the numbers they produced do not.
+
 ## Fix the cause, keep the diff reviewable
 
 These pull against each other, and both are real.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,202 @@
+# Agent instructions for torch-rbln
+
+torch-rbln is an out-of-tree PyTorch backend (`PrivateUse1`) for Rebellions NPUs. C++ lives in `aten/`, `c10/`, and `torch_rbln/csrc/`; Python in `torch_rbln/`; tests in `test/`.
+
+These documents own their subjects. Read them rather than duplicating them here:
+
+| Subject                                                    | Document                     |
+| ---------------------------------------------------------- | ---------------------------- |
+| Test infrastructure, markers, fixtures, templates          | `docs/TEST_GUIDE.md`         |
+| Environment variables and runtime options                  | `docs/CONFIGURATION.md`      |
+| Lint setup and commands                                    | `docs/LINTING.md`            |
+| PR process, issue labels, merge policy                     | `docs/CONTRIBUTING.md`       |
+| CI and release lanes                                       | `docs/WORKFLOWS.md`          |
+| PyTorch pin, vendored upstream files, rebel-compiler bumps | `docs/THIRD_PARTY_UPDATE.md` |
+
+## Terms
+
+The codebase already has a word for each of these. Use it, and do not reach for a synonym because the sentence reads better.
+
+- **eager mode** — op-by-op dispatch through the generated shim. Each op is compiled and cached individually, so "eager" does not mean the compiler is uninvolved.
+- **graph mode** — the user's `torch.compile(backend="rbln")` over a whole FX graph.
+- **deploy mode** — `TORCH_RBLN_DEPLOY=ON`, which skips the host-side NaN/Inf scan. It is not a third execution path.
+- **logical device** — what `rbln:N` and `device_count()` refer to: one or more **physical NPUs** grouped by `RBLN_NPUS_PER_DEVICE` or `RBLN_DEVICE_MAP`. Always say which of the two you mean.
+- **fallback** — two separate controls. `TORCH_RBLN_DISABLE_FALLBACK` covers unsupported ops, compile errors, and non-blocking copies; `TORCH_RBLN_DEV_DISABLE_OP_CPU_FALLBACK` covers the per-dispatch checks (`dtype`, `scalar`, `storage_offset`, `nan_inf`, …). Name the one you mean.
+- **shim** — the generated Python wrapper in `register_ops.py`. **kernel** — a hand-written implementation, C++ or Python. Not interchangeable.
+- **suite** — a `run_tests.py` tree: `core`, `distributed`, `models`, `ops`. **lane** — what a marker selects: the CI lane, the release lane, the perf lane.
+
+## Which file do I edit
+
+Two questions come before any change, and getting either wrong wastes the whole session.
+
+**Is this even our layer?** Three layers own this stack; only two are in this repository.
+
+1. **torch-rbln Python** (`torch_rbln/`) — shims, device and memory APIs, `torch.compile` patches
+2. **torch-rbln C++** (`aten/`, `c10/`, `torch_rbln/csrc/`) — allocator, guard, copy, kernels, process group
+3. **rebel-compiler / librbln** — the compiler and runtime; a separate repository. `pyproject.toml` carries the version range, `constraints-build-dev.txt` the exact dev build pin.
+
+- Say which layer the defect is in, and what the minimal set of changes is, before writing any of them.
+- **Do not work around a layer-3 defect in layer 1 or 2.** A guard that makes a compiler or runtime bug invisible hides it from the team that can fix it and stays here permanently.
+- When it is layer 3: reduce it to a minimal reproducer, report it to the rebel-compiler team, and say so in the PR. If the failure is architecture-specific, `xfail_rebel` / `xfail_atom` (`test/utils.py`) mark it strictly, so it fails again once the bug is fixed. A failure that is not architecture-specific does not get parked — it stays visible.
+- **The boundary runs both ways — before building machinery here, check what the pinned runtime already does.**
+- **Bump the pin when your change needs it; leave it alone when only your experiment did.** Raising `constraints-build-dev.txt` in the PR that requires a newer compiler is normal here — say in the body what the change needs from it. What does not belong is a pin you moved while trying versions, or a local-wheel path some tool wrote into `pyproject.toml`. A scheduled workflow also proposes bumps on its own, so an unexplained one reads as noise. Moving the *range* in `pyproject.toml` is a separate procedure — `docs/THIRD_PARTY_UPDATE.md` owns it and the two places that stay aligned.
+- To settle which layer it is, install a different `rebel-compiler` version and rebuild. Building against a compiler source checkout is heavier and mutates this tree — ask first, and use a worktree you can throw away.
+
+**Is this file generated?** These are build outputs; the edit disappears on the next build.
+
+| File                                                                             | Real source                                                    |
+| --------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| `torch_rbln/_internal/register_ops.py`                                           | `aten/src/ATen/native/native_functions.yaml`, `tools/codegen/` |
+| `torch_rbln/_internal/_abi_snapshot.py`                                          | `cmake/abi_snapshot.py.in`, configured at build time           |
+| `torch_rbln/lib/`, `torch_rbln/include/`, `torch_rbln/_C/__init__.pyi`, `build/` | `cmake --install`                                              |
+
+`register_ops.py` is the one that catches people: every eager shim (`add_rbln`, `mul_rbln`, …), 1400 lines of ordinary-looking Python, gitignored. Fixing an op there works until the next build.
+
+`native_functions.yaml`, `tags.yaml`, and `test/ops/test_ops.py` are adapted from upstream PyTorch; the two YAML files name the upstream tag they came from on their first line. Keep the diff no larger than the change requires, and keep that line true when you re-sync one. A torch version bump moves three things together — `[project].dependencies`, `[build-system].requires`, and these files re-synced from the new tag (`docs/THIRD_PARTY_UPDATE.md`). `tools/linter` is maintained in-tree and refreshed by `sync-linter.sh`; do not copy it from upstream.
+
+## Commands
+
+Run everything through `uv`. Never use the system `python3` or a bare `pip`.
+
+```bash
+uv run --no-sync pytest test/rbln/test_tensor_copy.py -x   # narrowest target covering the change
+uv run --no-sync python test/run_tests.py --suite=core     # a whole suite, the way CI runs it
+uv run --no-sync lintrunner -m origin/dev -a               # lint and auto-fix what you changed
+uv pip install -e . --no-build-isolation                   # rebuild — see below
+```
+
+**A change under `aten/`, `c10/`, `torch_rbln/csrc/`, `CMakeLists.txt`, or `native_functions.yaml` does not reach your interpreter until you rebuild.** The build needs `rebel-compiler` present at the pin, installed with `uv pip install --constraint constraints-build-dev.txt rebel-compiler`. A link error naming `rbln::` symbols means the installed one is older than the pin — install the pinned version rather than changing code to match what you have. An `AttributeError` for a missing `torch_rbln._C` attribute means the opposite: the built extension is older than the Python tree, which is what a branch switch leaves behind. An `RBLN ABI mismatch` is a third shape — the snapshot this build recorded and the loaded `librbln.so` disagree.
+
+Skip the rebuild and pytest loads the previously built `torch_rbln/_C` and `torch_rbln/lib/*.so`: the run tests the old code and its result means nothing. A bare `ninja -C build` stages nothing into `torch_rbln/`; the install step does. The build needs GCC 13 or newer (`CC=gcc-13 CXX=g++-13`), enforced by `cmake/FindTorch.cmake`.
+
+Verify the rebuild actually took before trusting any result. An install can skip the build step and leave the previous binary in place while reporting success; grepping the built artifact for a string only your change introduces is the cheap check.
+
+`lintrunner -m <base>` lints against a merge base; use the branch your PR targets, which CI does too (`docs/LINTING.md` shows `origin/main`, correct only for a release PR). It covers every file the PR touches, not the ones you edited this session — that difference is what gets a PR rejected by CI for a file you never opened.
+
+## Evidence
+
+- **Read the source, do not infer it.** rebel-compiler ships its headers and `librbln.so` in the wheel; PyTorch is in the venv. An answer from an issue description, a changelog, or a plausible reading of a symptom is a guess; do not state it as fact.
+- **Separate the symptom from the cause.** A narrowed symptom is not a cause. If the cause is not identified, say so.
+- **Mark what you verified and what you inferred**, in the same message.
+- **Reproduce before you fix**, and say so if you could not. The minimal reproducer is a deliverable: a standalone script another team can run without installing a model or a suite.
+- **State what you could not do** — tests you could not run, hardware you did not have, assumptions you could not check. An empty list is a claim; write it only if it is true.
+- **If you cannot finish, do not produce a plausible partial result.** Stop and say what blocked you.
+- **Tests that break after your change are your regressions.** Debug them; do not stash or revert to check whether they also fail on `dev`.
+
+## Measuring
+
+- **Print the base before every measurement**: the commit of torch-rbln, of rebel-compiler, and of any consumer in the loop, plus the venv and the env vars that matter. A number without its base compares to nothing later.
+- **Name a target by commit plus working-tree state**, never by branch. "dev" does not say which uncommitted changes were in the tree.
+- **Fix the environment and change nothing but the thing under test.** Thread counts, allocator mode, and log level move the mean more than most changes do; log level is not cosmetic here. Change the harness and the comparison resets.
+- **A debug-only flag is not the production baseline.** A result measured with one set does not describe what ships.
+
+## Before saying a change is done
+
+Do these without being asked. `.claude/skills/finishing-a-change/SKILL.md` is the full list.
+
+1. Rebuild, if the change touched the native side.
+2. `lintrunner -a`, and read the output.
+3. Run the tests covering the change; report the command and its result. "Should pass" is not a result.
+4. **State the regression and performance impact** — what else takes this path, and what the change costs on it. If you did not measure, say you did not measure.
+5. Read your own diff for verbose comments, leftover scratch files, and code with no caller.
+6. Write the PR body to claim exactly what the code does, and no more.
+
+## Operators
+
+Three registration paths, and the choice decides what else must change.
+
+- **YAML path** — a `func:` entry with a `PrivateUse1: <name>_rbln` dispatch in `native_functions.yaml`; codegen emits the shim. This is the default.
+- **Hand-written Python kernel** — the same YAML entry plus the `use_custom_kernel_rbln` tag; codegen emits only the registration and you supply the kernel.
+- **C++ path** — a kernel in `aten/src/ATen/native/rbln/` registered with `m.impl(...)` in `RBLNRegisterOps.cpp`, for ops touching storage, strides, or the allocator.
+
+An op registered only in C++ is invisible to op-test discovery: add it to `_ops_with_rbln_native_kernel` in `test/filters.py` or its OpInfo tests never run.
+
+Every op runs both eager and inside a user's graph, and must produce the same numbers on both; `test/rbln/test_graph_eager_mode.py` is the guard. Say which paths you exercised.
+
+Read `.claude/skills/adding-an-op/SKILL.md` before starting.
+
+## Patching upstream PyTorch
+
+`torch_rbln/_internal/monkey_patches.py` replaces upstream symbols at import through `apply_all_patches()`: `torch.compile`, `torch._dynamo.reset`, and — on torch below 2.13 — `GuardBuilder.id_match_unchecked` and `torch.Tensor.__repr__`. A new patch follows the existing shape; `test/rbln/test_torch_compile_patch.py` asserts it.
+
+- **Inert for everyone else.** A non-RBLN backend must reach the original untouched, the way the `torch.compile` wrapper early-returns on `is_rbln_backend`.
+- **Narrow the global surface.** The `__repr__` patch is scoped by a thread-local to guard build only, so a user's `repr(tensor)` is unchanged. Do not replace a global unconditionally.
+- **Idempotent, with the original saved.** Guard re-application with the module-level flag and keep the original in a module global.
+- **Every patch is undone by `remove_all_patches()`**, including the caches it warmed — `clear_rbln_compile_cache()` and `warm_cache.clear()` are part of the teardown.
+- **A backport of an upstream fix is version-gated and cites the issue**, so it becomes a no-op once upstream lands it — see the `torch.__version__ >= (2, 13)` early return.
+- Registration is lazy: the dynamo backend registers on the first `torch.compile` call, not at import. Keep it that way — see the import rule below.
+
+## Contracts that bite
+
+- **Nothing on the import path may claim a device.** `import torch_rbln` runs at `import torch` through the backend autoload entry point. The device mapping is *planned* by queries like `device_count()`, which claim nothing, and *committed* — frozen for the process — by the first real use: an allocation, a `synchronize()`, a collective. Selecting a device does not commit (`docs/CONFIGURATION.md`). A launcher may therefore set `RBLN_DEVICES` after import, including inside a forked worker, as long as nothing has used a device yet; an arch query at import takes that away. `test/rbln/test_import_rbln_devices_seal.py` is the guard.
+- **The rebel ABI handshake decides whether this build and the loaded runtime may talk.** `rebel-compiler` declares the interface it implements and the oldest consumer it accepts; the build freezes the first of those into `_abi_snapshot.py`, and `import torch_rbln` checks that the loaded `librbln.so` still accepts that snapshot before any other rebel call. We keep no number of our own — there is nothing to bump, and the snapshot is generated, so a mismatch is a build or an install to correct, never a file to edit. It moves only on a rebuild, so a stale build gives a stale verdict, and a wheel already shipped cannot follow a later raise of the minimum. `TORCH_RBLN_SKIP_ABI_CHECK` hides the diagnosis, not the incompatibility: use it to unblock a machine while a matching wheel builds, never to make an import go green. `docs/CONFIGURATION.md` has the contract.
+- **Upstream's own test is the contract**, not what the hardware happens to do. For `PrivateUse1`, `torch.accelerator`, AMP, the profiler, and pinned memory, read the corresponding test in the PyTorch repository at the pinned version and satisfy what it asserts. **When the contract is ambiguous, follow CUDA** — that is what vLLM, lmcache, and transformers are written against.
+- **CPU fallback is a product feature, not a way to make code work.** Do not add a case to `is_cpu_fallback_cases()`, route an op to `fallback_rbln`, or change a `TORCH_RBLN_DISABLE_FALLBACK` category to move a test outcome — that turns a correctness bug into a silent performance cliff. The suite force-disables `compile_error` (`test/conftest.py`) so compile failures surface.
+- **A run where a fallback fired is a failed run.** A CPU fallback compares CPU against CPU; an export that fell back to `jit.trace` gives plausible output from an untested path. Grep the log before calling a run successful, and keep the fallback disabled in minimal reproducers — drop it and the bug disappears.
+- **A new variable of ours takes the `TORCH_RBLN_` prefix.** The bare `RBLN_*` namespace is shared: `RBLN_DEVICES` and its `RBLN_VISIBLE_DEVICES` alias belong to the runtime, `RBLN_DUMMY_DEVICE` is validated by it, and the ids in `RBLN_DEVICE_MAP` index the pool `RBLN_DEVICES` leaves visible rather than system ids. Do not add to that namespace or reinterpret what is in it.
+- **A new `TORCH_RBLN_*` variable** is read in one place — `env_utils.py`, or its C++ config object — and documented in `docs/CONFIGURATION.md`. Read it live, the way the per-dispatch flags in `DispatchShim.cpp` do. A value cached in `static` or `@lru_cache` state latches for the whole process, so a test that sets it later changes nothing and what it did set leaks into later tests on that worker — this has already cost a CI flake.
+
+## Production code
+
+- **No `print`.** Use the logging facility.
+- **No test-only entry points.** A hook or knob that exists so a test can reach internal state does not belong in shipped code. Restructure the test, or the code.
+- Code either succeeds or fails with a clear error. No `except Exception` or bare `except` to get past a problem; no `except: pass`; no unrequested fallback, default, or silent recovery.
+- Do not route a case that cannot happen into an `else`. Use `raise`, `assert`, or `RBLN_CHECK`.
+- Delete removed code completely: no renamed `_var` leftovers, no dead re-exports, no `# removed`.
+- Everything in the repository is English — code, comments, log and error messages, test names, docs, commits, PR titles and bodies. Reply to the user in the language they write in.
+
+## Fix the cause, keep the diff reviewable
+
+These pull against each other, and both are real.
+
+- **Fix the cause, not the report.** A change that blocks the symptom and leaves the mechanism comes back under another name. When a class of bug repeats, revisit the earlier fixes rather than adding one more.
+- **A diff nobody can review does not land.** When the patch keeps growing, stop and re-check the approach — that usually means the fix is in the wrong place, not that the problem is large.
+- **Do not land code with no caller.** Machinery belongs in the change that consumes it and measures it. Check who actually calls the thing before building for the general case.
+- **One tuning constant per trade-off**, and the PR carries the measurement that picks its value.
+- Reuse before you write: no new file when the code fits in one that exists, no helper called once, no abstraction for a single use. Delete the scratch files you made while iterating.
+
+## Prose
+
+Everything written in words — a comment, a docstring, a doc page, a PR body, a bug report — earns its length or gets cut. A sentence stays if it changes what the reader decides; the rest costs them more than it saved you.
+
+- Do not restate the code, describe your changes, address the reader, or comment code you did not otherwise change. When a comment narrates the next line, delete it and let the name carry the meaning. Assume the reader knows PyTorch dispatch and RBLN hardware.
+- Keep what a reader needs in order to decide something: a runtime contract nothing validates, why a retry or fallback is sound, which direction a heuristic is conservative in, and why a threshold sits where it does — the reason for the value, not the arithmetic that produces it. These may be long; explain them properly. `torch_rbln/_internal/compile_cache.py` and the fixtures in `test/conftest.py` are the level.
+- Your change makes comments stale. Re-read every comment around the lines you touched.
+- A bug report or an issue is four things: the symptom with numbers, the reproducer, where to look, and what you verified. The triggers you tried, the workarounds that failed, why nobody caught it earlier, and mechanisms you have not confirmed stay in your own notes.
+- Do not flatten a corner case into a tidy rule. An honest boundary is worth more than "X always fails", because the boundary is what someone acts on.
+
+## Tests
+
+Read `docs/TEST_GUIDE.md` before adding a test — it is the contract for this suite, and review checks against it. `.claude/skills/writing-tests/SKILL.md` covers what goes wrong on top of it. The rules broken most often:
+
+- A test must fail without the change it covers. Verify that; do not assume it.
+- **A test with no `@pytest.mark.test_set_ci` does not run on a PR to `dev`.** It runs only in the release lane, on PRs to `main`. Mark `single_worker` when the test mutates device or process-global state.
+- Assertion rewriting is off (`--assert=plain`), so a bare `assert a == b` prints no values.
+- Do not re-run a flaky test until it goes green, and do not loosen a tolerance to make one pass.
+- Do not assert an optimization the runtime is free to change, or write an assertion a hardcoded constant would also satisfy.
+- If the test diff dwarfs the code change, cut scope.
+
+## When a rule is in the way
+
+A deliberate deferral from earlier work is a decision, not an oversight. A test behind an `importorskip`, a dependency left uninstalled, a check postponed to CI — before you install it, run it, or "unblock" it, surface that decision and ask whether it still holds.
+
+Not all of these carry the same weight. The rules about safety and correctness — do not edit a generated file, do not work around a layer-3 defect, do not silence a fallback, do not push without asking — are absolute. The rest are what a reviewer will raise: a single-use helper, a test diff larger than the change, a comment that restates the code. Treat those as the default and say why when you depart from one.
+
+When you believe a case is a real exception — a comment no naming can replace, a workaround whose root fix is out of scope, an edit that has to touch a generated file — stop and ask before writing the code. Do not decide it alone, and do not work around it quietly.
+
+## Commits and PRs
+
+`type(scope): summary`, matching the existing history — `fix(profiler): register the kineto bridge unconditionally so import doesn't seal RBLN_DEVICES`.
+
+Explain intent; the diff already shows what changed. Claim exactly what the code does — a check that only runs under a condition is not "the index is range-checked". Fill in **Affected Modules** and **How to Test**, link the issue, and name the layer you changed.
+
+- Open PRs as drafts. A feature branch comes from `dev` and targets `dev`; `rc` goes `dev` → `main`; a hotfix comes from `main` and targets `main`. Tags are cut on `main`, and everything is squash-merged (`docs/RELEASE_PROCESS.md`).
+- **A fix for a regression the feature itself introduced belongs in the same PR.** Split it out and whichever lands first puts mainline in the regressed state.
+- **No internal names.** A working label from the conversation that produced the change — a version number, a phase, a step — means nothing later and fossilizes in the history. Name the mechanism.
+
+## Skills
+
+- Adding or changing an operator: `.claude/skills/adding-an-op/SKILL.md`
+- Adding or changing tests: `.claude/skills/writing-tests/SKILL.md`
+- Investigating a bug or a test failure: `.claude/skills/debugging/SKILL.md`
+- Before claiming a change is done: `.claude/skills/finishing-a-change/SKILL.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+Read `AGENTS.md`.

--- a/docs/EXPLAIN.md
+++ b/docs/EXPLAIN.md
@@ -47,7 +47,7 @@ matches `torch.profiler.profile`'s parameter name; the older `trace=` still work
 
 ## 4. Reading the report
 
-A real report (an integer-metadata region) annotated line by line:
+An example report (an integer-metadata region) annotated line by line:
 
 ```
 [overhead: 2 signals]  RBLN EXPLAIN   (region wall 66.430ms | device mem 128.00 MB peak, reserved)   (1)
@@ -92,7 +92,7 @@ dispatch/cpu_fallback  2,000       --  try: graph mode, or a supported dtype
 
 The example above is one shape. Below is the range you'll actually see, from cleanest to richest. Skim them once — recognizing the *shape* of a report is most of reading it.
 
-**(G1) Clean.** Nothing hidden happened. The report names *what it checked* (so `[clean]` is trustworthy, not silent) and reminds you clean ≠ fast. (Note the 5.6 s region wall: that is real decode time. `[clean]` means "no hidden host overhead" — `explain` says nothing about device-compute time.)
+**(G1) Clean.** Nothing hidden happened. The report names *what it checked* (so `[clean]` is trustworthy, not silent) and reminds you clean ≠ fast. (Note the large region wall: `[clean]` means "no hidden host overhead" — `explain` says nothing about device-compute time.)
 
 ```
 [clean]  RBLN EXPLAIN   (region wall 5.620s | device mem 2.46 GB peak, reserved)
@@ -142,7 +142,7 @@ runtime/v2v_slow      1    0 B  real d2h DMA (costly)
 
 > G2 vs G3 is the single most important distinction: a `host_bounce`/`v2v_slow` count is a *copy-path* count (blind to residency); the `>>` physical d2h line is the real-transfer line for the copy. `0` = served on host (cheap); `>0` = real crossing (the thing to fix). (It counts **synchronous / host-served** transfers; a deliberate `non_blocking=True` copy on **pinned** host memory takes the async DMA path and is intentionally not itemized — see the note in §6.)
 
-**(G4) A real vLLM decode step (device-tensor mode) — the capstone.** This is a 400-step steady-decode window of a Llama-1B run with `VLLM_RBLN_USE_DEVICE_TENSOR=1`, captured with `with_stack=True`. It shows nearly every signal at once: the attention-metadata integer math falling back (`sub`/`mul`/`clamp`, `dtype-not-fp16`), the `positions[idx]` gather going host-slow (`v2v_slow` + the `d2d_copy` bounce), all **host-served** (`physical d2h: 0`), under a worker pinned to one core (oversubscription), with the rebel-runtime share and the exact source lines:
+**(G4) A decode step in device-tensor mode — the capstone.** Captured with `with_stack=True`, it shows nearly every signal at once: the attention-metadata integer math falling back (`sub`/`mul`/`clamp`, `dtype-not-fp16`), the `positions[idx]` gather going host-slow (`v2v_slow` + the `d2d_copy` bounce), all **host-served** (`physical d2h: 0`), under a worker pinned to one core (oversubscription), with the rebel-runtime share and the exact source lines:
 
 ```
 [overhead: 3 signals]  RBLN EXPLAIN   (region wall 5.791s | device mem 5.06 GB peak, reserved)


### PR DESCRIPTION
## Summary of Changes

Nothing in the repository said which conventions a change has to follow, so every coding agent guessed and reviewers wrote the same comments by hand. The shapes that came back were consistent: verbose comments, an abstraction for one call site, a workaround where the cause was reachable, and tests that pass whether the code is right or wrong.

`AGENTS.md` holds the rules that apply to any change; `CLAUDE.md` is a one-line pointer to it. The steps that only matter at one moment live in `.claude/skills/` so they stay out of the always-loaded file: `adding-an-op`, `writing-tests`, `debugging`, `finishing-a-change`.

Most of the content is repository facts an agent cannot infer and reviewers have had to repeat:

- A change under `aten/`, `c10/`, `torch_rbln/csrc/`, or `tools/codegen/` is not in the interpreter until a rebuild — every test result before that describes the previous build.
- `torch_rbln/_internal/register_ops.py` is generated and gitignored, so fixing an op there works until someone builds.
- `rebel-compiler` is a layer this repository does not own. A guard that hides a compiler defect hides it from the team that can fix it.
- Matching numbers do not show that an op ran on the device: an unaligned or fp32 input takes the host path and then agrees with CPU exactly.
- An op registered only in C++ is invisible to op-test discovery unless it is listed in `test/filters.py`.

Every rule is written so a reviewer can point at it and say yes or no, and the sections that pull against each other — fix the cause, keep the diff reviewable — say so rather than pretending they do not.

---

## Related Issues / Tickets

* Related to #

---

## Type of Change

- [x] `docs` — Documentation

---

## Affected Modules

- [x] Docs

---

## How to Test

1. `uv run --no-sync lintrunner -m origin/dev`
2. Spot-check the facts against their sources: `test/conftest.py` for the fixtures and markers, `tools/codegen/` for what the build generates, `torch_rbln/csrc/rbln/DispatchShim.h` for the shim contract, `docs/CONFIGURATION.md` for the ABI handshake.

---

## Checklist

* [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
* [ ] This PR is linked to a corresponding issue
* [x] The test method is described, and the expected result is clearly stated
* [x] Relevant documentation has been updated (if applicable)

---

## Notes

Docs only; no production code and no test changes.

`.gitignore` also excludes the per-machine agent settings that sit beside the skills, so only the shared files are tracked.
