### PR TITLE
docs(streams): state that events cannot be shared across processes

### DIFF
--- a/torch_rbln/device/streams.py
+++ b/torch_rbln/device/streams.py
@@ -5,8 +5,9 @@ implementation, so the generic ``torch.Stream`` / ``torch.Event`` already work w
 ``device="rbln"``; this module adds the ``torch.cuda``-style surface on top.
 
 Not supported: event timing (:meth:`Event.elapsed_time` raises), stream priorities
-(accepted but ignored), :meth:`torch.Stream.native_handle`, and native cross-device
-event waits (they degrade to a host-side synchronize).
+(accepted but ignored), :meth:`torch.Stream.native_handle`, native cross-device event
+waits (they degrade to a host-side synchronize), and cross-process event sharing
+(:meth:`Event.ipc_handle` / :meth:`Event.from_ipc_handle` raise).
 """
 
 from typing import Any, Optional  # noqa: UP035
@@ -78,8 +79,16 @@ class Stream(torch.Stream):
 
 class Event(torch.Event):
     r"""An RBLN event: a recordable marker in a stream for cross-stream ordering and
-    completion queries. Mirrors :class:`torch.cuda.Event`. ``enable_timing`` is
-    accepted for API parity, but :meth:`elapsed_time` is unsupported.
+    completion queries. Mirrors :class:`torch.cuda.Event`. ``enable_timing``,
+    ``blocking`` and ``interprocess`` are accepted for API parity and ignored, and
+    :meth:`elapsed_time` is unsupported.
+
+    Cross-process event sharing is not supported: :meth:`ipc_handle` and
+    :meth:`from_ipc_handle` are inherited from :class:`torch.Event` and raise
+    ``NotImplementedError: torch.Event ipc is not supported yet``, so
+    ``interprocess=True`` grants no capability. Both attributes are present, so a
+    capability probe that only looks them up succeeds and the failure surfaces at the
+    call.
     """
 
     def __new__(  # noqa: PYI034


### PR DESCRIPTION
## Summary of Changes

Nothing said that `torch.rbln.Event` accepts `interprocess=True` and drops it. The one
thing that flag is for — `ipc_handle()` / `from_ipc_handle()` — is inherited from
`torch.Event`, so both are **present as attributes** and raise only once called:

```
NotImplementedError: torch.Event ipc is not supported yet, please open an issue if you need this!
```

The message names `torch.Event` rather than RBLN, and points its "open an issue" at
PyTorch, so searching for it does not land anywhere useful.

## Why now

LMCache's multiprocess KV transfer detects the capability exactly that way
(rebellions-sw/torch-rbln-internal#55):

| Check | Result |
| --- | --- |
| `hasattr(torch_dev, "Event")` | passes |
| constructor signature exposes `interprocess` (`inspect.signature`) | passes |
| `hasattr(torch_dev.Event, "from_ipc_handle")` | passes (inherited) |
| calling `event.ipc_handle()` | `NotImplementedError` |

All three gates pass and the failure surfaces at transfer time instead. Before the
stream and event API landed, the first gate failed cleanly.

## Changes

- Add cross-process event sharing to the module docstring's "Not supported" list.
- Add a paragraph to `Event`. Its opening sentence named only `enable_timing`, so
  `blocking` and `interprocess` are now named alongside it — neither was documented
  anywhere before.

The same wording goes into the SDK doc mirror (rebellions-sw/rbln_sdk_doc#713).

## Verification

- `ruff format --check` and `ruff check` (0.16.0) pass.
- Docstrings parse, checked through `ast`.

Documentation only; no behaviour change.

## Follow-up (out of scope here)

The real fix is to **raise at construction** when `interprocess=True`, rather than
accepting and ignoring it, so consumers can fail fast again. Worth deciding separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
