### PR TITLE
feat(rebel): declare the rebel-compiler Python surface torch-rbln calls

### DIFF
--- a/cmake/FindRebel.cmake
+++ b/cmake/FindRebel.cmake
@@ -170,6 +170,40 @@ unset(_rebel_abi_header)
 unset(_rebel_abi_lines)
 unset(_rebel_abi_line)
 
+# The rebel Python surface torch-rbln drives is declared in torch_rbln/_internal/rebel_contract.py
+# and is not covered by RBLN_ABI_CURRENT. Report divergence here so whoever moves the rebel pin
+# sees it at configure time. rebel lands interface changes first and torch-rbln follows, so this
+# never fails the build -- both kinds are warnings, neither is an error.
+set(_rebel_contract_checker "${CMAKE_CURRENT_LIST_DIR}/../tools/check_rebel_contract.py")
+set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${_rebel_contract_checker}")
+execute_process(
+  COMMAND ${_rebel_python} "${_rebel_contract_checker}"
+  OUTPUT_VARIABLE _rebel_contract_output
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  ERROR_QUIET
+  TIMEOUT 120
+)
+if(_rebel_contract_output)
+  string(REPLACE "\n" ";" _rebel_contract_lines "${_rebel_contract_output}")
+  foreach(_line IN LISTS _rebel_contract_lines)
+    if(_line MATCHES "^BROKEN=(.+)$")
+      message(WARNING
+        "FindRebel: this rebel-compiler no longer provides what torch-rbln calls -- ${CMAKE_MATCH_1}. "
+        "Update torch_rbln/_internal/rebel_contract.py and its call site.")
+    elseif(_line MATCHES "^DRIFTED=(.+)$")
+      message(WARNING
+        "FindRebel: this rebel-compiler grew a parameter torch-rbln does not pass -- ${CMAKE_MATCH_1}. "
+        "The call still works on rebel's default; decide whether to follow it and record the "
+        "answer in torch_rbln/_internal/rebel_contract.py.")
+    elseif(_line MATCHES "^ERROR=(.+)$")
+      message(STATUS "FindRebel: rebel contract not checked -- ${CMAKE_MATCH_1}")
+    endif()
+  endforeach()
+  unset(_rebel_contract_lines)
+endif()
+unset(_rebel_contract_checker)
+unset(_rebel_contract_output)
+
 mark_as_advanced(
   ${PACKAGE_NAME}_INCLUDE_DIR
   ${PACKAGE_NAME}_LIBRARY

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -289,6 +289,7 @@ ignore = [
 ]
 select = [
     "B",
+    "TID251",
     "B904",
     "C4",
     "G",
@@ -351,9 +352,17 @@ select = [
     "UP"
 ]
 
+# Every rebel-compiler name torch-rbln uses is declared in
+# torch_rbln/_internal/rebel_contract.py, which is the only module that may import rebel.
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"rebel".msg = "declare it in torch_rbln/_internal/rebel_contract.py and reach it through that module"
+
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = [
     "F401"
+]
+"torch_rbln/_internal/rebel_contract.py" = [
+    "TID251"
 ]
 
 

--- a/test/internal/test_rebel_contract.py
+++ b/test/internal/test_rebel_contract.py
@@ -1,0 +1,201 @@
+# Owner(s): ["module: PrivateUse1"]
+
+"""The rebel-compiler Python surface torch-rbln declares in ``rebel_contract``.
+
+Three things are checked here:
+
+  - the installed rebel still satisfies ``CONTRACT`` (``BROKEN`` is empty);
+  - the verifier can tell the divergences apart, against a fabricated module, so a green run
+    means "checked" rather than "read nothing";
+  - ``rebel_contract`` is still the only module under ``torch_rbln/`` that imports rebel.
+
+``DRIFTED`` is reported, never asserted: rebel lands interface changes before torch-rbln follows,
+so a rebel parameter that gained a default must not fail this suite.
+"""
+
+import ast
+import sys
+import types
+from pathlib import Path
+
+import pytest
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+from torch_rbln._internal import rebel_contract
+from torch_rbln._internal.rebel_contract import BROKEN, DRIFTED, Name
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_FAKE_MODULE = "torch_rbln_fake_rebel"
+
+# What torch-rbln passes to the sync-runtime prepare methods; reused by the fabricated cases.
+_PARAMS = ("device_inputs", "cpu_inputs")
+
+
+@pytest.mark.test_set_ci
+class TestContractHolds(TestCase):
+    """The installed rebel against what torch-rbln declares it calls."""
+
+    def test_nothing_broken(self):
+        divergences = rebel_contract.broken()
+        self.assertEqual(divergences, [], "\n".join(str(d) for d in divergences))
+
+    def test_no_entry_is_broken(self):
+        # Per entry as well as in aggregate, for a failure that names which one. DRIFTED is not
+        # asserted: a rebel parameter that gained a default still works, and turning that red
+        # here would make torch-rbln's suite the thing that blocks an additive rebel change.
+        labels = [name.label for name in rebel_contract.CONTRACT]
+        self.assertEqual(len(labels), len(set(labels)), "a duplicated entry hides a real divergence")
+        for name in rebel_contract.CONTRACT:
+            with self.subTest(name=name.label):
+                divergence = rebel_contract._verify(name)
+                self.assertNotEqual(getattr(divergence, "kind", None), BROKEN, str(divergence))
+
+    def test_every_entry_resolves(self):
+        # Guards the other way: an entry naming something that never existed would report BROKEN
+        # once and otherwise look like coverage.
+        for name in rebel_contract.CONTRACT:
+            with self.subTest(name=name.label):
+                self.assertIsNone(rebel_contract._resolution_error(name), name.label)
+
+    def test_runtime_methods_are_what_the_hit_path_calls(self):
+        self.assertEqual(rebel_contract.RUNTIME_METHODS, ("prepare_inputs", "prepare_outputs", "run"))
+
+
+@pytest.mark.test_set_ci
+class TestVerifierDetects(TestCase):
+    """The verifier against a fabricated rebel, one divergence per case."""
+
+    def _entry(self, fn=None, attr="entry", params=_PARAMS, **members):
+        """Register a throwaway module and verify ``attr`` on it against ``params``."""
+        module = types.ModuleType(_FAKE_MODULE)
+        if fn is not None:
+            module.entry = fn
+        for name, value in members.items():
+            setattr(module, name, value)
+        sys.modules[_FAKE_MODULE] = module
+        self.addCleanup(sys.modules.pop, _FAKE_MODULE, None)
+        return rebel_contract._verify(Name(_FAKE_MODULE, attr, params))
+
+    def test_unchanged_is_clean(self):
+        def entry(device_inputs, cpu_inputs): ...
+
+        self.assertIsNone(self._entry(entry))
+
+    def test_renamed_parameter_is_broken(self):
+        def entry(dev, cpu): ...
+
+        self.assertEqual(self._entry(entry).kind, BROKEN)
+
+    def test_reordered_parameters_are_broken(self):
+        def entry(cpu_inputs, device_inputs): ...
+
+        self.assertEqual(self._entry(entry).kind, BROKEN)
+
+    def test_new_required_parameter_is_broken(self):
+        def entry(device_inputs, cpu_inputs, stale): ...
+
+        self.assertEqual(self._entry(entry).kind, BROKEN)
+
+    def test_new_required_keyword_only_is_broken(self):
+        def entry(device_inputs, cpu_inputs, *, stale): ...
+
+        self.assertEqual(self._entry(entry).kind, BROKEN)
+
+    def test_new_defaulted_parameter_is_drift_not_break(self):
+        def entry(device_inputs, cpu_inputs, stale=()): ...
+
+        divergence = self._entry(entry)
+        self.assertEqual(divergence.kind, DRIFTED)
+        self.assertIn("stale", divergence.detail)
+
+    def test_missing_attribute_is_broken(self):
+        self.assertEqual(self._entry().kind, BROKEN)
+
+    def test_missing_module_is_broken(self):
+        self.assertEqual(rebel_contract._verify(Name("torch_rbln_no_such_rebel_module")).kind, BROKEN)
+
+    def test_leading_self_is_not_counted(self):
+        class Runtime:
+            def entry(self, device_inputs, cpu_inputs): ...
+
+        self.assertIsNone(self._entry(attr="Runtime.entry", Runtime=Runtime))
+
+
+@pytest.mark.test_set_ci
+class TestSignatureReader(TestCase):
+    """``inspect.signature`` raises on every pybind11 entry point; the docstring is the fallback."""
+
+    def test_reads_a_real_pybind_signature(self):
+        prepare_inputs = _sync_runtime_type().prepare_inputs
+        signature = rebel_contract._read_signature(prepare_inputs)
+        self.assertIsNotNone(signature)
+        self.assertEqual(signature.positional[0], "self")
+        self.assertIn("device_inputs", signature.positional)
+
+    def test_overloaded_entry_point_reads_as_unknown_not_broken(self):
+        # pybind renders an overload set as ``(*args, **kwargs)``, which names no parameters.
+        # Reporting BROKEN off that would be a false alarm, so it reads as unknown instead.
+        def entry(*args, **kwargs): ...
+
+        entry.__doc__ = "entry(*args, **kwargs)\nOverloaded function."
+        self.assertIsNone(rebel_contract._read_pybind_signature(entry))
+
+    def test_unparseable_docstring_reads_as_unknown(self):
+        def entry(): ...
+
+        entry.__doc__ = "not a signature at all"
+        self.assertIsNone(rebel_contract._read_pybind_signature(entry))
+
+
+@pytest.mark.test_set_ci
+class TestImportChokepoint(TestCase):
+    """``rebel_contract`` is the only module under ``torch_rbln/`` that imports rebel.
+
+    ruff's TID251 enforces this in lint; this asserts it from the tree, so the invariant holds
+    where lint is not run. Parsed rather than grepped: a rebel import inside a string -- the
+    subprocess scripts under test/ are full of them -- is not an import.
+    """
+
+    CONTRACT_MODULE = Path("torch_rbln/_internal/rebel_contract.py")
+
+    def test_only_the_contract_module_imports_rebel(self):
+        offenders = []
+        sources = sorted((_REPO_ROOT / "torch_rbln").rglob("*.py"))
+        self.assertTrue(sources, "found no sources to check")
+        for path in sources:
+            relative = path.relative_to(_REPO_ROOT)
+            if relative == self.CONTRACT_MODULE:
+                continue
+            for node in ast.walk(ast.parse(path.read_text())):
+                if isinstance(node, ast.Import):
+                    names = [alias.name for alias in node.names]
+                elif isinstance(node, ast.ImportFrom):
+                    names = [node.module or ""]
+                else:
+                    continue
+                if any(name.split(".")[0] == "rebel" for name in names):
+                    offenders.append(f"{relative}:{node.lineno}")
+        self.assertEqual(offenders, [], "add the name to rebel_contract.CONTRACT and reach it through that module")
+
+    def test_the_check_can_see_an_offender(self):
+        # Without this, a walk that silently visited nothing would read as a clean tree.
+        tree = ast.parse("from rebel.device_info import get_npu_name\n")
+        modules = [n.module for n in ast.walk(tree) if isinstance(n, ast.ImportFrom)]
+        self.assertEqual([m.split(".")[0] for m in modules if m], ["rebel"])
+
+    def test_a_rebel_import_inside_a_string_is_not_an_import(self):
+        tree = ast.parse('SCRIPT = """\nfrom rebel._C import get_npu_name\n"""\n')
+        self.assertEqual([n for n in ast.walk(tree) if isinstance(n, (ast.Import, ast.ImportFrom))], [])
+
+
+def _sync_runtime_type():
+    """rebel's sync-runtime type, reached the way ``CONTRACT`` declares it."""
+    import importlib
+
+    return importlib.import_module("rebel._C").PyRblnSyncRuntime
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/internal/test_rebel_contract.py
+++ b/test/internal/test_rebel_contract.py
@@ -14,7 +14,10 @@ so a rebel parameter that gained a default must not fail this suite.
 """
 
 import ast
+import shutil
+import subprocess
 import sys
+import tempfile
 import types
 from pathlib import Path
 
@@ -188,6 +191,50 @@ class TestImportChokepoint(TestCase):
     def test_a_rebel_import_inside_a_string_is_not_an_import(self):
         tree = ast.parse('SCRIPT = """\nfrom rebel._C import get_npu_name\n"""\n')
         self.assertEqual([n for n in ast.walk(tree) if isinstance(n, (ast.Import, ast.ImportFrom))], [])
+
+
+@pytest.mark.test_set_ci
+class TestConfigureTimeReport(TestCase):
+    """``tools/check_rebel_contract.py``, whose output FindRebel.cmake matches line by line."""
+
+    def _run(self, contract_source):
+        contract = Path(self._tmp) / "torch_rbln" / "_internal"
+        contract.mkdir(parents=True)
+        (contract / "rebel_contract.py").write_text(contract_source)
+        (Path(self._tmp) / "tools").mkdir()
+        checker = Path(self._tmp) / "tools" / "check_rebel_contract.py"
+        checker.write_text((_REPO_ROOT / "tools" / "check_rebel_contract.py").read_text())
+        return subprocess.run([sys.executable, str(checker)], capture_output=True, text=True)
+
+    def setUp(self):
+        self._tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self._tmp, True)
+
+    def test_clean_contract_prints_nothing(self):
+        result = self._run("def verify():\n    return []\n")
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout.strip(), "")
+
+    def test_each_divergence_is_one_matchable_line(self):
+        result = self._run(
+            "class D:\n"
+            "    kind = 'DRIFTED'\n"
+            "    name = 'rebel.x:y'\n"
+            "    detail = 'grew\\ndefaulted'\n"
+            "def verify():\n"
+            "    return [D(), D()]\n"
+        )
+        lines = result.stdout.splitlines()
+        self.assertEqual(len(lines), 2, result.stdout)
+        for line in lines:
+            self.assertTrue(line.startswith("DRIFTED=rebel.x:y: "), line)
+
+    def test_a_broken_check_reports_and_still_exits_zero(self):
+        # The build must not stop because the contract check itself could not run.
+        result = self._run("raise RuntimeError('boom\\nsecond line')\n")
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(len(result.stdout.splitlines()), 1, result.stdout)
+        self.assertTrue(result.stdout.startswith("ERROR="), result.stdout)
 
 
 def _sync_runtime_type():

--- a/test/internal/test_warm_cache_internals.py
+++ b/test/internal/test_warm_cache_internals.py
@@ -15,13 +15,14 @@ generated Python wrappers depend on:
 """
 
 import threading
+from unittest import mock
 
 import pytest
 import torch
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 from torch_rbln import _C  # type: ignore[attr-defined]
-from torch_rbln._internal import warm_cache
+from torch_rbln._internal import rebel_contract, warm_cache
 
 
 # Most suites here exercise the C++ warm-cache's process-wide / thread-local
@@ -216,9 +217,9 @@ class TestWarmCacheHitPath(TestCase):
 class TestWarmCacheHandleGate(TestCase):
     """Which runtime handles the hit path accepts.
 
-    The hit path calls three methods by name, so a handle is usable exactly
-    when it carries all three. The gate runs before an entry is cached, which
-    is what keeps a rebel-side rename from reaching the C++ side at all.
+    The hit path calls the methods ``rebel_contract`` declares, so a handle is usable exactly
+    when it carries all of them. The gate runs before an entry is cached, which is what keeps a
+    rebel-side rename from reaching the C++ side at all.
     """
 
     class _Runtime:
@@ -226,35 +227,36 @@ class TestWarmCacheHandleGate(TestCase):
         def prepare_outputs(self, *a, **k): ...
         def run(self, *a, **k): ...
 
-    def test_handle_with_all_three_methods_is_accepted(self) -> None:
-        self.assertTrue(warm_cache._is_drivable_runtime_handle(self._Runtime()))
+    def test_handle_with_every_declared_method_is_accepted(self) -> None:
+        methods = rebel_contract.runtime_methods(self._Runtime())
+        self.assertIsNotNone(methods)
+        self.assertEqual(len(methods), len(rebel_contract.RUNTIME_METHODS))
 
     def test_handle_missing_any_method_is_refused(self) -> None:
-        for name in ("prepare_inputs", "prepare_outputs", "run"):
+        for name in rebel_contract.RUNTIME_METHODS:
             handle = self._Runtime()
             setattr(handle, name, None)  # shadows the class method
-            self.assertFalse(
-                warm_cache._is_drivable_runtime_handle(handle),
+            self.assertIsNone(
+                rebel_contract.runtime_methods(handle),
                 f"a handle whose {name} is not callable must be refused",
             )
 
     def test_absent_handle_is_refused(self) -> None:
-        self.assertFalse(warm_cache._is_drivable_runtime_handle(None))
-        self.assertFalse(warm_cache._is_drivable_runtime_handle(object()))
+        self.assertIsNone(rebel_contract.runtime_methods(None))
+        self.assertIsNone(rebel_contract.runtime_methods(object()))
 
 
 @pytest.mark.test_set_ci
 class TestWarmCacheContractBreak(TestCase):
     """A runtime that rejects the hit path's call must cost only the fast path.
 
-    A runtime whose ``prepare_inputs`` no longer accepts this call shape has to
-    stay harmless: correct results, on the Python wrapper path, for as long as
-    it takes torch-rbln to catch up. That guarantee is what lets rebel merge
-    without waiting for a matching torch-rbln, so assert it rather than assume
-    it.
+    A runtime whose ``prepare_inputs`` no longer accepts this call shape has to stay harmless:
+    correct results, on the Python wrapper path, for as long as it takes torch-rbln to catch up.
+    That guarantee is what lets rebel merge without waiting for a matching torch-rbln, so assert
+    it rather than assume it.
 
-    The stand-in raises ``TypeError``, which is what pybind raises when the
-    argument count no longer matches.
+    ``TypeError`` is what pybind raises when the argument count no longer matches, and it is the
+    signal the shim reads as "this build's call no longer fits", so the rejection uses it.
     """
 
     SHAPE = 192  # 64-aligned and unused elsewhere, so the first call compiles
@@ -263,30 +265,27 @@ class TestWarmCacheContractBreak(TestCase):
         self._orig_install = _C._warmcache_install_pending
         self.addCleanup(setattr, _C, "_warmcache_install_pending", self._orig_install)
         self.addCleanup(_C._warmcache_clear)
+        # A break disables the cache for the process; later tests need it back.
+        self.addCleanup(_C._warmcache_set_enabled, True)
+        self.addCleanup(_C._warmcache_take_contract_break)
+
+    def _install_a_rejecting_prepare_inputs(self) -> None:
+        def rejecting(*a, **k):
+            raise TypeError("prepare_inputs(): incompatible function arguments")
+
+        def install(*, dyn_runtime, prepare_inputs, **kw):
+            return self._orig_install(dyn_runtime=dyn_runtime, prepare_inputs=rejecting, **kw)
+
+        _C._warmcache_install_pending = install
 
     def test_rejected_call_keeps_values_and_stops_hitting(self) -> None:
-        class RejectingHandle:
-            """Delegates everything except the call the hit path makes first."""
-
-            def __init__(self, inner):
-                self._inner = inner
-
-            def prepare_inputs(self, *a, **k):
-                raise TypeError("prepare_inputs(): incompatible function arguments")
-
-            def __getattr__(self, name):
-                return getattr(self._inner, name)
-
-        def install_with_rejecting_handle(*, dyn_runtime, runtime_handle, **kw):
-            return self._orig_install(dyn_runtime=dyn_runtime, runtime_handle=RejectingHandle(runtime_handle), **kw)
-
-        _C._warmcache_install_pending = install_with_rejecting_handle
+        self._install_a_rejecting_prepare_inputs()
 
         x = torch.arange(self.SHAPE, dtype=torch.float16, device="rbln")
         y = torch.ones(self.SHAPE, dtype=torch.float16, device="rbln")
         expected = torch.arange(1, self.SHAPE + 1, dtype=torch.float16)
 
-        # First call installs the rejecting handle; the rest would hit it.
+        # First call installs the rejecting method; the rest would hit it.
         self.assertEqual((x + y).to("cpu"), expected)
         hits_before = _C._dispatch_shim_warm_segments_dump()[0]
         for _ in range(4):
@@ -294,6 +293,41 @@ class TestWarmCacheContractBreak(TestCase):
 
         hits_after = _C._dispatch_shim_warm_segments_dump()[0]
         self.assertEqual(hits_after, hits_before, "a rejected call was counted as a hit")
+
+    def test_rejected_call_stops_the_fast_path_instead_of_retrying(self) -> None:
+        # Without this, every dispatch erases the entry and forces a recompile that reinstalls
+        # the same rejected call -- correct results at the cost of a compile per dispatch.
+        self._install_a_rejecting_prepare_inputs()
+
+        x = torch.arange(self.SHAPE, dtype=torch.float16, device="rbln")
+        y = torch.ones(self.SHAPE, dtype=torch.float16, device="rbln")
+
+        self.assertTrue(_C._warmcache_is_enabled())
+        for _ in range(3):
+            (x + y).to("cpu")
+        self.assertFalse(_C._warmcache_is_enabled(), "a rejected call left the fast path armed")
+
+    def test_the_break_reaches_the_user_through_the_dispatch_path(self) -> None:
+        # The whole handoff: the C++ hit path flags the break, install_pending consumes the flag
+        # on the miss that follows, and the report comes out of Python -- which is where the
+        # contract declaration is, and so the only side that can name what changed.
+        self._install_a_rejecting_prepare_inputs()
+
+        x = torch.arange(self.SHAPE, dtype=torch.float16, device="rbln")
+        y = torch.ones(self.SHAPE, dtype=torch.float16, device="rbln")
+
+        (x + y).to("cpu")  # installs the rejecting method
+        with self.assertWarns(RuntimeWarning) as caught:
+            for _ in range(3):
+                (x + y).to("cpu")
+        self.assertIn("warm cache is off", str(caught.warning))
+
+    def test_the_report_names_the_divergence(self) -> None:
+        divergence = rebel_contract.Divergence("rebel.made_up:entry", rebel_contract.BROKEN, "not there")
+        with mock.patch.object(rebel_contract, "verify", return_value=[divergence]):
+            with self.assertWarns(RuntimeWarning) as caught:
+                warm_cache._warn_contract_break()
+        self.assertIn("rebel.made_up:entry", str(caught.warning))
 
 
 if __name__ == "__main__":

--- a/tools/check_rebel_contract.py
+++ b/tools/check_rebel_contract.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Report how the rebel-compiler being built against differs from what torch-rbln declares.
+
+Runs the same check torch-rbln runs at import, so whoever moves the rebel pin sees the
+divergence at configure time rather than as a slower eager path at runtime. Loaded by path
+because torch_rbln cannot be imported before it is built.
+
+Prints one ``BROKEN=`` or ``DRIFTED=`` line per divergence, and ``ERROR=`` when the check itself
+could not run. Always exits 0: this reports, it does not gate a build.
+"""
+
+import importlib.util
+import os
+import sys
+from typing import Any
+
+
+_CONTRACT = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "torch_rbln", "_internal", "rebel_contract.py"
+)
+
+
+def _load_contract() -> Any:
+    spec = importlib.util.spec_from_file_location("_rebel_contract_for_build", _CONTRACT)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load the rebel contract from {_CONTRACT}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _record(kind: str, text: str) -> str:
+    """One ``KIND=text`` line. CMake matches per line, so the text cannot carry newlines."""
+    return f"{kind}={' '.join(text.split())}"
+
+
+def main() -> int:
+    # Importing rebel imports torch, which autoloads the torch_rbln backend extension -- the one
+    # this build is producing. On a first build it does not exist yet and the import would fail.
+    os.environ["TORCH_DEVICE_BACKEND_AUTOLOAD"] = "0"
+
+    try:
+        divergences = _load_contract().verify()
+    except Exception as e:  # a contract check must never be the reason a build stops
+        print(_record("ERROR", f"{type(e).__name__}: {e}"))
+        return 0
+
+    for divergence in divergences:
+        print(_record(divergence.kind, f"{divergence.name}: {divergence.detail}"))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/torch_rbln/_internal/device_arch_utils.py
+++ b/torch_rbln/_internal/device_arch_utils.py
@@ -2,6 +2,8 @@
 
 import functools
 
+from torch_rbln._internal import rebel_contract
+
 
 __all__ = ["get_device_arch", "is_atom_device", "is_rebel_device"]
 
@@ -25,9 +27,7 @@ def get_device_arch() -> str:
     NPU name can't be queried.
     """
     try:
-        from rebel.device_info import get_npu_name
-
-        return _arch_from_npu_name(get_npu_name(0) or "")
+        return _arch_from_npu_name(rebel_contract.get_npu_name(0))
     except Exception:
         return "unknown"
 

--- a/torch_rbln/_internal/env_diagnostic.py
+++ b/torch_rbln/_internal/env_diagnostic.py
@@ -371,6 +371,23 @@ def _resolve_so_paths(d: dict[str, Any]) -> list[dict[str, Any]]:
     return result
 
 
+def _rebel_contract_info() -> dict[str, Any]:
+    """How the installed rebel differs from the Python surface torch-rbln declares it calls.
+
+    Reported here rather than at import: verifying the contract imports rebel submodules, and
+    rebel's own import triggers torch's backend autoload, which imports torch_rbln -- running it
+    there would re-enter a half-initialized rebel and report a break that is not one.
+    """
+    out: dict[str, Any] = {"divergences": [], "error": None}
+    try:
+        from torch_rbln._internal import rebel_contract
+
+        out["divergences"] = [str(d) for d in rebel_contract.verify()]
+    except Exception as e:
+        out["error"] = f"rebel_contract unavailable: {e}"
+    return out
+
+
 def collect_diagnostics() -> dict[str, Any]:
     """Gather env snapshot, compiler package locations, and runtime-library resolution state."""
     candidates = _runtime_lib_candidates()
@@ -378,6 +395,7 @@ def collect_diagnostics() -> dict[str, Any]:
         "torch_rbln": _torch_rbln_info(),
         "rebel_compiler": _rebel_compiler_info(),
         "rebel_abi": _rebel_abi_info(),
+        "rebel_contract": _rebel_contract_info(),
         "env": _env_snapshot(),
         "rebel": _package_location("rebel"),
         "runtime_lib": _runtime_lib_state(),
@@ -458,6 +476,17 @@ def format_diagnostics(d: dict[str, Any] | None = None, verbose: bool = True) ->
         lines.append("  >>> check is DISABLED via TORCH_RBLN_SKIP_ABI_CHECK; import will not enforce it.")
     if abi.get("error"):
         lines.append(f"  error: {abi['error']}")
+
+    lines.extend(["", "rebel Python surface (torch_rbln/_internal/rebel_contract.py):"])
+    contract = d.get("rebel_contract") or {}
+    if contract.get("error"):
+        lines.append(f"  error: {contract['error']}")
+    elif not contract.get("divergences"):
+        lines.append("  matches what this torch-rbln calls")
+    else:
+        for divergence in contract["divergences"]:
+            lines.append(f"  {divergence}")
+
     lines.extend(
         [
             "",

--- a/torch_rbln/_internal/monkey_patches.py
+++ b/torch_rbln/_internal/monkey_patches.py
@@ -3,6 +3,7 @@
 import threading
 import warnings
 
+from torch_rbln._internal import rebel_contract
 from torch_rbln._internal.compile_cache import clear_rbln_compile_cache
 from torch_rbln._internal.torch_compile_patch_helpers import CompiledFunctionWrapper, is_rbln_backend
 
@@ -42,8 +43,7 @@ def _register_rbln_backend() -> bool:
         return True
 
     try:
-        # Importing registers 'rbln' via module-level register_backend() side effects.
-        import rebel.core.torch_compile  # noqa: F401
+        rebel_contract.register_torch_compile_backend()
 
         if _is_backend_registered("rbln"):
             _rbln_backend_registered = True

--- a/torch_rbln/_internal/rebel_contract.py
+++ b/torch_rbln/_internal/rebel_contract.py
@@ -1,0 +1,271 @@
+"""The rebel-compiler Python surface torch-rbln drives.
+
+torch-rbln's C dependency on rebel is declared in ``rebel/runtime/api/rbln_runtime_api.h``,
+recorded at build time by FindRebel.cmake and checked against the loaded librbln.so at import
+(:mod:`torch_rbln._internal.abi_check`). Its Python dependency was declared nowhere: the names
+were spelled at each call site, and a rebel-side rename arrived as an ImportError, as an arch
+reported ``"unknown"``, or as a warm cache that quietly stopped serving.
+
+:data:`CONTRACT` is that declaration -- every rebel attribute torch-rbln reaches for and the
+positional parameters it passes. This module is also the only one under ``torch_rbln/`` that may
+import rebel; ruff's TID251 banned-api rule holds that.
+
+rebel lands interface changes and torch-rbln follows afterwards, so :func:`verify` reports two
+kinds of divergence and only one of them is a defect:
+
+``BROKEN``
+    The call torch-rbln makes no longer works: a name is gone, renamed, reordered, or gained a
+    required parameter. Fails the contract test.
+``DRIFTED``
+    The call still works; rebel grew a parameter that has a default. Reported, never asserted --
+    whoever moves the rebel pin decides whether to follow it.
+
+Both are reported at configure time by FindRebel.cmake and by ``python -m torch_rbln.diagnose``.
+Neither runs at import: verifying imports rebel submodules, and rebel's own import triggers
+torch's backend autoload, which imports torch_rbln -- checking there re-enters a half-initialized
+rebel and reports a break that is not one.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import inspect
+from typing import Any, NamedTuple
+
+
+BROKEN = "BROKEN"
+DRIFTED = "DRIFTED"
+
+
+class Name(NamedTuple):
+    """One rebel attribute torch-rbln depends on.
+
+    ``attr`` is dotted and resolved from ``module``; None declares the module itself, imported
+    for a side effect. ``params`` lists the positional parameters torch-rbln passes, in order and
+    excluding ``self``; None declares a non-callable.
+    """
+
+    module: str
+    attr: str | None = None
+    params: tuple[str, ...] | None = None
+
+    @property
+    def label(self) -> str:
+        return f"{self.module}:{self.attr}" if self.attr else self.module
+
+
+class Divergence(NamedTuple):
+    """One way the installed rebel differs from :data:`CONTRACT`."""
+
+    name: str
+    kind: str
+    detail: str
+
+    def __str__(self) -> str:
+        return f"{self.kind} {self.name}: {self.detail}"
+
+
+# Positional arguments the C++ warm-cache hit path passes to each sync-runtime method.
+RUNTIME_METHOD_PARAMS: dict[str, tuple[str, ...]] = {
+    "prepare_inputs": ("device_inputs", "cpu_inputs"),
+    "prepare_outputs": ("device_outputs", "cpu_outputs"),
+    "run": (),
+}
+
+# The methods themselves, in the order install resolves them.
+RUNTIME_METHODS: tuple[str, ...] = tuple(RUNTIME_METHOD_PARAMS)
+
+# Instance attribute of rebel's DynamoRuntime holding the sync runtime, and the torch.compile
+# option rebel's backend appends that runtime into. Both are per-instance, so :func:`verify`
+# cannot reach them; the warm-cache hit-path test is what covers them.
+RUNTIME_HANDLE_ATTR = "_runtime_handle"
+RUNTIME_HOLDER_OPTION = "_runtime_holder"
+
+CONTRACT: tuple[Name, ...] = (
+    *(Name("rebel._C", f"PyRblnSyncRuntime.{method}", params) for method, params in RUNTIME_METHOD_PARAMS.items()),
+    Name("rebel.device_info", "get_npu_name", ("device_id",)),
+    Name("rebel.core.torch_eager", "eager_execution_helper", ()),
+    Name("rebel.core.torch_eager", "EagerExecutionHelper.set_out_tensor", ("out_tensors",)),
+    Name("rebel.core.torch_eager", "EagerExecutionHelper.clear_out_tensor", ()),
+    # Imported for the module-level register_backend() that makes backend="rbln" resolvable.
+    Name("rebel.core.torch_compile"),
+)
+
+
+# --------------------------------------------------------------------------------------------
+# Call sites
+# --------------------------------------------------------------------------------------------
+
+
+def get_npu_name(device_id: int) -> str:
+    """rebel's name for the NPU at ``device_id``."""
+    from rebel.device_info import get_npu_name as _get_npu_name
+
+    return str(_get_npu_name(device_id) or "")
+
+
+def eager_execution_helper() -> Any:
+    """A fresh rebel eager-execution helper (``set_out_tensor`` / ``clear_out_tensor``)."""
+    from rebel.core.torch_eager import eager_execution_helper as _eager_execution_helper
+
+    return _eager_execution_helper()
+
+
+def register_torch_compile_backend() -> None:
+    """Register rebel's ``"rbln"`` torch.compile backend.
+
+    Registration is a module-level side effect of the import; ImportError reaches the caller.
+    """
+    import rebel.core.torch_compile  # noqa: F401
+
+
+def runtime_methods(handle: Any) -> list[Any] | None:
+    """``handle``'s bound :data:`RUNTIME_METHODS`, or None if it is missing any of them.
+
+    None keeps the op on the Python wrapper path, which is slower and correct.
+    """
+    bound = [getattr(handle, name, None) for name in RUNTIME_METHODS]
+    if not all(callable(method) for method in bound):
+        return None
+    return bound
+
+
+# --------------------------------------------------------------------------------------------
+# Verification
+# --------------------------------------------------------------------------------------------
+
+
+class _Signature(NamedTuple):
+    positional: tuple[str, ...]
+    defaulted: int
+    kwonly_required: tuple[str, ...]
+
+
+def _read_pybind_signature(fn: Any) -> _Signature | None:
+    """Read a pybind11 entry point's signature off the first line of its docstring.
+
+    That line is valid Python, so it parses exactly. Returns None for an overloaded entry point,
+    whose first line is ``(*args, **kwargs)`` and carries no parameter names.
+    """
+    lines = (getattr(fn, "__doc__", None) or "").splitlines()
+    if not lines:
+        return None
+    try:
+        tree = ast.parse(f"def {lines[0].strip()}: ...")
+    except SyntaxError:
+        return None
+    node = tree.body[0]
+    if not isinstance(node, ast.FunctionDef):
+        return None
+    args = node.args
+    if args.vararg is not None or args.kwarg is not None:
+        return None
+    return _Signature(
+        tuple(arg.arg for arg in (*args.posonlyargs, *args.args)),
+        len(args.defaults),
+        tuple(arg.arg for arg, default in zip(args.kwonlyargs, args.kw_defaults) if default is None),
+    )
+
+
+def _read_signature(fn: Any) -> _Signature | None:
+    """``fn``'s signature, or None if it cannot be read.
+
+    ``inspect.signature`` raises on every pybind11 entry point, which is most of this surface.
+    """
+    try:
+        signature = inspect.signature(fn)
+    except (TypeError, ValueError):
+        return _read_pybind_signature(fn)
+    positional: list[str] = []
+    defaulted = 0
+    kwonly_required: list[str] = []
+    for parameter in signature.parameters.values():
+        if parameter.kind in (parameter.POSITIONAL_ONLY, parameter.POSITIONAL_OR_KEYWORD):
+            positional.append(parameter.name)
+            if parameter.default is not parameter.empty:
+                defaulted += 1
+        elif parameter.kind is parameter.KEYWORD_ONLY and parameter.default is parameter.empty:
+            kwonly_required.append(parameter.name)
+    return _Signature(tuple(positional), defaulted, tuple(kwonly_required))
+
+
+def _verify_signature(name: Name, fn: Any) -> Divergence | None:
+    """Compare ``fn`` against the parameters ``name`` declares torch-rbln passes."""
+    assert name.params is not None
+    signature = _read_signature(fn)
+    if signature is None:
+        return None
+
+    # Bound and unbound forms differ by a leading self; the declaration carries neither.
+    positional = signature.positional
+    if positional and positional[0] == "self":
+        positional = positional[1:]
+
+    declared = name.params
+    if positional[: len(declared)] != declared:
+        return Divergence(
+            name.label,
+            BROKEN,
+            f"torch-rbln passes {list(declared)}, rebel now takes {list(positional)}",
+        )
+    if signature.kwonly_required:
+        return Divergence(
+            name.label,
+            BROKEN,
+            f"rebel now requires keyword-only {list(signature.kwonly_required)}, which torch-rbln does not pass",
+        )
+    required = len(positional) - signature.defaulted
+    if required > len(declared):
+        return Divergence(
+            name.label,
+            BROKEN,
+            f"rebel now requires {list(positional[:required])}, and torch-rbln passes only {list(declared)}",
+        )
+    if len(positional) > len(declared):
+        return Divergence(
+            name.label,
+            DRIFTED,
+            f"rebel grew defaulted {list(positional[len(declared) :])}; torch-rbln keeps passing {list(declared)} "
+            f"and takes rebel's defaults for the rest",
+        )
+    return None
+
+
+def _resolve(name: Name) -> Any:
+    """The object ``name`` declares. Raises ImportError or AttributeError if it is not there."""
+    obj: Any = importlib.import_module(name.module)
+    for part in name.attr.split(".") if name.attr else ():
+        obj = getattr(obj, part)
+    return obj
+
+
+def _resolution_error(name: Name) -> Divergence | None:
+    """Why ``name`` cannot be reached at all, or None."""
+    try:
+        obj = _resolve(name)
+    except ImportError as e:
+        return Divergence(name.label, BROKEN, f"module not importable: {e}")
+    except AttributeError:
+        return Divergence(name.label, BROKEN, "attribute not found")
+    if name.params is not None and not callable(obj):
+        return Divergence(name.label, BROKEN, "not callable")
+    return None
+
+
+def _verify(name: Name) -> Divergence | None:
+    divergence = _resolution_error(name)
+    if divergence is not None or name.params is None:
+        return divergence
+    return _verify_signature(name, _resolve(name))
+
+
+def verify() -> list[Divergence]:
+    """How the installed rebel differs from :data:`CONTRACT`, worst first."""
+    found = [d for d in (_verify(name) for name in CONTRACT) if d is not None]
+    return sorted(found, key=lambda d: d.kind != BROKEN)
+
+
+def broken() -> list[Divergence]:
+    """Only the divergences that stop a call torch-rbln makes."""
+    return [d for d in verify() if d.kind == BROKEN]

--- a/torch_rbln/_internal/warm_cache.py
+++ b/torch_rbln/_internal/warm_cache.py
@@ -7,45 +7,59 @@ warm cache), the C++ shim:
   1. Saves a thread-local "pending" `CacheKey` built from the live args.
   2. Calls the generated Python wrapper (e.g. ``add_out_rbln``) via pybind.
 
-The Python wrapper's ``else`` branch (device path) now passes an empty
+The Python wrapper's ``else`` branch (device path) passes an empty
 ``_runtime_holder`` list via the compile ``options``. After the first
-backend compile, rebel's ``rbln_backend`` appends the
-``DynamoRuntime`` that owns the compiled sync runtime to this list. The generated wrapper then calls :func:`install_pending` with
-that runtime and the post-compile output-tensor profiles.
+backend compile, rebel's ``rbln_backend`` appends the ``DynamoRuntime``
+that owns the compiled sync runtime to this list. The generated wrapper
+then calls :func:`install_pending` with that runtime and the
+post-compile output-tensor profiles.
 
-:func:`install_pending` packs the output profiles into the shape the
-C++ side expects and hands them, with the runtime handle, to
-``torch_rbln._C._warmcache_install_pending``. The C++ side matches
-against the pending key it saved on the way in and inserts a
-:class:`CacheEntry` keyed by (op name, input profile, scalars, device
-index).
+:func:`install_pending` resolves the runtime's ``prepare_inputs`` /
+``prepare_outputs`` / ``run`` through
+:mod:`torch_rbln._internal.rebel_contract`, which declares those names
+and is the only place they are spelled, and hands the bound methods and
+the output profiles to ``torch_rbln._C._warmcache_install_pending``. The
+C++ side matches against the pending key it saved on the way in and
+inserts a :class:`CacheEntry` keyed by (op name, input profile, scalars,
+device index).
 
 Subsequent dispatches of the same op with a matching input profile hit
-the warm cache on the C++ side, which calls the handle's
-``prepare_inputs`` / ``prepare_outputs`` / ``run`` — no Python wrapper,
-no Dynamo recompile check.
+the warm cache on the C++ side, which calls those three bound methods —
+no Python wrapper, no Dynamo recompile check.
+
+A hit that raises ``TypeError`` means rebel's runtime no longer accepts
+this build's call. The C++ side then disables the cache for the process
+and flags it; :func:`install_pending` consumes the flag and reports which
+declared names diverged.
 """
 
 from __future__ import annotations
 
+import warnings
 from typing import Any
 
 import torch
 
 import torch_rbln._C as _C
+from torch_rbln._internal import rebel_contract
 
 
-# What the C++ hit path calls on the runtime handle; see WarmCache.h.
-_RUNTIME_METHODS = ("prepare_inputs", "prepare_outputs", "run")
+def _warn_contract_break() -> None:
+    """Report the rebel divergence that turned the warm cache off.
 
-
-def _is_drivable_runtime_handle(handle: Any) -> bool:
-    """True iff the C++ hit path can drive ``handle``.
-
-    The three methods are the whole contract; a handle missing any of them is
-    skipped so the op stays on the (correct, slower) Python wrapper path.
+    The C++ hit path sets the flag once and disables the cache in the same step, so this runs
+    at most once per process. The divergence list comes from the contract declaration, which is
+    why the message can name what changed instead of only that something did.
     """
-    return all(callable(getattr(handle, name, None)) for name in _RUNTIME_METHODS)
+    divergences = rebel_contract.verify()
+    detail = "\n  ".join(str(d) for d in divergences) or "rebel_contract.verify() found no divergence"
+    warnings.warn(
+        f"The RBLN warm cache is off for this process: rebel's runtime rejected the call this "
+        f"torch-rbln makes, so eager ops take the slower Python path and results are unaffected. "
+        f"Against the installed rebel-compiler:\n  {detail}",
+        RuntimeWarning,
+        stacklevel=2,
+    )
 
 
 _DTYPE_KEY = {
@@ -65,14 +79,21 @@ def install_pending(runtime_holder: list, outputs: Any) -> bool:
     # Hot codegen-injected path: skip work whenever WarmCache is disabled.
     # `_warmcache_is_enabled` is one C call; cheaper than the rest of this
     # function and makes WC OFF nearly free on the cold path.
-    if not runtime_holder or not _C._warmcache_is_enabled():
+    if not _C._warmcache_is_enabled():
+        # The break disables the cache, and the miss it falls through to reaches here with an
+        # empty holder (nothing recompiled), so the flag has to be read before that early exit.
+        if _C._warmcache_take_contract_break():
+            _warn_contract_break()
         if runtime_holder:
             runtime_holder.clear()
         return False
+    if not runtime_holder:
+        return False
 
     dyn_runtime = runtime_holder[-1]
-    runtime_handle = getattr(dyn_runtime, "_runtime_handle", None)
-    if not _is_drivable_runtime_handle(runtime_handle):
+    runtime_handle = getattr(dyn_runtime, rebel_contract.RUNTIME_HANDLE_ATTR, None)
+    methods = rebel_contract.runtime_methods(runtime_handle)
+    if methods is None:
         runtime_holder.clear()
         return False
 
@@ -91,14 +112,12 @@ def install_pending(runtime_holder: list, outputs: Any) -> bool:
         runtime_holder.clear()
         return False
 
-    num_inputs = getattr(dyn_runtime, "_num_inputs", 0)
-    num_outputs = getattr(dyn_runtime, "_num_outputs", len(profiles))
-
+    prepare_inputs, prepare_outputs, run = methods
     ok = _C._warmcache_install_pending(
         dyn_runtime=dyn_runtime,
-        runtime_handle=runtime_handle,
-        num_inputs=num_inputs,
-        num_outputs=num_outputs,
+        prepare_inputs=prepare_inputs,
+        prepare_outputs=prepare_outputs,
+        run=run,
         out_profiles=profiles,
     )
     # Drop the harvested DynamoRuntime so subsequent compile invocations on the

--- a/torch_rbln/csrc/rbln/DispatchShim.cpp
+++ b/torch_rbln/csrc/rbln/DispatchShim.cpp
@@ -1060,6 +1060,7 @@ bool try_warmcache_hit(torch::jit::Stack* stack, const SchemaCache& cache, const
   pybind11::gil_scoped_acquire wc_gil;
   const uint64_t _seg_t_gil = now_ns();
   bool runtime_failed = false;
+  bool contract_broken = false;
   // Each phase timer is assigned right after its corresponding runtime call.
   // A throw skips the remaining assignments and lands in the early return
   // below, so the diag accumulators are only read on the all-assigned path.
@@ -1079,12 +1080,27 @@ bool try_warmcache_hit(torch::jit::Stack* stack, const SchemaCache& cache, const
     _seg_t_prep_out = now_ns();
     entry->run();
     _seg_t_run = now_ns();
-  } catch (const pybind11::error_already_set&) {
+  } catch (const pybind11::error_already_set& e) {
+    // TypeError is the arity/type mismatch pybind raises before the runtime's
+    // body runs: the call this build makes no longer fits rebel's runtime.
+    // Unlike the profile-specific failures below, that holds for every profile.
+    contract_broken = e.matches(PyExc_TypeError);
     clear_and_fail();
   } catch (const std::exception&) {
     clear_and_fail();
   } catch (...) {
     clear_and_fail();
+  }
+  if (contract_broken) {
+    // Recompiling reinstalls the same call, so retrying costs a compile per
+    // dispatch and never succeeds. Shut the fast path off for the process
+    // instead; results come from the Python wrapper, which is correct. The
+    // flag is consumed by ``warm_cache.install_pending``, which can name what
+    // diverged because it holds the contract declaration.
+    WarmCache::instance().set_enabled(false);
+    WarmCache::instance().clear();
+    WarmCache::mark_contract_break();
+    return false;
   }
   if (runtime_failed) {
     // The runtime that we cached cannot serve this profile after all (e.g.
@@ -1493,9 +1509,9 @@ void diag_reset_trace_by_op() {
 
 bool install_warmcache_from_pending(
     pybind11::object dyn_runtime,
-    const pybind11::object& runtime_handle,
-    uint32_t num_inputs,
-    uint32_t num_outputs,
+    pybind11::object prepare_inputs,
+    pybind11::object prepare_outputs,
+    pybind11::object run,
     const std::vector<std::tuple<std::vector<int64_t>, std::string, bool>>& out_profiles) {
   PendingInstall p = take_pending();
   if (!p.valid)
@@ -1523,17 +1539,9 @@ bool install_warmcache_from_pending(
 
   CacheEntry entry;
   entry.py_dyn_runtime = std::move(dyn_runtime);
-  // A runtime missing any of the three cannot be driven from the hit path, so
-  // refuse to install rather than cache an entry whose every hit would fail.
-  try {
-    entry.prepare_inputs = runtime_handle.attr("prepare_inputs");
-    entry.prepare_outputs = runtime_handle.attr("prepare_outputs");
-    entry.run = runtime_handle.attr("run");
-  } catch (const pybind11::error_already_set&) {
-    return false;
-  }
-  entry.num_inputs = num_inputs;
-  entry.num_outputs = num_outputs;
+  entry.prepare_inputs = std::move(prepare_inputs);
+  entry.prepare_outputs = std::move(prepare_outputs);
+  entry.run = std::move(run);
   entry.out_profiles.reserve(out_profiles.size());
   for (const auto& tup : out_profiles) {
     OutputProfile op;

--- a/torch_rbln/csrc/rbln/DispatchShim.h
+++ b/torch_rbln/csrc/rbln/DispatchShim.h
@@ -93,14 +93,14 @@ void diag_reset_warm_segments();
 // Returns true if an install actually happened (pending key was valid and
 // accepted). Safe to call when no pending context exists — returns false.
 //
-// `runtime_handle` is rebel's sync-runtime object, whose `prepare_inputs` /
-// `prepare_outputs` / `run` the hit path calls.
+// The three bound methods are the rebel runtime's, resolved by name in
+// `torch_rbln._internal.rebel_contract` — the only place those names are spelled.
 // `out_profiles` is a list of (shape, dtype_str, is_rbln) per output tensor.
 bool install_warmcache_from_pending(
     pybind11::object dyn_runtime,
-    const pybind11::object& runtime_handle,
-    uint32_t num_inputs,
-    uint32_t num_outputs,
+    pybind11::object prepare_inputs,
+    pybind11::object prepare_outputs,
+    pybind11::object run,
     const std::vector<std::tuple<std::vector<int64_t>, std::string, bool>>& out_profiles);
 
 } // namespace torch_rbln::shim

--- a/torch_rbln/csrc/rbln/Module.cpp
+++ b/torch_rbln/csrc/rbln/Module.cpp
@@ -391,10 +391,16 @@ void register_internal_api(py::module_& module) {
       "Internal: install a warm-cache entry from the thread-local pending key "
       "set by the shim on the way into the miss path",
       pybind11::arg("dyn_runtime"),
-      pybind11::arg("runtime_handle"),
-      pybind11::arg("num_inputs"),
-      pybind11::arg("num_outputs"),
+      pybind11::arg("prepare_inputs"),
+      pybind11::arg("prepare_outputs"),
+      pybind11::arg("run"),
       pybind11::arg("out_profiles"));
+
+  module.def(
+      "_warmcache_take_contract_break",
+      []() { return torch_rbln::warmcache::WarmCache::take_contract_break(); },
+      "Internal: true once if a warm-cache hit found rebel's runtime no longer accepts "
+      "the call this build makes; clears the flag");
 
   module.def(
       "_warmcache_set_enabled",

--- a/torch_rbln/csrc/rbln/WarmCache.cpp
+++ b/torch_rbln/csrc/rbln/WarmCache.cpp
@@ -175,4 +175,16 @@ void WarmCache::request_force_recompile() {
   t_force_recompile = true;
 }
 
+namespace {
+std::atomic<bool> g_contract_break{false};
+} // namespace
+
+bool WarmCache::take_contract_break() {
+  return g_contract_break.exchange(false, std::memory_order_relaxed);
+}
+
+void WarmCache::mark_contract_break() {
+  g_contract_break.store(true, std::memory_order_relaxed);
+}
+
 } // namespace torch_rbln::warmcache

--- a/torch_rbln/csrc/rbln/WarmCache.h
+++ b/torch_rbln/csrc/rbln/WarmCache.h
@@ -146,16 +146,13 @@ struct CacheEntry {
   pybind11::object py_dyn_runtime;
 
   // The rebel runtime's bound methods, resolved once at install so a hit pays
-  // a call and not an attribute lookup. Calling by name rather than linking
-  // rebel's C++ symbols keeps torch-rbln off a contract nothing guarantees:
-  // those signatures ship in no header, and adding a parameter renames the
-  // symbol a build would have linked.
+  // a call and not an attribute lookup. They arrive already bound from
+  // ``torch_rbln._internal.rebel_contract``, which declares the names and is
+  // the only place they are spelled; nothing here names a rebel symbol.
   pybind11::object prepare_inputs;
   pybind11::object prepare_outputs;
   pybind11::object run;
 
-  uint32_t num_inputs{0};
-  uint32_t num_outputs{0};
   c10::SmallVector<OutputProfile, 2> out_profiles;
 };
 
@@ -222,6 +219,14 @@ class WarmCache {
   // Python wrapper consumes (and clears) the flag exactly once.
   static bool consume_force_recompile();
   static void request_force_recompile();
+
+  // Contract break: a hit raised TypeError, so rebel's runtime no longer accepts
+  // the call this build makes. Recompiling cannot fix that, so ``find`` is shut
+  // off for the process rather than erasing and rebuilding an entry whose every
+  // hit would fail the same way. Process-global, consumed once by the Python
+  // install path, which reports which rebel names diverged.
+  static bool take_contract_break();
+  static void mark_contract_break();
 
  private:
   WarmCache() = default;

--- a/torch_rbln/device/context_holder.py
+++ b/torch_rbln/device/context_holder.py
@@ -1,9 +1,9 @@
 from contextlib import contextmanager
 
-from rebel.core.torch_eager import eager_execution_helper
+from torch_rbln._internal import rebel_contract
 
 
-helper = eager_execution_helper()
+helper = rebel_contract.eager_execution_helper()
 
 
 @contextmanager


### PR DESCRIPTION
## Summary of Changes

torch-rbln reaches rebel-compiler two ways. The C surface is declared in `rebel/runtime/api/rbln_runtime_api.h`, version-gated by `rbln_abi.h`, recorded at build time by `FindRebel.cmake` and checked against the loaded `librbln.so` at import. The Python surface was declared nowhere: the names were spelled at each call site, in two languages, and a rebel-side rename arrived as an ImportError, as an arch reported `"unknown"`, or as a warm cache that quietly stopped serving.

`torch_rbln/_internal/rebel_contract.py` is that declaration — the eight rebel attributes torch-rbln reaches for and the positional parameters it passes — and it is the only module under `torch_rbln/` that imports rebel. What changes:

| rebel change | before | after |
| --- | --- | --- |
| a name is renamed | nothing; the warm cache silently stops serving | configure warns, contract test fails |
| a parameter gains a default | the call silently takes rebel's default | configure warns; torch-rbln chooses when to follow |
| a parameter becomes required | a compile per dispatch, forever | the fast path stops and names what diverged |

**rebel is not held up by any of it.** Nothing was added to `test/rbln`, which is the only directory rebel's CI runs, and nothing fails a build: both divergence kinds are `message(WARNING)`.

Three commits: the declaration and the chokepoint; the warm cache reaching rebel only through it; the reporting.

**Also:** no rebel name is spelled in C++ any more — `install_pending` resolves the three bound methods in Python and passes them down. `num_inputs` / `num_outputs` went with it: stored on the cache entry, read nowhere, and they carried a dependency on two more rebel private attributes.

**Layer:** torch-rbln only. No rebel-compiler change, no pin move, no ABI bump.

## Non-goals

This declares rebel's Python *attribute* surface. Three dependencies stay where they are, and calling this "the rebel contract in one place" would be wrong without saying so:

* the packaging layout in `rbln_runtime_lib.py` (the `rebel-compiler` distribution name, its RECORD entries, the `librbln.so` basename) — load-bearing at both cmake configure and import;
* the env-var names in `rdma_env.py` (`RBLN_LOCAL_IP`, `RBLN_ROOT_IP`);
* `_runtime_handle` and the `_runtime_holder` compile option, declared as constants but per-instance, so `verify()` cannot reach them. The warm-cache hit-path test is what covers them.

Not addressed either: the hit path still does not wrap the two prepares in `begin_io_patch_batch` / `end_io_patch_batch`, and `prepare_inputs`' `stale` parameter is still taken at rebel's default. Both predate this PR; the second is now reported when the pin crosses `rebel_compiler#13059` instead of passing silently.

## Related Issues / Tickets

* Resolves rebellions-sw/torch-rbln-internal#44
* Related to RBLN-SW/torch-rbln#214

Stacked on rebellions-sw/fsw-inference#214; base is `chan/warmcache-pybind-call`.

## Type of Change

- [x] `core` — Changes to RBLN backend, device layer, C++ extension, op registration, or `torch.compile` integration

## Affected Modules

- [x] Backend
- [x] C++ extension (`torch_rbln/csrc`)
- [x] Build/Tools

## How to Test

1. `uv run --no-sync pytest test/internal/test_rebel_contract.py test/internal/test_warm_cache_internals.py`
2. Verify the contract holds against the installed rebel and that the verifier tells BROKEN from DRIFTED against a fabricated module.
3. Edge case: add `from rebel.device_info import get_npu_name` to any file under `torch_rbln/` — `lintrunner` must fail with TID251. Reverting it must make lint pass.

## Verification

| Command | Result |
| --- | --- |
| `uv run --no-sync lintrunner -m origin/dev` | no findings |
| `uv run --no-sync python test/run_tests.py --suite=core` | 4232 passed, 29 skipped, 3 xfailed, 0 failed |
| `uv run --no-sync pytest test/internal/ test/rbln/test_dispatch_shim_precheck.py test/rbln/test_warm_cache_view_on_device.py` | 118 passed |

Built with `CC=gcc-13`, rebel-compiler 0.11.3.dev0, torch 2.11.0. The contract also verifies clean against rebel-compiler 0.11.1.post1.

## Notes

**Performance.** The hit path is unchanged from rebellions-sw/fsw-inference#214, so the prepare-segment cost measured there stands and is not recovered here.

**Why the check does not run at import.** Verifying imports rebel submodules, and rebel's own import reaches `import torch`, which autoloads torch_rbln. Checking there re-enters a half-initialized rebel: `import rebel` — the entry order optimum-rbln and vllm-rbln use — reported a BROKEN that was not one. The report lives at configure time and in `python -m torch_rbln.diagnose` instead.

**The circuit breaker is process-wide and one-way.** A `TypeError` from inside rebel's runtime body, rather than from pybind's argument binding, would disable the fast path for the process. rebel's own input validation throws `std::runtime_error`, so `TypeError` reaching us today means the call shape no longer fits; the worst case if that ever changes is the slower path, which is why it is drawn this way.

**A test that guards a failure mode rather than a feature.** `TestWarmCacheContractBreak` asserts that a rejected call keeps values correct, stops counting hits, disables the cache rather than retrying, and surfaces the reason. The retry case is the one this PR changes; the others were true before and are asserted so they stay true.
