### PR TITLE
test(profiler): xfail the kineto alignment checks where the profiler runtime faults on REBEL

### DIFF
--- a/test/rbln/test_kineto_region_device_alignment.py
+++ b/test/rbln/test_kineto_region_device_alignment.py
@@ -45,7 +45,7 @@ from torch.profiler import profile, ProfilerActivity
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 import torch_rbln  # noqa: F401  -- registers the rbln device + the kineto bridge
-from test.utils import is_atom_device
+from test.utils import is_atom_device, is_rebel_device
 
 
 DEVICE = torch.device("rbln:0")
@@ -103,6 +103,15 @@ def async_dispatch(monkeypatch):
 
 @pytest.mark.test_set_ci
 @pytest.mark.single_worker
+# Not xfail_rebel(): that helper is strict, and the fault is host-dependent, so a REBEL host
+# that does create the runtime must not fail the job on XPASS. `-rEfX` still reports the XPASS,
+# which is the signal to drop this marker.
+@pytest.mark.xfail(
+    condition=is_rebel_device(),
+    reason="create_runtime(activate_profiler=True) faults on the REBEL CI hosts "
+    "(Create query pool / System Passes); re-enable once the runtime carries the fix",
+    strict=False,
+)
 @pytest.mark.skipif(
     is_atom_device(),
     reason="rbln kineto export is REBEL-only; rbln_kineto_is_active() reports inactive on ATOM",


### PR DESCRIPTION
## Summary of Changes

`TestKinetoRegionDeviceAlignment` (4 tests) fails on the REBEL CI hosts and is the only
red in the `pytest - core` job. The failure is not in what the tests assert — it is raised
out of rebel-compiler while the profiler-enabled runtime is created, so the checks never
see a trace:

```
File ".../rebel/core/torch_compile.py", line 550, in rbln_backend
  sync_runtime = compiled_model.create_runtime(...)
File ".../rebel/compiled_model.py", line 180, in create_runtime
  rt_handle = executor.create_sync_runtime(context, timeout, activate_profiler, process_group)
RuntimeError: Failed at Create query pool, SetPrimaryPoolConfig. node_idx=0, chiplet_id=3, cs_cmd_capa=11
```

This parks the class behind a `condition=is_rebel_device()` xfail so the lane goes green
while the runtime side is addressed. ATOM behaviour is untouched: the existing
`skipif(is_atom_device())` still wins there.

The marker is **non-strict**, which departs from the `xfail_rebel` / `xfail_atom` default
this repository uses for architecture-specific failures. The fault is host-dependent
rather than uniform across REBEL, so a strict marker would fail the job on a host that
does create the runtime. `addopts` carries `-rEfX`, so such a host still prints
`XPASSED test/rbln/test_kineto_region_device_alignment.py::...` — that line is the signal
to drop the marker and re-enable the checks.

---

## Related Issues / Tickets

The runtime-side defect is tracked outside this repository; no torch-rbln issue is opened
for the marker itself.

---

## Type of Change

- [x] `other` — test marker only; parks a known runtime failure

---

## Affected Modules

- [x] `torch.compile`  <!-- test-only: test/rbln/test_kineto_region_device_alignment.py -->

---

## How to Test

1. `uv run --no-sync pytest test/rbln/test_kineto_region_device_alignment.py -rEfXs`
   - On ATOM: `4 skipped`, unchanged reason (`rbln kineto export is REBEL-only`).
   - On a REBEL host that faults: `4 xfailed` instead of `4 failed`.
   - On a REBEL host that does not fault: `4 xpassed`, printed as `XPASSED` lines, job stays green.
2. `uv run --no-sync pytest test/rbln -m 'test_set_ci and single_worker' --collect-only -q`
   — still `19/4253 tests collected`, the same count the failing job selected.

---
