### PR TITLE
feat(memory): expose device-memory binding and huge host buffers

### DIFF
--- a/c10/rbln/RBLNFunctions.cpp
+++ b/c10/rbln/RBLNFunctions.cpp
@@ -614,6 +614,10 @@ void free_nothrow(void* data) noexcept {
 void bind_device_memory(void* rbln_data, size_t nbytes) {
   RBLN_CHECK(rbln_data != nullptr, "bind_device_memory: rbln_data is nullptr");
   RBLN_CHECK(nbytes > 0, "bind_device_memory: nbytes must be positive, but got {}", nbytes);
+  // Unlike the other vmem-configuring leaves here, this one is reachable from a public Python
+  // entry point at any time, teardown included, where the raw rbln_* call would SEGFAULT
+  // rather than raise.
+  require_runtime("bind device memory");
   const auto vaddr = reinterpret_cast<uint64_t>(rbln_data);
   RBLN_LOG_DEBUG("bind_device_memory: vaddr={:#x} nbytes={}", vaddr, nbytes);
   RBLN_CHECK(

--- a/c10/rbln/RBLNFunctions.cpp
+++ b/c10/rbln/RBLNFunctions.cpp
@@ -614,9 +614,9 @@ void free_nothrow(void* data) noexcept {
 void bind_device_memory(void* rbln_data, size_t nbytes) {
   RBLN_CHECK(rbln_data != nullptr, "bind_device_memory: rbln_data is nullptr");
   RBLN_CHECK(nbytes > 0, "bind_device_memory: nbytes must be positive, but got {}", nbytes);
-  // Unlike the other vmem-configuring leaves here, this one is reachable from a public Python
-  // entry point at any time, teardown included, where the raw rbln_* call would SEGFAULT
-  // rather than raise.
+  // Reachable from a public Python entry point at any time, teardown included, where the raw
+  // rbln_* call would SEGFAULT rather than raise. The vmem-configuring leaves that only run
+  // downstream of an allocation do not repeat the check: malloc already made it.
   require_runtime("bind device memory");
   const auto vaddr = reinterpret_cast<uint64_t>(rbln_data);
   RBLN_LOG_DEBUG("bind_device_memory: vaddr={:#x} nbytes={}", vaddr, nbytes);
@@ -631,6 +631,9 @@ void bind_device_memory(void* rbln_data, size_t nbytes) {
 void set_device_layout_like(void* target_data, const void* ref_data) {
   RBLN_CHECK(target_data != nullptr, "set_device_layout_like: target is nullptr");
   RBLN_CHECK(ref_data != nullptr, "set_device_layout_like: ref is nullptr");
+  // Same reason as bind_device_memory: a public Python entry point, so nothing
+  // upstream has established that the runtime is loaded.
+  require_runtime("set the device layout");
   const auto target_vaddr = reinterpret_cast<uint64_t>(target_data);
   const auto ref_vaddr = reinterpret_cast<uint64_t>(ref_data);
   RBLN_LOG_DEBUG("set_device_layout_like: target={:#x} ref={:#x}", target_vaddr, ref_vaddr);

--- a/c10/rbln/RBLNFunctions.cpp
+++ b/c10/rbln/RBLNFunctions.cpp
@@ -611,6 +611,19 @@ void free_nothrow(void* data) noexcept {
   }
 }
 
+void bind_device_memory(void* rbln_data, size_t nbytes) {
+  RBLN_CHECK(rbln_data != nullptr, "bind_device_memory: rbln_data is nullptr");
+  RBLN_CHECK(nbytes > 0, "bind_device_memory: nbytes must be positive, but got {}", nbytes);
+  const auto vaddr = reinterpret_cast<uint64_t>(rbln_data);
+  RBLN_LOG_DEBUG("bind_device_memory: vaddr={:#x} nbytes={}", vaddr, nbytes);
+  RBLN_CHECK(
+      !::rbln::rbln_set_raw_memory_alloc(vaddr, static_cast<uint64_t>(nbytes)),
+      "rbln_set_raw_memory_alloc failed (vaddr={:#x}, {} bytes); the pointer may not be RBLN device memory or the "
+      "device may be out of memory",
+      vaddr,
+      nbytes);
+}
+
 void set_device_layout_like(void* target_data, const void* ref_data) {
   RBLN_CHECK(target_data != nullptr, "set_device_layout_like: target is nullptr");
   RBLN_CHECK(ref_data != nullptr, "set_device_layout_like: ref is nullptr");

--- a/c10/rbln/RBLNFunctions.h
+++ b/c10/rbln/RBLNFunctions.h
@@ -122,6 +122,26 @@ C10_RBLN_API ::rbln::MemoryInfo get_memory_info(const void* data);
 C10_RBLN_API bool is_eager_malloc();
 
 /**
+ * @brief Give the vmem region at ``rbln_data`` a flat single-node device allocation.
+ *
+ * A device allocation reserves a virtual address and materialises the physical memory
+ * behind it lazily, on first use through a torch op. A consumer that reads those physical
+ * buffers out of band -- a collective library, direct storage (NVMe) DMA -- never runs
+ * such an op, so it would find nothing there. This materialises the allocation up front.
+ *
+ * The layout is flat and 1:1, with no dtype transform, on the device's main node: the
+ * shape a consumer that treats the region as bytes expects. Use set_device_layout_like()
+ * instead when the region has to match another tensor's layout.
+ *
+ * Re-binding an already-bound region is allowed and is what the collective path does
+ * before every operation.
+ *
+ * @param rbln_data Base pointer of an RBLN allocation (not an interior/view address).
+ * @param nbytes Size of the allocation in bytes. Must be positive.
+ */
+C10_RBLN_API void bind_device_memory(void* rbln_data, size_t nbytes);
+
+/**
  * @brief Configure ``target``'s device allocation to match ``ref``'s layout and
  *        dtype, without copying data.
  *

--- a/c10/rbln/RBLNFunctions.h
+++ b/c10/rbln/RBLNFunctions.h
@@ -136,7 +136,7 @@ C10_RBLN_API bool is_eager_malloc();
  * Re-binding an already-bound region is allowed and is what the collective path does
  * before every operation.
  *
- * @param rbln_data Base pointer of an RBLN allocation (not an interior/view address).
+ * @param rbln_data Base pointer of an RBLN allocation (not an interior address).
  * @param nbytes Size of the allocation in bytes. Must be positive.
  */
 C10_RBLN_API void bind_device_memory(void* rbln_data, size_t nbytes);

--- a/test/rbln/test_set_device_layout_like.py
+++ b/test/rbln/test_set_device_layout_like.py
@@ -6,7 +6,7 @@ The op configures ``target``'s device allocation to match a device-resident
 ``ref``'s layout and dtype, without copying data, so a later ``target`` <->
 ``ref`` device-to-device copy stays on the fast path. The binding validates its
 inputs first: both must be RBLN tensors, on the same device, with the same
-dtype, and each a whole base allocation (not a view) — a dtype mismatch would
+dtype, and each covering its whole storage — a dtype mismatch would
 reinterpret ``target``'s buffer as a different dtype.
 
 Coverage: API visibility, and the rejected-input paths.
@@ -60,29 +60,29 @@ class TestSetDeviceLayoutLike:
             torch.rbln.set_device_layout_like(target, ref)
 
     def test_offset_view_target_raises(self):
-        """A storage_offset>0 view is not a whole base allocation and is rejected
-        with a clear error."""
+        """A storage_offset>0 view does not cover its storage and is rejected with
+        a clear error."""
         base = torch.empty(64, dtype=torch.float16, device=DEVICE)
         view = base[8:24]
         assert view.storage_offset() != 0
         ref = torch.empty(16, dtype=torch.float16, device=DEVICE)
-        with pytest.raises(RuntimeError, match="whole base"):
+        with pytest.raises(RuntimeError, match="whole storage"):
             torch.rbln.set_device_layout_like(view, ref)
 
     def test_narrowing_view_target_raises(self):
         """A storage_offset==0 view that doesn't span its storage (``base[:k]``)
-        is still not a whole base allocation — reject it."""
+        still does not cover it — reject it."""
         base = torch.empty(64, dtype=torch.float16, device=DEVICE)
         view = base[:16]
         assert view.storage_offset() == 0 and view.is_contiguous()
         ref = torch.empty(16, dtype=torch.float16, device=DEVICE)
-        with pytest.raises(RuntimeError, match="whole base"):
+        with pytest.raises(RuntimeError, match="whole storage"):
             torch.rbln.set_device_layout_like(view, ref)
 
     def test_view_ref_raises(self):
         target = torch.empty(16, dtype=torch.float16, device=DEVICE)
         ref_view = torch.empty(64, dtype=torch.float16, device=DEVICE)[:16]
-        with pytest.raises(RuntimeError, match="whole base"):
+        with pytest.raises(RuntimeError, match="whole storage"):
             torch.rbln.set_device_layout_like(target, ref_view)
 
 

--- a/test/rbln/test_tensor_memory.py
+++ b/test/rbln/test_tensor_memory.py
@@ -11,13 +11,16 @@ Validates that device operations produce correct results under non-trivial memor
 """
 
 import gc
+import os
 import sys
+from unittest import mock
 
 import pytest
 import torch
 from torch.testing._internal.common_device_type import dtypes, instantiate_device_type_tests
 from torch.testing._internal.common_utils import parametrize, run_tests, TestCase
 
+import torch_rbln._C
 from test.utils import run_in_isolated_process, SUPPORTED_DTYPES
 
 
@@ -203,6 +206,15 @@ class TestInputOutputTensors(TestCase):
         run_in_isolated_process(_input_output_tensor_memory_independence_worker, self.rbln_device, dtype)
 
 
+def _device_bytes() -> int:
+    """Bytes of device memory the runtime holds right now.
+
+    Process-global and recorded at every runtime buffer alloc/free, so only a delta
+    taken across the call under test says anything.
+    """
+    return torch_rbln._C._rt_prof_memory()[0]
+
+
 def _bind_after_shutdown_worker(device):
     """Assert ``bind_device_memory`` raises rather than faulting once the runtime is down.
 
@@ -230,37 +242,65 @@ class TestBindDeviceMemory(TestCase):
     a consumer that reads the physical buffers out of band and so never runs the op
     that would otherwise trigger the lazy bind.
 
-    Whether the memory really became physical is not observable from Python -- what
-    is checked here is that the call succeeds on the tensors it accepts, leaves them
-    usable, and rejects the ones whose base address it cannot bind.
+    The runtime's device-memory gauge is what makes that observable from Python; no
+    torch op stands in for it, since an op either materializes the allocation itself
+    or -- ``zero_`` -- marks it logically zero without allocating anything.
     """
 
     rbln_device = torch.device("rbln:0")
 
+    def test_bind_allocates_the_physical_memory(self):
+        # The postcondition itself. Nothing but the bind can account for the delta:
+        # the allocation is still lazy (asserted), the device and its one-time pools
+        # are already committed by the synchronize, and no op runs on ``t``.
+        nbytes = 8 << 20
+        with mock.patch.dict(os.environ):
+            os.environ.pop("TORCH_RBLN_EAGER_MALLOC", None)  # would bind at allocation
+            torch.rbln.synchronize()
+
+            before_alloc = _device_bytes()
+            t = torch.empty(nbytes, dtype=torch.uint8, device=self.rbln_device)
+            before_bind = _device_bytes()
+            torch.rbln.bind_device_memory(t)
+            after_bind = _device_bytes()
+
+        self.assertEqual(before_bind, before_alloc, "the allocation was expected to still be lazy")
+        # The runtime may bring more along -- a slab it grew to serve this -- but not less.
+        self.assertGreaterEqual(after_bind - before_bind, nbytes)
+
     def test_binds_a_whole_tensor(self):
         t = torch.empty(4096, dtype=torch.uint8, device=self.rbln_device)
         torch.rbln.bind_device_memory(t)
-        # The region must still behave like any other device tensor afterwards.
-        t.zero_()
-        self.assertEqual(t.cpu(), torch.zeros(4096, dtype=torch.uint8))
+        # The region must still behave like any other device tensor afterwards. Not
+        # ``zero_``: that marks the allocation logically zero, and the next device read
+        # then serves zeros over whatever a consumer wrote into it out of band.
+        payload = torch.arange(4096, dtype=torch.int32).to(torch.uint8)
+        t.copy_(payload)
+        self.assertEqual(t.cpu(), payload)
 
     def test_rebinding_is_allowed(self):
         # The collective path re-binds the same tensor before every operation, so a
-        # second bind must not fail.
-        t = torch.empty(4096, dtype=torch.uint8, device=self.rbln_device)
+        # second bind must not fail -- and must not allocate the region a second time.
+        nbytes = 8 << 20
+        t = torch.empty(nbytes, dtype=torch.uint8, device=self.rbln_device)
         torch.rbln.bind_device_memory(t)
+        before = _device_bytes()
         torch.rbln.bind_device_memory(t)
+        self.assertLess(_device_bytes() - before, nbytes)
 
     def test_rejects_cpu_tensor(self):
         with self.assertRaises(RuntimeError):
             torch.rbln.bind_device_memory(torch.empty(4096, dtype=torch.uint8))
 
-    def test_rejects_view(self):
-        # A view's data_ptr() is an interior address; binding it would configure the
-        # wrong region, so it is refused rather than silently mis-bound.
+    def test_rejects_interior_view(self):
+        # A slice's data_ptr() is an interior address; binding it would configure the
+        # wrong region, so it is refused rather than silently mis-bound. A view that
+        # still spans the whole storage carries the allocation's own address and size,
+        # and is accepted.
         base = torch.empty(4096, dtype=torch.uint8, device=self.rbln_device)
         with self.assertRaises(RuntimeError):
             torch.rbln.bind_device_memory(base[16:])
+        torch.rbln.bind_device_memory(base.view(64, 64))
 
     @pytest.mark.single_worker
     def test_raises_once_runtime_is_shutting_down(self):
@@ -309,8 +349,9 @@ class TestHugeHostEmpty(TestCase):
         with self.assertRaises(ValueError):
             torch.rbln.huge_host_empty(0)
 
-    def test_rejects_size_beyond_size_t(self):
-        # Past this the provider's round-up to the alignment wraps to zero, so it
+    def test_rejects_size_above_the_supported_bound(self):
+        # The bound is ours, and stricter than the fault it exists for: near the top
+        # of a uint64 the provider's round-up to the alignment wraps to zero, so it
         # allocates nothing and then prefaults the original size over it.
         for nbytes in (sys.maxsize + 1, (1 << 64) - 1):
             with self.assertRaises(ValueError):

--- a/test/rbln/test_tensor_memory.py
+++ b/test/rbln/test_tensor_memory.py
@@ -6,7 +6,11 @@ Test suite for tensor memory correctness.
 Validates that device operations produce correct results under non-trivial memory scenarios:
 - Storage aliasing: multiple tensors sharing the same underlying storage
 - Input/output memory independence: ensuring that input and output tensors do not share overlapping memory
+- Bound allocations: device buffers handed to a consumer that DMAs out of band
+- Huge host buffers: the host side of the same transfers
 """
+
+import gc
 
 import pytest
 import torch
@@ -198,8 +202,90 @@ class TestInputOutputTensors(TestCase):
         run_in_isolated_process(_input_output_tensor_memory_independence_worker, self.rbln_device, dtype)
 
 
+@pytest.mark.test_set_ci
+class TestBindDeviceMemory(TestCase):
+    """
+    ``torch.rbln.bind_device_memory`` materializes a tensor's device allocation, for
+    a consumer that reads the physical buffers out of band and so never runs the op
+    that would otherwise trigger the lazy bind.
+
+    Whether the memory really became physical is not observable from Python -- what
+    is checked here is that the call succeeds on the tensors it accepts, leaves them
+    usable, and rejects the ones whose base address it cannot bind.
+    """
+
+    rbln_device = torch.device("rbln:0")
+
+    def test_binds_a_whole_tensor(self):
+        t = torch.empty(4096, dtype=torch.uint8, device=self.rbln_device)
+        torch.rbln.bind_device_memory(t)
+        # The region must still behave like any other device tensor afterwards.
+        t.zero_()
+        self.assertEqual(t.cpu(), torch.zeros(4096, dtype=torch.uint8))
+
+    def test_rebinding_is_allowed(self):
+        # The collective path re-binds the same tensor before every operation, so a
+        # second bind must not fail.
+        t = torch.empty(4096, dtype=torch.uint8, device=self.rbln_device)
+        torch.rbln.bind_device_memory(t)
+        torch.rbln.bind_device_memory(t)
+
+    def test_rejects_cpu_tensor(self):
+        with self.assertRaises(RuntimeError):
+            torch.rbln.bind_device_memory(torch.empty(4096, dtype=torch.uint8))
+
+    def test_rejects_view(self):
+        # A view's data_ptr() is an interior address; binding it would configure the
+        # wrong region, so it is refused rather than silently mis-bound.
+        base = torch.empty(4096, dtype=torch.uint8, device=self.rbln_device)
+        with self.assertRaises(RuntimeError):
+            torch.rbln.bind_device_memory(base[16:])
+
+
+@pytest.mark.test_set_ci
+class TestHugeHostEmpty(TestCase):
+    """
+    ``torch.rbln.huge_host_empty`` returns host memory the device can DMA into
+    without staging through a bounce buffer and without faulting a page per
+    4 KiB mid-transfer.
+
+    Host-only: no device is involved, so these run without an NPU.
+    """
+
+    def test_returns_zeroed_uint8_tensor(self):
+        nbytes = 4 * 1024 * 1024
+        t = torch.rbln.huge_host_empty(nbytes)
+        self.assertEqual(t.device.type, "cpu")
+        self.assertEqual(t.dtype, torch.uint8)
+        self.assertEqual(t.numel(), nbytes)
+        # Zero-filled is part of the contract, though not a discriminating check:
+        # freshly mapped pages read as zero anyway, so this catches a wrapper that
+        # stopped zero-filling only by luck. The prefaulting it comes from is not
+        # observable from here.
+        self.assertTrue(bool((t == 0).all()))
+
+    def test_is_huge_page_aligned(self):
+        t = torch.rbln.huge_host_empty(4 * 1024 * 1024)
+        self.assertEqual(t.data_ptr() % (2 * 1024 * 1024), 0)
+
+    def test_buffer_outlives_its_python_handle(self):
+        # The tensor shares the allocation rather than copying it, so nothing but
+        # the buffer-protocol reference keeps it alive. If that reference were
+        # missing the write below would land in freed memory.
+        t = torch.rbln.huge_host_empty(4 * 1024 * 1024)
+        gc.collect()
+        t[:1024] = 7
+        self.assertTrue(bool((t[:1024] == 7).all()))
+        self.assertTrue(bool((t[1024:] == 0).all()))
+
+    def test_rejects_zero_size(self):
+        with self.assertRaises(ValueError):
+            torch.rbln.huge_host_empty(0)
+
+
 instantiate_device_type_tests(TestAliasedTensors, globals(), only_for="privateuse1")
 instantiate_device_type_tests(TestInputOutputTensors, globals(), only_for="privateuse1")
+instantiate_device_type_tests(TestBindDeviceMemory, globals(), only_for="privateuse1")
 
 
 if __name__ == "__main__":

--- a/test/rbln/test_tensor_memory.py
+++ b/test/rbln/test_tensor_memory.py
@@ -11,6 +11,7 @@ Validates that device operations produce correct results under non-trivial memor
 """
 
 import gc
+import sys
 
 import pytest
 import torch
@@ -202,6 +203,26 @@ class TestInputOutputTensors(TestCase):
         run_in_isolated_process(_input_output_tensor_memory_independence_worker, self.rbln_device, dtype)
 
 
+def _bind_after_shutdown_worker(device):
+    """Assert ``bind_device_memory`` raises rather than faulting once the runtime is down.
+
+    Runs in a spawned process: the shutdown flag is process-global and set-once, so
+    flipping it here would poison every later test on this worker.
+    """
+    # Third Party
+    import torch
+
+    import torch_rbln._C
+
+    t = torch.empty(4096, dtype=torch.uint8, device=device)
+    torch_rbln._C._set_runtime_shutting_down(True)
+    try:
+        torch.rbln.bind_device_memory(t)
+    except RuntimeError:
+        return
+    raise AssertionError("bind_device_memory did not raise with the runtime shutting down")
+
+
 @pytest.mark.test_set_ci
 class TestBindDeviceMemory(TestCase):
     """
@@ -240,6 +261,12 @@ class TestBindDeviceMemory(TestCase):
         base = torch.empty(4096, dtype=torch.uint8, device=self.rbln_device)
         with self.assertRaises(RuntimeError):
             torch.rbln.bind_device_memory(base[16:])
+
+    @pytest.mark.single_worker
+    def test_raises_once_runtime_is_shutting_down(self):
+        # The raw runtime call would fault rather than raise past teardown, and this
+        # entry point is public, so a caller can reach it there.
+        run_in_isolated_process(_bind_after_shutdown_worker, str(self.rbln_device))
 
 
 @pytest.mark.test_set_ci
@@ -281,6 +308,19 @@ class TestHugeHostEmpty(TestCase):
     def test_rejects_zero_size(self):
         with self.assertRaises(ValueError):
             torch.rbln.huge_host_empty(0)
+
+    def test_rejects_size_beyond_size_t(self):
+        # Past this the provider's round-up to the alignment wraps to zero, so it
+        # allocates nothing and then prefaults the original size over it.
+        for nbytes in (sys.maxsize + 1, (1 << 64) - 1):
+            with self.assertRaises(ValueError):
+                torch.rbln.huge_host_empty(nbytes)
+
+    def test_rejects_negative_and_non_integer(self):
+        with self.assertRaises(ValueError):
+            torch.rbln.huge_host_empty(-1)
+        with self.assertRaises(TypeError):
+            torch.rbln.huge_host_empty(4096.0)
 
 
 instantiate_device_type_tests(TestAliasedTensors, globals(), only_for="privateuse1")

--- a/torch_rbln/csrc/distributed/c10d/rbln/ProcessGroupRBLN.cpp
+++ b/torch_rbln/csrc/distributed/c10d/rbln/ProcessGroupRBLN.cpp
@@ -276,9 +276,11 @@ void ensureRcclRawMemory(const at::Tensor& tensor) {
   if (!mem_info) {
     return;
   }
-  RBLN_CHECK(
-      rbln::rbln_set_raw_memory_alloc(mem_info->key_vaddr, tensor.storage().nbytes()) == RBLNRetCode_SUCCESS,
-      "Failed to allocate RCCL raw memory");
+  // key_vaddr rather than data_ptr(): a view's data_ptr() is an interior address, and the
+  // binding covers the whole enclosing allocation.
+  c10::rbln::bind_device_memory(
+      reinterpret_cast<void*>(mem_info->key_vaddr), // NOLINT(performance-no-int-to-ptr)
+      tensor.storage().nbytes());
 }
 
 /**
@@ -333,9 +335,9 @@ void ensureContiguousRcclRawMemory(const std::vector<at::Tensor>& tensors) {
   for (const auto& tensor : tensors) {
     auto mem_info = getRcclMemoryInfo(tensor);
     TORCH_CHECK(mem_info, "ensureContiguousRcclRawMemory: tensor must be tracked by VMemoryManager");
-    TORCH_CHECK(
-        rbln::rbln_set_raw_memory_alloc(mem_info->key_vaddr, tensor.storage().nbytes()) == RBLNRetCode_SUCCESS,
-        "Failed to allocate RCCL raw memory");
+    c10::rbln::bind_device_memory(
+        reinterpret_cast<void*>(mem_info->key_vaddr), // NOLINT(performance-no-int-to-ptr)
+        tensor.storage().nbytes());
   }
 }
 

--- a/torch_rbln/csrc/rbln/Module.cpp
+++ b/torch_rbln/csrc/rbln/Module.cpp
@@ -178,13 +178,13 @@ void register_stream_api(py::module_& module) {
 // set_device_layout_like operates on a whole tensor allocation, so a view
 // (non-zero storage_offset, or not spanning its storage) is rejected up front
 // with a clear error instead of misbehaving downstream.
-void check_base_rbln_tensor(const at::Tensor& t, const char* name) {
-  TORCH_CHECK(
-      t.device().is_privateuseone(), "set_device_layout_like: ", name, " must be an RBLN tensor, got ", t.device());
+void check_base_rbln_tensor(const at::Tensor& t, const char* api, const char* name) {
+  TORCH_CHECK(t.device().is_privateuseone(), api, ": ", name, " must be an RBLN tensor, got ", t.device());
   TORCH_CHECK(
       t.storage_offset() == 0 && t.is_contiguous() &&
           static_cast<int64_t>(t.storage().nbytes()) == t.numel() * t.element_size(),
-      "set_device_layout_like: ",
+      api,
+      ": ",
       name,
       " must be a whole base (non-view) RBLN tensor");
 }
@@ -212,6 +212,16 @@ void register_internal_api(py::module_& module) {
       },
       "Internal: mark RBLN virtual memory as zero-initialized (no host alloc)");
 
+  // Materialise a tensor's device allocation up front, for a consumer that reads the physical
+  // buffers out of band. Used by torch_rbln.bind_device_memory().
+  module.def(
+      "_bind_device_memory",
+      [](const at::Tensor& tensor) {
+        check_base_rbln_tensor(tensor, "bind_device_memory", "tensor");
+        c10::rbln::bind_device_memory(tensor.data_ptr(), tensor.storage().nbytes());
+      },
+      "Internal: give an RBLN tensor a flat single-node device allocation");
+
   // Set target's device-allocation layout to match ref's, without copying data.
   // Used by torch_rbln.set_device_layout_like().
   module.def(
@@ -220,8 +230,8 @@ void register_internal_api(py::module_& module) {
         // Validate inputs up front so misuse fails with a clear error. dtype
         // must match: a mismatch would reinterpret target's buffer as a
         // different dtype.
-        check_base_rbln_tensor(target, "target");
-        check_base_rbln_tensor(ref, "ref");
+        check_base_rbln_tensor(target, "set_device_layout_like", "target");
+        check_base_rbln_tensor(ref, "set_device_layout_like", "ref");
         TORCH_CHECK(
             target.device() == ref.device(),
             "set_device_layout_like: target and ref must be on the same device (got ",

--- a/torch_rbln/csrc/rbln/Module.cpp
+++ b/torch_rbln/csrc/rbln/Module.cpp
@@ -175,9 +175,11 @@ void register_stream_api(py::module_& module) {
       "Internal: set current rbln stream; returns the previous as (stream_id, device_index, device_type)");
 }
 
-// set_device_layout_like operates on a whole tensor allocation, so a view
-// (non-zero storage_offset, or not spanning its storage) is rejected up front
-// with a clear error instead of misbehaving downstream.
+// Both callers configure the whole device allocation behind the tensor's base
+// address, so a tensor that does not cover its storage is rejected up front
+// instead of misbehaving downstream. Covering it is the whole contract: a torch
+// view that still spans its storage (base.view(...), base[:]) carries the
+// allocation's own address and size, and is accepted.
 void check_base_rbln_tensor(const at::Tensor& t, const char* api, const char* name) {
   TORCH_CHECK(t.device().is_privateuseone(), api, ": ", name, " must be an RBLN tensor, got ", t.device());
   TORCH_CHECK(
@@ -186,7 +188,7 @@ void check_base_rbln_tensor(const at::Tensor& t, const char* api, const char* na
       api,
       ": ",
       name,
-      " must be a whole base (non-view) RBLN tensor");
+      " must cover its whole storage (contiguous, storage_offset 0)");
 }
 
 /**

--- a/torch_rbln/memory.py
+++ b/torch_rbln/memory.py
@@ -14,7 +14,9 @@ import torch_rbln._C
 
 
 __all__ = [
+    "bind_device_memory",
     "empty_cache",
+    "huge_host_empty",
     "set_device_layout_like",
     "max_memory_allocated",
     "max_memory_reserved",
@@ -251,6 +253,71 @@ def reset_peak_memory_stats(device: Optional[Union[int, str, torch.device]] = No
 
 _offload_lock = threading.Lock()
 _offload_depth = 0
+
+
+def bind_device_memory(tensor: torch.Tensor) -> None:
+    """
+    Materialize ``tensor``'s device allocation instead of leaving it lazy.
+
+    A device allocation reserves a virtual address and materializes the physical
+    memory behind it on first use through a torch op. A consumer that reads those
+    physical buffers *out of band* -- a collective library, direct storage (NVMe)
+    DMA -- never runs such an op, so it would find nothing there. Call this after
+    allocating a buffer you are handing to one.
+
+    The region is laid out flat and 1:1 with no dtype transform, on the device's
+    main node -- what a consumer treating it as bytes expects. Use
+    :func:`set_device_layout_like` instead when the layout has to match another
+    tensor's. Binding an already-bound region is allowed.
+
+    Args:
+        tensor: A whole (non-view) RBLN tensor: contiguous, zero storage offset,
+            and covering its whole storage.
+
+    Raises:
+        RuntimeError: if ``tensor`` is not an RBLN tensor, is a view, or the
+            runtime rejects the allocation.
+
+    Example::
+
+        staging = torch.empty(nbytes, dtype=torch.uint8, device="rbln:0")
+        torch.rbln.bind_device_memory(staging)
+    """
+    torch_rbln._C._bind_device_memory(tensor)
+
+
+def huge_host_empty(nbytes: int) -> torch.Tensor:
+    """
+    Allocate a host buffer the device can DMA into without a staging copy.
+
+    An ordinary CPU tensor is 64 B aligned; the runtime's copy path stages any
+    host address that is not page aligned through a bounce buffer, and even an
+    aligned one pays a page fault per 4 KiB the first time the runtime resolves
+    its host addresses -- which lands in the transfer, not in setup. This returns
+    huge-page-backed memory instead, prefaulted, so neither happens.
+
+    The buffer is released when the last reference to the returned tensor (or to
+    a view of it) goes away.
+
+    Args:
+        nbytes: Size of the buffer in bytes. Must be positive.
+
+    Returns:
+        torch.Tensor: A zero-filled 1-D ``uint8`` CPU tensor of ``nbytes`` bytes,
+        sharing the buffer's memory rather than copying it.
+
+    Example::
+
+        slab = torch.rbln.huge_host_empty(1 << 30)
+        slab.view(...)  # hand to whatever consumes the host side
+    """
+    # Third Party
+    from rebel.host_memory import HugeHostBuffer
+
+    # frombuffer takes a buffer-protocol reference, which is what keeps the
+    # allocation alive for as long as the tensor is: HugeHostBuffer frees itself
+    # on collection and nothing else holds it.
+    return torch.frombuffer(HugeHostBuffer(nbytes), dtype=torch.uint8)
 
 
 @contextlib.contextmanager

--- a/torch_rbln/memory.py
+++ b/torch_rbln/memory.py
@@ -81,8 +81,8 @@ def _normalize_device(device: Optional[Union[int, str, torch.device]]) -> torch.
 def set_device_layout_like(target: torch.Tensor, ref: torch.Tensor) -> None:
     """Configure ``target``'s device-allocation layout to match ``ref`` (no copy).
 
-    Both must be RBLN tensors with the same dtype, on the same device, and each a
-    *whole base allocation* — not a view/slice.  ``ref`` must be device-resident.
+    Both must be RBLN tensors with the same dtype, on the same device, and each
+    covering its whole storage.  ``ref`` must be device-resident.
     ``target`` adopts ``ref``'s layout and dtype while keeping its own size; no
     data is transferred.  A subsequent device-to-device copy between ``target``
     and ``ref`` then stays on the fast path.
@@ -273,12 +273,14 @@ def bind_device_memory(tensor: torch.Tensor) -> None:
     tensor's. Binding an already-bound region is allowed.
 
     Args:
-        tensor: A whole (non-view) RBLN tensor: contiguous, zero storage offset,
-            and covering its whole storage.
+        tensor: An RBLN tensor covering its whole storage: contiguous, with zero
+            storage offset. A view that still spans the whole storage is fine; a
+            slice or an interior view is not, since its address is not the
+            allocation's.
 
     Raises:
-        RuntimeError: if ``tensor`` is not an RBLN tensor, is a view, or the
-            runtime rejects the allocation.
+        RuntimeError: if ``tensor`` is not an RBLN tensor, does not cover its
+            whole storage, or the runtime rejects the allocation.
 
     Example::
 
@@ -296,7 +298,9 @@ def huge_host_empty(nbytes: int) -> torch.Tensor:
     host address that is not page aligned through a bounce buffer, and even an
     aligned one pays a page fault per 4 KiB the first time the runtime resolves
     its host addresses -- which lands in the transfer, not in setup. This returns
-    huge-page-backed memory instead, prefaulted, so neither happens.
+    2 MiB-aligned memory instead, prefaulted, so neither happens. It also asks
+    for transparent huge pages, but that part is best effort: with THP disabled
+    the alignment still holds and nothing is huge-page backed.
 
     The buffer is released when the last reference to the returned tensor (or to
     a view of it) goes away.

--- a/torch_rbln/memory.py
+++ b/torch_rbln/memory.py
@@ -5,6 +5,8 @@ cache management, memory statistics, and memory monitoring capabilities.
 """
 
 import contextlib
+import operator
+import sys
 import threading
 from typing import Dict, Iterator, Optional, Union  # noqa: UP035
 
@@ -300,11 +302,16 @@ def huge_host_empty(nbytes: int) -> torch.Tensor:
     a view of it) goes away.
 
     Args:
-        nbytes: Size of the buffer in bytes. Must be positive.
+        nbytes: Size of the buffer in bytes. Must be in ``1..sys.maxsize``.
 
     Returns:
         torch.Tensor: A zero-filled 1-D ``uint8`` CPU tensor of ``nbytes`` bytes,
         sharing the buffer's memory rather than copying it.
+
+    Raises:
+        TypeError: if ``nbytes`` is not an integer.
+        ValueError: if ``nbytes`` is outside ``1..sys.maxsize``.
+        MemoryError: if the allocation fails.
 
     Example::
 
@@ -313,6 +320,16 @@ def huge_host_empty(nbytes: int) -> torch.Tensor:
     """
     # Third Party
     from rebel.host_memory import HugeHostBuffer
+
+    # Bound the request to what a size_t can carry. Past that the provider's
+    # round-up to the alignment wraps to zero, which allocates nothing and then
+    # prefaults the original size over it -- a segfault instead of an error.
+    # Reported upstream; this is the range check this API owes its callers either
+    # way. `operator.index` rather than `int()`, so a float is a TypeError rather
+    # than a silent truncation.
+    nbytes = operator.index(nbytes)
+    if not 0 < nbytes <= sys.maxsize:
+        raise ValueError(f"nbytes must be in 1..{sys.maxsize}, but got {nbytes}")
 
     # frombuffer takes a buffer-protocol reference, which is what keeps the
     # allocation alive for as long as the tensor is: HugeHostBuffer frees itself


### PR DESCRIPTION
## Summary of Changes

Two APIs for a consumer that DMAs between RBLN device memory and host memory without going through a torch op — so each side has to be ready before the transfer, not materialized during it. The caller is LMCache-RBLN's direct-storage (NVMe) offload path, which reaches past torch-rbln into `rebel._C` for both today (rebellions-sw/fsw-inference#526).

Layer 1 (`torch_rbln/`) and layer 2 (`c10/`, `torch_rbln/csrc/`). Eager dispatch only.

### `torch.rbln.bind_device_memory(tensor)`

An allocation reserves a virtual address and materializes the physical memory behind it on first use through a torch op. A consumer reading those physical buffers out of band never runs one, so it finds nothing there.

The collective path already solves this per operation — `ensureRcclRawMemory` calls `rbln_set_raw_memory_alloc` before every collective, from a dozen sites. This lifts that call into `c10::rbln::bind_device_memory`, routes `ProcessGroupRBLN`'s two binding sites through it, and exposes it:

```python
staging = torch.empty(nbytes, dtype=torch.uint8, device="rbln:0")
torch.rbln.bind_device_memory(staging)
```

`TORCH_RBLN_EAGER_MALLOC`, `is_eager_malloc()`, and the lazy/eager split in `c10::rbln::malloc` are untouched — this binds one region, it does not add an allocation mode.

The tensor has to cover its whole storage: an interior address (a slice, a narrowing view) would configure the wrong region, while a whole-storage `base.view(...)` carries the allocation's own address and size and is accepted. `ensureRcclRawMemory` keeps resolving `key_vaddr` through `rbln_get_memory_info` because it is handed interior views.

### `torch.rbln.huge_host_empty(nbytes)`

The host side of the same transfers, as a tensor over `rebel.host_memory.HugeHostBuffer` (rebel_compiler#12443) — 2 MiB aligned, prefaulted, released with the tensor's last reference. It asks for transparent huge pages through `madvise`, which is best effort: with THP disabled the alignment still holds and nothing is huge-page backed. It replaces the `allocate_huge_host_memory` / `free_huge_host_memory` pair #12443 deprecated, leaving that pair with no caller.

An ordinary CPU tensor is 64 B aligned, so `MultiCopyCmdBuffer` stages it through a bounce buffer (`multi_copy_cmd_buffer.cc`, against `kHostPageSize`); and even an aligned buffer costs a page fault per 4 KiB the first time the runtime resolves its host addresses, inside the transfer rather than in setup.

**`RBLNPinnedAllocator` is deliberately untouched.** It already returns page-aligned memory, which is all the bounce check looks at, so raising its alignment would change no transfer. Whether every `pin_memory=True` allocation should get huge pages is a separate question needing its own measurement.

---

## Related Issues / Tickets

* Related to rebellions-sw/fsw-inference#526 — the LMCache cleanup these let land
* Related to rebellions-sw/fsw-inference#428 — the linear-stack invariant
* Consumes rebellions-sw/rebel_compiler#12443, whose follow-up list names this

## Type of Change

- [x] `feature` — New capability or functionality

## Affected Modules

- [x] Memory
- [x] C++ extension (`torch_rbln/csrc`)

---

## How to Test

```bash
uv run --no-sync pytest test/rbln/test_tensor_memory.py -k "BindDeviceMemory or HugeHostEmpty" -v
```

**All 12 pass on hardware** (built against the pinned `rebel-compiler==0.11.3.dev0`):

* `TestBindDeviceMemory` — the bind puts physical memory behind a lazy allocation (below); the region stays usable afterwards; re-binding succeeds and does not allocate again (the collective path re-binds before every operation, so it must); a CPU tensor and an interior view are rejected, a whole-storage view is not; the call raises rather than faulting once the runtime is shutting down.
* `TestHugeHostEmpty` — returns a `uint8` CPU tensor of the requested size, 2 MiB aligned; the buffer outlives its `HugeHostBuffer` handle; zero, negative, non-integer and out-of-range sizes raise. Host-only, no NPU needed.

Two of them discriminate, which is the part worth checking:

* `test_bind_allocates_the_physical_memory` reads the runtime's device-memory gauge (`_rt_prof_memory`) around the call. No torch op can stand in for it — an op either materializes the allocation itself, or, for `zero_`, marks it logically zero without allocating anything — so this is the only witness the postcondition has from Python. Verified by removing the `rbln_set_raw_memory_alloc` call and rebuilding: every other test in the class still passed and this one failed.
* `test_is_huge_page_aligned`: a plain `torch.empty` of the same size is not 2 MiB aligned, checked directly.

The collective path has no new test — both sites make the same runtime call as before, through the shared helper. `test/distributed/test_process_group.py` covers them and now passes in full (406 tests, 4 NPUs).

## Notes

Not verified:

* **Nothing asserts actual huge-page backing.** Whether `madvise` is honoured depends on the host's THP setting, so the test asserts the 2 MiB alignment — which the provider does guarantee, and which is what keeps the copy path off its bounce buffer.
* `test_returns_zeroed_uint8_tensor`'s zero check is a contract assertion, not a discriminating one — freshly mapped pages read as zero anyway, so a wrapper that stopped zero-filling would only fail it by luck. The prefaulting behind it is not observable from Python.
* **No measurement accompanies either addition.** The mechanisms are read out of the runtime source (`multi_copy_cmd_buffer.cc` for the bounce, #12443 for the prefault), not measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

