### PR TITLE
fix(core): locate librbln.so from what an editable install states about itself

### DIFF
--- a/test/rbln/test_rbln_runtime_lib.py
+++ b/test/rbln/test_rbln_runtime_lib.py
@@ -7,20 +7,35 @@ decides, with LD_LIBRARY_PATH as the one override, and that nothing guesses at a
 of that record.
 """
 
-import json
 import os
 import shutil
 import sys
 import tempfile
 import types
-from contextlib import ExitStack
-from importlib.metadata import PackageNotFoundError
+import unittest
+from importlib.metadata import distribution, PackageNotFoundError
 from unittest.mock import patch
 
 import pytest
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 from torch_rbln._internal import rbln_runtime_lib
+
+
+def _compiler_is_installed() -> bool:
+    """Whether this environment has a rebel-compiler distribution for the resolver to find.
+
+    The rest of this file synthesizes what it needs, so it runs on a host with no compiler and no
+    device. Only the checks against the real install depend on one.
+    """
+    try:
+        distribution("rebel-compiler")
+    except PackageNotFoundError:
+        return False
+    return True
+
+
+_NEEDS_COMPILER = unittest.skipUnless(_compiler_is_installed(), "needs an installed rebel-compiler")
 
 
 def _record(name: str, located: str):
@@ -33,55 +48,15 @@ def _record(name: str, located: str):
     return _Entry(name)
 
 
-def _dist(direct_url: str | None = None, files: list | None = None):
-    """A stand-in for the installed distribution, carrying only what the resolver reads."""
-
-    class _Dist:
-        def __init__(self):
-            self.files = files or []
-
-        def read_text(self, name: str) -> str | None:
-            return direct_url if name == "direct_url.json" else None
-
-    return _Dist()
-
-
-def _editable_url(source_root: str) -> str:
-    """What an installer writes to direct_url.json for `pip/uv install -e <source_root>`."""
-    return json.dumps({"url": f"file://{source_root}", "dir_info": {"editable": True}})
-
-
-class _ImportHook:
-    """A redirecting editable install's finder, holding the map of files its build installed."""
-
-    def __init__(self, directory: str, known_wheel_files: dict):
-        self.dir = directory
-        self.known_wheel_files = known_wheel_files
-
-    def find_spec(self, fullname, path=None, target=None):  # noqa: ARG002
-        return None
-
-
 @pytest.mark.test_set_ci
 class TestRblnRuntimeLibResolve(TestCase):
     """Resolution order for librbln.so."""
 
-    def _isolated_resolution(self, *, keep_import_hook: bool = False, keep_editable_root: bool = False, **overrides):
-        """Blank every channel except the one under test.
-
-        The two channels an editable install answers on read live interpreter state and sit ahead of
-        the record, so on a machine with an editable rebel-compiler they answer before the layout
-        the test built.
-        """
+    def _isolated_env(self, **overrides: str):
+        """Blank the environment overrides so only the candidate under test can match."""
         env = dict.fromkeys(("LD_LIBRARY_PATH",), "")
         env.update(overrides)
-        stack = ExitStack()
-        stack.enter_context(patch.dict(os.environ, env, clear=False))
-        if not keep_import_hook:
-            stack.enter_context(patch.object(rbln_runtime_lib, "_import_hook_libraries", side_effect=lambda: iter(())))
-        if not keep_editable_root:
-            stack.enter_context(patch.object(rbln_runtime_lib, "_editable_source_root", return_value=None))
-        return stack
+        return patch.dict(os.environ, env, clear=False)
 
     def _make_root(self) -> str:
         """A throwaway directory to build a layout under."""
@@ -101,6 +76,7 @@ class TestRblnRuntimeLibResolve(TestCase):
             pass
         return path
 
+    @_NEEDS_COMPILER
     def test_resolves_to_an_existing_library(self):
         path, source = rbln_runtime_lib.resolve_runtime_library()
         self.assertTrue(os.path.isfile(path), f"{path} (from {source}) does not exist")
@@ -109,7 +85,7 @@ class TestRblnRuntimeLibResolve(TestCase):
         # The only override, and the one the dynamic loader and rebel-compiler honour too, so all
         # three sides land on the same file.
         override = self._make_lib("custom", "librbln.so")
-        with self._isolated_resolution(LD_LIBRARY_PATH=os.path.dirname(override)):
+        with self._isolated_env(LD_LIBRARY_PATH=os.path.dirname(override)):
             path, source = rbln_runtime_lib.resolve_runtime_library()
         self.assertEqual(path, os.path.realpath(override))
         self.assertEqual(source, "LD_LIBRARY_PATH")
@@ -122,7 +98,7 @@ class TestRblnRuntimeLibResolve(TestCase):
         installed = self._make_lib("site-packages", "custom", "librbln.so")
         anchor = os.path.dirname(os.path.dirname(imported))
         with (
-            self._isolated_resolution(),
+            self._isolated_env(),
             patch.object(rbln_runtime_lib, "_rebel_package_anchors", return_value=[anchor]),
             patch.object(
                 rbln_runtime_lib,
@@ -140,7 +116,7 @@ class TestRblnRuntimeLibResolve(TestCase):
         library = self._make_lib("somewhere", "new_home", "librbln.so")
         anchor = os.path.dirname(os.path.dirname(library))
         with (
-            self._isolated_resolution(),
+            self._isolated_env(),
             patch.object(rbln_runtime_lib, "_rebel_package_anchors", return_value=[anchor]),
             patch.object(
                 rbln_runtime_lib,
@@ -155,14 +131,15 @@ class TestRblnRuntimeLibResolve(TestCase):
     def test_a_leftover_build_tree_does_not_outrank_the_record(self):
         # A source checkout that was built once keeps <src>/build/librbln.so around forever, so it
         # answers only when the record does not -- otherwise it shadows a distribution that names
-        # the file exactly.
+        # the file exactly. The distribution installed the package in use here, so its record
+        # speaks for it.
         root = self._make_root()
         stale = self._make_lib("build", "librbln.so", root=root)
         shipped = self._make_lib("site", "new_home", "librbln.so", root=root)
-        anchor = os.path.join(root, "python")
+        anchor = os.path.join(root, "site")
         self.assertTrue(os.path.isfile(stale), "the leftover build tree must exist to compete")
         with (
-            self._isolated_resolution(),
+            self._isolated_env(),
             patch.object(rbln_runtime_lib, "_rebel_package_anchors", return_value=[anchor]),
             patch.object(
                 rbln_runtime_lib,
@@ -173,13 +150,35 @@ class TestRblnRuntimeLibResolve(TestCase):
             path, _ = rbln_runtime_lib.resolve_runtime_library()
         self.assertEqual(path, shipped)
 
+    def test_a_record_from_another_tree_does_not_answer_for_the_imported_package(self):
+        # A wheel installed in site-packages while a checkout on PYTHONPATH provides the package:
+        # the recorded library belongs to the wheel's Python, and rebel-compiler loads the one
+        # beside its own files -- the checkout's. Taking the recorded one maps both.
+        root = self._make_root()
+        checkout_build = self._make_lib("checkout", "build", "librbln.so", root=root)
+        installed = self._make_lib("site-packages", "shipped", "librbln.so", root=root)
+        anchor = os.path.join(root, "checkout", "python")
+        self.assertTrue(os.path.isfile(installed), "the installed library must exist to compete")
+        with (
+            self._isolated_env(),
+            patch.object(rbln_runtime_lib, "_rebel_package_anchors", return_value=[anchor]),
+            patch.object(
+                rbln_runtime_lib,
+                "_record_entries",
+                return_value=[_record("shipped/librbln.so", installed)],
+            ),
+        ):
+            path, source = rbln_runtime_lib.resolve_runtime_library()
+        self.assertEqual(path, checkout_build)
+        self.assertEqual(source, "rebel source build tree")
+
     def test_an_editable_install_falls_back_to_the_build_tree(self):
         # pip install -e <src>/python: the package is <src>/python/rebel, the library <src>/build,
         # and the distribution records neither.
         library = self._make_lib("build", "librbln.so")
         source_root = os.path.dirname(os.path.dirname(library))
         with (
-            self._isolated_resolution(),
+            self._isolated_env(),
             patch.object(
                 rbln_runtime_lib, "_rebel_package_anchors", return_value=[os.path.join(source_root, "python")]
             ),
@@ -189,9 +188,51 @@ class TestRblnRuntimeLibResolve(TestCase):
         self.assertEqual(path, library)
         self.assertEqual(source, "rebel source build tree")
 
+    def test_the_origin_decides_which_tree_provides_the_library(self):
+        # An editable install reports its search locations out of a set holding both the source
+        # tree and the build tree, so their order changes from process to process. ``origin`` names
+        # the __init__.py that will run: one value, and the tree rebel-compiler loads beside.
+        # Both trees hold a library, and the one that does not provide rebel sorts first, so an
+        # order-based choice picks the wrong file rather than merely trying it.
+        root = self._make_root()
+        library = self._make_lib("checkout", "build", "librbln.so", root=root)
+        elsewhere = self._make_lib("another", "build", "librbln.so", root=root)
+        package = os.path.join(root, "checkout", "python", "rebel")
+        staging = os.path.join(root, "another", "python", "rebel")
+        self.assertTrue(os.path.isfile(elsewhere), "the other tree's library must exist to compete")
+        for locations in ([package, staging], [staging, package]):
+            spec = types.SimpleNamespace(
+                origin=os.path.join(package, "__init__.py"), submodule_search_locations=locations
+            )
+            with (
+                self._isolated_env(),
+                patch.object(rbln_runtime_lib.importlib.util, "find_spec", return_value=spec),
+                patch.object(rbln_runtime_lib, "_record_entries", return_value=[]),
+            ):
+                path, source = rbln_runtime_lib.resolve_runtime_library()
+            self.assertEqual(path, library, f"locations in the order {locations} resolved elsewhere")
+            self.assertEqual(source, "rebel source build tree")
+
+    def test_the_search_locations_answer_when_there_is_no_origin(self):
+        # A directory an uninstall left behind imports as a namespace package: no origin, and the
+        # search locations are all there is to go on.
+        root = self._make_root()
+        library = self._make_lib("checkout", "build", "librbln.so", root=root)
+        spec = types.SimpleNamespace(
+            origin=None, submodule_search_locations=[os.path.join(root, "checkout", "python", "rebel")]
+        )
+        with (
+            self._isolated_env(),
+            patch.object(rbln_runtime_lib.importlib.util, "find_spec", return_value=spec),
+            patch.object(rbln_runtime_lib, "_record_entries", return_value=[]),
+        ):
+            path, source = rbln_runtime_lib.resolve_runtime_library()
+        self.assertEqual(path, library)
+        self.assertEqual(source, "rebel source build tree")
+
     def test_missing_library_reports_what_was_tried(self):
         with (
-            self._isolated_resolution(),
+            self._isolated_env(),
             patch.object(rbln_runtime_lib, "_rebel_package_anchors", return_value=["/nonexistent/anchor"]),
             patch.object(rbln_runtime_lib, "_record_entries", return_value=[]),
         ):
@@ -203,133 +244,11 @@ class TestRblnRuntimeLibResolve(TestCase):
         self.assertIn("LD_LIBRARY_PATH", message)
         self.assertIn("python -m torch_rbln.diagnose", message)
 
-    def test_every_search_location_is_tried_whatever_order_they_arrive_in(self):
-        # An editable install reports its search locations out of a set holding both the source
-        # tree and the build tree, so their order changes from process to process. Every one has to
-        # be tried whichever arrives first, or resolution is a coin flip.
-        #
-        # The location that leads nowhere sorts first, so trying only one of them fails here.
-        root = self._make_root()
-        library = self._make_lib("checkout", "build", "librbln.so", root=root)
-        locations = [
-            os.path.join(root, "build_tree", "rebel"),
-            os.path.join(root, "checkout", "python", "rebel"),
-        ]
-        for ordered in (locations, list(reversed(locations))):
-            spec = types.SimpleNamespace(submodule_search_locations=ordered)
-            with (
-                self._isolated_resolution(),
-                patch.object(rbln_runtime_lib.importlib.util, "find_spec", return_value=spec),
-                patch.object(rbln_runtime_lib, "_record_entries", return_value=[]),
-            ):
-                path, source = rbln_runtime_lib.resolve_runtime_library()
-            self.assertEqual(path, library, f"locations in the order {ordered} resolved elsewhere")
-            self.assertEqual(source, "rebel source build tree")
-
-    def test_an_import_hook_names_the_library_outright(self):
-        # A redirecting editable install carries the map of files its build installed, so the
-        # library is named rather than guessed at -- and it outranks the record because that hook
-        # is what `import rebel` goes through.
-        root = self._make_root()
-        library = self._make_lib("staging", "lib", "librbln.so", root=root)
-        recorded = self._make_lib("site-packages", "lib", "librbln.so", root=root)
-        hook = _ImportHook(
-            directory=os.path.join(root, "staging"),
-            known_wheel_files={"lib.librbln": os.path.join("lib", "librbln.so")},
-        )
-        sys.meta_path.insert(0, hook)
-        self.addCleanup(sys.meta_path.remove, hook)
-        with (
-            self._isolated_resolution(keep_import_hook=True),
-            patch.object(rbln_runtime_lib, "_rebel_package_anchors", return_value=[os.path.join(root, "staging")]),
-            patch.object(rbln_runtime_lib, "_record_entries", return_value=[_record("lib/librbln.so", recorded)]),
-        ):
-            path, source = rbln_runtime_lib.resolve_runtime_library()
-        self.assertEqual(path, library)
-        self.assertEqual(source, "editable install import hook")
-
-    def test_an_editable_install_uses_the_directory_it_was_installed_from(self):
-        # PEP 610 records the checkout an editable install points at, which is the only exact
-        # statement of where it lives: rebel-compiler installs from <source>/python and builds into
-        # <source>/build, and the record names no library to go by.
-        root = self._make_root()
-        library = self._make_lib("build", "librbln.so", root=root)
-        with (
-            self._isolated_resolution(keep_editable_root=True),
-            patch.object(
-                rbln_runtime_lib,
-                "distribution",
-                return_value=_dist(_editable_url(os.path.join(root, "python"))),
-            ),
-            patch.object(rbln_runtime_lib, "_rebel_package_anchors", return_value=[]),
-        ):
-            path, source = rbln_runtime_lib.resolve_runtime_library()
-        self.assertEqual(path, library)
-        self.assertEqual(source, "editable install source tree")
-
-    def test_a_hook_from_another_checkout_does_not_outrank_the_record(self):
-        # A redirecting install of another project can carry a library of this name from its own
-        # build tree. Taking it pairs this interpreter's rebel with a runtime built elsewhere.
-        root = self._make_root()
-        foreign = self._make_lib("elsewhere", "lib", "librbln.so", root=root)
-        recorded = self._make_lib("site-packages", "lib", "librbln.so", root=root)
-        hook = _ImportHook(
-            directory=os.path.join(root, "elsewhere"),
-            known_wheel_files={"lib.librbln": os.path.join("lib", "librbln.so")},
-        )
-        sys.meta_path.insert(0, hook)
-        self.addCleanup(sys.meta_path.remove, hook)
-        self.assertTrue(os.path.isfile(foreign), "the foreign library must exist to compete")
-        with (
-            self._isolated_resolution(keep_import_hook=True),
-            patch.object(
-                rbln_runtime_lib, "_rebel_package_anchors", return_value=[os.path.join(root, "site-packages")]
-            ),
-            patch.object(rbln_runtime_lib, "_record_entries", return_value=[_record("lib/librbln.so", recorded)]),
-        ):
-            path, source = rbln_runtime_lib.resolve_runtime_library()
-        self.assertEqual(path, recorded)
-        self.assertIn("record", source)
-
-    def test_a_recorded_checkout_that_is_not_the_imported_one_does_not_answer(self):
-        # The metadata can name a checkout the package is no longer imported from -- another clone
-        # on PYTHONPATH, or an install left behind. Its build output is a different runtime.
-        root = self._make_root()
-        elsewhere = self._make_lib("checkout_b", "build", "librbln.so", root=root)
-        self.assertTrue(os.path.isfile(elsewhere), "the other checkout's library must exist to compete")
-        with (
-            self._isolated_resolution(keep_editable_root=True),
-            patch.object(
-                rbln_runtime_lib,
-                "distribution",
-                return_value=_dist(_editable_url(os.path.join(root, "checkout_b", "python"))),
-            ),
-            patch.object(
-                rbln_runtime_lib,
-                "_rebel_package_anchors",
-                return_value=[os.path.join(root, "checkout_a", "python")],
-            ),
-            patch.object(rbln_runtime_lib, "_record_entries", return_value=[]),
-        ):
-            with self.assertRaises(FileNotFoundError) as ctx:
-                rbln_runtime_lib.resolve_runtime_library()
-        self.assertNotIn(elsewhere, str(ctx.exception))
-
-    def test_a_non_editable_install_is_not_read_as_a_source_directory(self):
-        # direct_url.json also describes an install from a wheel URL; only the editable flag makes
-        # the recorded directory a checkout to look under.
-        with patch.object(
-            rbln_runtime_lib,
-            "distribution",
-            return_value=_dist(json.dumps({"url": "https://example.invalid/rebel_compiler.whl"})),
-        ):
-            self.assertIsNone(rbln_runtime_lib._editable_source_root())
-
     def test_an_absent_distribution_is_named_as_the_reason(self):
         # With nothing installed there is no candidate to report, and a bare list of paths reads as
         # a path problem. The message has to name the interpreter that is missing the package.
         with (
-            self._isolated_resolution(),
+            self._isolated_env(),
             patch.object(rbln_runtime_lib, "distribution", side_effect=PackageNotFoundError("rebel-compiler")),
             patch.object(rbln_runtime_lib, "_rebel_package_anchors", return_value=["/site-packages"]),
         ):
@@ -364,6 +283,7 @@ class TestRblnRuntimeLibRecord(TestCase):
         ):
             self.assertEqual(rbln_runtime_lib.record_relative_dir(library), os.path.join("rebel", "lib"))
 
+    @_NEEDS_COMPILER
     def test_the_installed_library_is_under_its_recorded_directory(self):
         # The same rule against the real install, at whatever depth it happens to sit.
         library, _ = rbln_runtime_lib.resolve_runtime_library()
@@ -377,6 +297,7 @@ class TestRblnRuntimeLibRecord(TestCase):
     def test_a_library_outside_the_record_has_no_relative_directory(self):
         self.assertIsNone(rbln_runtime_lib.record_relative_dir("/nowhere/librbln.so"))
 
+    @_NEEDS_COMPILER
     def test_the_include_directory_comes_from_a_recorded_header(self):
         include_dir = rbln_runtime_lib.record_include_dir()
         self.assertIsNotNone(include_dir)

--- a/test/rbln/test_rbln_runtime_lib.py
+++ b/test/rbln/test_rbln_runtime_lib.py
@@ -13,6 +13,7 @@ import shutil
 import sys
 import tempfile
 import types
+from contextlib import ExitStack
 from importlib.metadata import PackageNotFoundError
 from unittest.mock import patch
 
@@ -65,11 +66,22 @@ class _ImportHook:
 class TestRblnRuntimeLibResolve(TestCase):
     """Resolution order for librbln.so."""
 
-    def _isolated_env(self, **overrides: str):
-        """Blank the environment overrides so only the candidate under test can match."""
+    def _isolated_resolution(self, *, keep_import_hook: bool = False, keep_editable_root: bool = False, **overrides):
+        """Blank every channel except the one under test.
+
+        The two channels an editable install answers on read live interpreter state and sit ahead of
+        the record, so on a machine with an editable rebel-compiler they answer before the layout
+        the test built.
+        """
         env = dict.fromkeys(("LD_LIBRARY_PATH",), "")
         env.update(overrides)
-        return patch.dict(os.environ, env, clear=False)
+        stack = ExitStack()
+        stack.enter_context(patch.dict(os.environ, env, clear=False))
+        if not keep_import_hook:
+            stack.enter_context(patch.object(rbln_runtime_lib, "_import_hook_libraries", side_effect=lambda: iter(())))
+        if not keep_editable_root:
+            stack.enter_context(patch.object(rbln_runtime_lib, "_editable_source_root", return_value=None))
+        return stack
 
     def _make_root(self) -> str:
         """A throwaway directory to build a layout under."""
@@ -97,7 +109,7 @@ class TestRblnRuntimeLibResolve(TestCase):
         # The only override, and the one the dynamic loader and rebel-compiler honour too, so all
         # three sides land on the same file.
         override = self._make_lib("custom", "librbln.so")
-        with self._isolated_env(LD_LIBRARY_PATH=os.path.dirname(override)):
+        with self._isolated_resolution(LD_LIBRARY_PATH=os.path.dirname(override)):
             path, source = rbln_runtime_lib.resolve_runtime_library()
         self.assertEqual(path, os.path.realpath(override))
         self.assertEqual(source, "LD_LIBRARY_PATH")
@@ -110,7 +122,7 @@ class TestRblnRuntimeLibResolve(TestCase):
         installed = self._make_lib("site-packages", "custom", "librbln.so")
         anchor = os.path.dirname(os.path.dirname(imported))
         with (
-            self._isolated_env(),
+            self._isolated_resolution(),
             patch.object(rbln_runtime_lib, "_rebel_package_anchors", return_value=[anchor]),
             patch.object(
                 rbln_runtime_lib,
@@ -128,7 +140,7 @@ class TestRblnRuntimeLibResolve(TestCase):
         library = self._make_lib("somewhere", "new_home", "librbln.so")
         anchor = os.path.dirname(os.path.dirname(library))
         with (
-            self._isolated_env(),
+            self._isolated_resolution(),
             patch.object(rbln_runtime_lib, "_rebel_package_anchors", return_value=[anchor]),
             patch.object(
                 rbln_runtime_lib,
@@ -150,7 +162,7 @@ class TestRblnRuntimeLibResolve(TestCase):
         anchor = os.path.join(root, "python")
         self.assertTrue(os.path.isfile(stale), "the leftover build tree must exist to compete")
         with (
-            self._isolated_env(),
+            self._isolated_resolution(),
             patch.object(rbln_runtime_lib, "_rebel_package_anchors", return_value=[anchor]),
             patch.object(
                 rbln_runtime_lib,
@@ -167,7 +179,7 @@ class TestRblnRuntimeLibResolve(TestCase):
         library = self._make_lib("build", "librbln.so")
         source_root = os.path.dirname(os.path.dirname(library))
         with (
-            self._isolated_env(),
+            self._isolated_resolution(),
             patch.object(
                 rbln_runtime_lib, "_rebel_package_anchors", return_value=[os.path.join(source_root, "python")]
             ),
@@ -179,7 +191,7 @@ class TestRblnRuntimeLibResolve(TestCase):
 
     def test_missing_library_reports_what_was_tried(self):
         with (
-            self._isolated_env(),
+            self._isolated_resolution(),
             patch.object(rbln_runtime_lib, "_rebel_package_anchors", return_value=["/nonexistent/anchor"]),
             patch.object(rbln_runtime_lib, "_record_entries", return_value=[]),
         ):
@@ -206,7 +218,7 @@ class TestRblnRuntimeLibResolve(TestCase):
         for ordered in (locations, list(reversed(locations))):
             spec = types.SimpleNamespace(submodule_search_locations=ordered)
             with (
-                self._isolated_env(),
+                self._isolated_resolution(),
                 patch.object(rbln_runtime_lib.importlib.util, "find_spec", return_value=spec),
                 patch.object(rbln_runtime_lib, "_record_entries", return_value=[]),
             ):
@@ -228,7 +240,8 @@ class TestRblnRuntimeLibResolve(TestCase):
         sys.meta_path.insert(0, hook)
         self.addCleanup(sys.meta_path.remove, hook)
         with (
-            self._isolated_env(),
+            self._isolated_resolution(keep_import_hook=True),
+            patch.object(rbln_runtime_lib, "_rebel_package_anchors", return_value=[os.path.join(root, "staging")]),
             patch.object(rbln_runtime_lib, "_record_entries", return_value=[_record("lib/librbln.so", recorded)]),
         ):
             path, source = rbln_runtime_lib.resolve_runtime_library()
@@ -242,7 +255,7 @@ class TestRblnRuntimeLibResolve(TestCase):
         root = self._make_root()
         library = self._make_lib("build", "librbln.so", root=root)
         with (
-            self._isolated_env(),
+            self._isolated_resolution(keep_editable_root=True),
             patch.object(
                 rbln_runtime_lib,
                 "distribution",
@@ -253,6 +266,54 @@ class TestRblnRuntimeLibResolve(TestCase):
             path, source = rbln_runtime_lib.resolve_runtime_library()
         self.assertEqual(path, library)
         self.assertEqual(source, "editable install source tree")
+
+    def test_a_hook_from_another_checkout_does_not_outrank_the_record(self):
+        # A redirecting install of another project can carry a library of this name from its own
+        # build tree. Taking it pairs this interpreter's rebel with a runtime built elsewhere.
+        root = self._make_root()
+        foreign = self._make_lib("elsewhere", "lib", "librbln.so", root=root)
+        recorded = self._make_lib("site-packages", "lib", "librbln.so", root=root)
+        hook = _ImportHook(
+            directory=os.path.join(root, "elsewhere"),
+            known_wheel_files={"lib.librbln": os.path.join("lib", "librbln.so")},
+        )
+        sys.meta_path.insert(0, hook)
+        self.addCleanup(sys.meta_path.remove, hook)
+        self.assertTrue(os.path.isfile(foreign), "the foreign library must exist to compete")
+        with (
+            self._isolated_resolution(keep_import_hook=True),
+            patch.object(
+                rbln_runtime_lib, "_rebel_package_anchors", return_value=[os.path.join(root, "site-packages")]
+            ),
+            patch.object(rbln_runtime_lib, "_record_entries", return_value=[_record("lib/librbln.so", recorded)]),
+        ):
+            path, source = rbln_runtime_lib.resolve_runtime_library()
+        self.assertEqual(path, recorded)
+        self.assertIn("record", source)
+
+    def test_a_recorded_checkout_that_is_not_the_imported_one_does_not_answer(self):
+        # The metadata can name a checkout the package is no longer imported from -- another clone
+        # on PYTHONPATH, or an install left behind. Its build output is a different runtime.
+        root = self._make_root()
+        elsewhere = self._make_lib("checkout_b", "build", "librbln.so", root=root)
+        self.assertTrue(os.path.isfile(elsewhere), "the other checkout's library must exist to compete")
+        with (
+            self._isolated_resolution(keep_editable_root=True),
+            patch.object(
+                rbln_runtime_lib,
+                "distribution",
+                return_value=_dist(_editable_url(os.path.join(root, "checkout_b", "python"))),
+            ),
+            patch.object(
+                rbln_runtime_lib,
+                "_rebel_package_anchors",
+                return_value=[os.path.join(root, "checkout_a", "python")],
+            ),
+            patch.object(rbln_runtime_lib, "_record_entries", return_value=[]),
+        ):
+            with self.assertRaises(FileNotFoundError) as ctx:
+                rbln_runtime_lib.resolve_runtime_library()
+        self.assertNotIn(elsewhere, str(ctx.exception))
 
     def test_a_non_editable_install_is_not_read_as_a_source_directory(self):
         # direct_url.json also describes an install from a wheel URL; only the editable flag makes
@@ -268,7 +329,7 @@ class TestRblnRuntimeLibResolve(TestCase):
         # With nothing installed there is no candidate to report, and a bare list of paths reads as
         # a path problem. The message has to name the interpreter that is missing the package.
         with (
-            self._isolated_env(),
+            self._isolated_resolution(),
             patch.object(rbln_runtime_lib, "distribution", side_effect=PackageNotFoundError("rebel-compiler")),
             patch.object(rbln_runtime_lib, "_rebel_package_anchors", return_value=["/site-packages"]),
         ):

--- a/test/rbln/test_rbln_runtime_lib.py
+++ b/test/rbln/test_rbln_runtime_lib.py
@@ -193,13 +193,15 @@ class TestRblnRuntimeLibResolve(TestCase):
 
     def test_every_search_location_is_tried_whatever_order_they_arrive_in(self):
         # An editable install reports its search locations out of a set holding both the source
-        # tree and the build tree, so their order changes from process to process. Both orders have
-        # to reach the same library, or resolution is a coin flip.
+        # tree and the build tree, so their order changes from process to process. Every one has to
+        # be tried whichever arrives first, or resolution is a coin flip.
+        #
+        # The location that leads nowhere sorts first, so trying only one of them fails here.
         root = self._make_root()
-        library = self._make_lib("build", "librbln.so", root=root)
+        library = self._make_lib("checkout", "build", "librbln.so", root=root)
         locations = [
-            os.path.join(root, "python", "rebel"),
-            os.path.join(root, "python", "build", "skbuild", "rebel"),
+            os.path.join(root, "build_tree", "rebel"),
+            os.path.join(root, "checkout", "python", "rebel"),
         ]
         for ordered in (locations, list(reversed(locations))):
             spec = types.SimpleNamespace(submodule_search_locations=ordered)

--- a/test/rbln/test_rbln_runtime_lib.py
+++ b/test/rbln/test_rbln_runtime_lib.py
@@ -17,7 +17,6 @@ from importlib.metadata import PackageNotFoundError
 from unittest.mock import patch
 
 import pytest
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 from torch_rbln._internal import rbln_runtime_lib
@@ -340,10 +339,6 @@ class TestRblnRuntimeLibAdopt(TestCase):
         ):
             self.assertEqual(rbln_runtime_lib.load_runtime_library(), "/opt/rebel/librbln.so")
 
-
-instantiate_device_type_tests(TestRblnRuntimeLibResolve, globals(), only_for="privateuse1")
-instantiate_device_type_tests(TestRblnRuntimeLibRecord, globals(), only_for="privateuse1")
-instantiate_device_type_tests(TestRblnRuntimeLibAdopt, globals(), only_for="privateuse1")
 
 if __name__ == "__main__":
     run_tests()

--- a/test/rbln/test_rbln_runtime_lib.py
+++ b/test/rbln/test_rbln_runtime_lib.py
@@ -7,9 +7,13 @@ decides, with LD_LIBRARY_PATH as the one override, and that nothing guesses at a
 of that record.
 """
 
+import json
 import os
 import shutil
+import sys
 import tempfile
+import types
+from importlib.metadata import PackageNotFoundError
 from unittest.mock import patch
 
 import pytest
@@ -27,6 +31,35 @@ def _record(name: str, located: str):
             return located
 
     return _Entry(name)
+
+
+def _dist(direct_url: str | None = None, files: list | None = None):
+    """A stand-in for the installed distribution, carrying only what the resolver reads."""
+
+    class _Dist:
+        def __init__(self):
+            self.files = files or []
+
+        def read_text(self, name: str) -> str | None:
+            return direct_url if name == "direct_url.json" else None
+
+    return _Dist()
+
+
+def _editable_url(source_root: str) -> str:
+    """What an installer writes to direct_url.json for `pip/uv install -e <source_root>`."""
+    return json.dumps({"url": f"file://{source_root}", "dir_info": {"editable": True}})
+
+
+class _ImportHook:
+    """A redirecting editable install's finder, holding the map of files its build installed."""
+
+    def __init__(self, directory: str, known_wheel_files: dict):
+        self.dir = directory
+        self.known_wheel_files = known_wheel_files
+
+    def find_spec(self, fullname, path=None, target=None):  # noqa: ARG002
+        return None
 
 
 @pytest.mark.test_set_ci
@@ -79,7 +112,7 @@ class TestRblnRuntimeLibResolve(TestCase):
         anchor = os.path.dirname(os.path.dirname(imported))
         with (
             self._isolated_env(),
-            patch.object(rbln_runtime_lib, "_rebel_package_anchor", return_value=anchor),
+            patch.object(rbln_runtime_lib, "_rebel_package_anchors", return_value=[anchor]),
             patch.object(
                 rbln_runtime_lib,
                 "_record_entries",
@@ -97,7 +130,7 @@ class TestRblnRuntimeLibResolve(TestCase):
         anchor = os.path.dirname(os.path.dirname(library))
         with (
             self._isolated_env(),
-            patch.object(rbln_runtime_lib, "_rebel_package_anchor", return_value=anchor),
+            patch.object(rbln_runtime_lib, "_rebel_package_anchors", return_value=[anchor]),
             patch.object(
                 rbln_runtime_lib,
                 "_record_entries",
@@ -119,7 +152,7 @@ class TestRblnRuntimeLibResolve(TestCase):
         self.assertTrue(os.path.isfile(stale), "the leftover build tree must exist to compete")
         with (
             self._isolated_env(),
-            patch.object(rbln_runtime_lib, "_rebel_package_anchor", return_value=anchor),
+            patch.object(rbln_runtime_lib, "_rebel_package_anchors", return_value=[anchor]),
             patch.object(
                 rbln_runtime_lib,
                 "_record_entries",
@@ -136,7 +169,9 @@ class TestRblnRuntimeLibResolve(TestCase):
         source_root = os.path.dirname(os.path.dirname(library))
         with (
             self._isolated_env(),
-            patch.object(rbln_runtime_lib, "_rebel_package_anchor", return_value=os.path.join(source_root, "python")),
+            patch.object(
+                rbln_runtime_lib, "_rebel_package_anchors", return_value=[os.path.join(source_root, "python")]
+            ),
             patch.object(rbln_runtime_lib, "_record_entries", return_value=[]),
         ):
             path, source = rbln_runtime_lib.resolve_runtime_library()
@@ -146,7 +181,7 @@ class TestRblnRuntimeLibResolve(TestCase):
     def test_missing_library_reports_what_was_tried(self):
         with (
             self._isolated_env(),
-            patch.object(rbln_runtime_lib, "_rebel_package_anchor", return_value="/nonexistent/anchor"),
+            patch.object(rbln_runtime_lib, "_rebel_package_anchors", return_value=["/nonexistent/anchor"]),
             patch.object(rbln_runtime_lib, "_record_entries", return_value=[]),
         ):
             with self.assertRaises(FileNotFoundError) as ctx:
@@ -156,6 +191,92 @@ class TestRblnRuntimeLibResolve(TestCase):
         self.assertIn("/nonexistent/build/librbln.so (from rebel source build tree)", message)
         self.assertIn("LD_LIBRARY_PATH", message)
         self.assertIn("python -m torch_rbln.diagnose", message)
+
+    def test_every_search_location_is_tried_whatever_order_they_arrive_in(self):
+        # An editable install reports its search locations out of a set holding both the source
+        # tree and the build tree, so their order changes from process to process. Both orders have
+        # to reach the same library, or resolution is a coin flip.
+        root = self._make_root()
+        library = self._make_lib("build", "librbln.so", root=root)
+        locations = [
+            os.path.join(root, "python", "rebel"),
+            os.path.join(root, "python", "build", "skbuild", "rebel"),
+        ]
+        for ordered in (locations, list(reversed(locations))):
+            spec = types.SimpleNamespace(submodule_search_locations=ordered)
+            with (
+                self._isolated_env(),
+                patch.object(rbln_runtime_lib.importlib.util, "find_spec", return_value=spec),
+                patch.object(rbln_runtime_lib, "_record_entries", return_value=[]),
+            ):
+                path, source = rbln_runtime_lib.resolve_runtime_library()
+            self.assertEqual(path, library, f"locations in the order {ordered} resolved elsewhere")
+            self.assertEqual(source, "rebel source build tree")
+
+    def test_an_import_hook_names_the_library_outright(self):
+        # A redirecting editable install carries the map of files its build installed, so the
+        # library is named rather than guessed at -- and it outranks the record because that hook
+        # is what `import rebel` goes through.
+        root = self._make_root()
+        library = self._make_lib("staging", "lib", "librbln.so", root=root)
+        recorded = self._make_lib("site-packages", "lib", "librbln.so", root=root)
+        hook = _ImportHook(
+            directory=os.path.join(root, "staging"),
+            known_wheel_files={"lib.librbln": os.path.join("lib", "librbln.so")},
+        )
+        sys.meta_path.insert(0, hook)
+        self.addCleanup(sys.meta_path.remove, hook)
+        with (
+            self._isolated_env(),
+            patch.object(rbln_runtime_lib, "_record_entries", return_value=[_record("lib/librbln.so", recorded)]),
+        ):
+            path, source = rbln_runtime_lib.resolve_runtime_library()
+        self.assertEqual(path, library)
+        self.assertEqual(source, "editable install import hook")
+
+    def test_an_editable_install_uses_the_directory_it_was_installed_from(self):
+        # PEP 610 records the checkout an editable install points at, which is the only exact
+        # statement of where it lives: rebel-compiler installs from <source>/python and builds into
+        # <source>/build, and the record names no library to go by.
+        root = self._make_root()
+        library = self._make_lib("build", "librbln.so", root=root)
+        with (
+            self._isolated_env(),
+            patch.object(
+                rbln_runtime_lib,
+                "distribution",
+                return_value=_dist(_editable_url(os.path.join(root, "python"))),
+            ),
+            patch.object(rbln_runtime_lib, "_rebel_package_anchors", return_value=[]),
+        ):
+            path, source = rbln_runtime_lib.resolve_runtime_library()
+        self.assertEqual(path, library)
+        self.assertEqual(source, "editable install source tree")
+
+    def test_a_non_editable_install_is_not_read_as_a_source_directory(self):
+        # direct_url.json also describes an install from a wheel URL; only the editable flag makes
+        # the recorded directory a checkout to look under.
+        with patch.object(
+            rbln_runtime_lib,
+            "distribution",
+            return_value=_dist(json.dumps({"url": "https://example.invalid/rebel_compiler.whl"})),
+        ):
+            self.assertIsNone(rbln_runtime_lib._editable_source_root())
+
+    def test_an_absent_distribution_is_named_as_the_reason(self):
+        # With nothing installed there is no candidate to report, and a bare list of paths reads as
+        # a path problem. The message has to name the interpreter that is missing the package.
+        with (
+            self._isolated_env(),
+            patch.object(rbln_runtime_lib, "distribution", side_effect=PackageNotFoundError("rebel-compiler")),
+            patch.object(rbln_runtime_lib, "_rebel_package_anchors", return_value=["/site-packages"]),
+        ):
+            with self.assertRaises(FileNotFoundError) as ctx:
+                rbln_runtime_lib.resolve_runtime_library()
+        message = str(ctx.exception)
+        self.assertIn("No rebel-compiler distribution is installed for", message)
+        self.assertIn(sys.executable, message)
+        self.assertIn("/site-packages", message)
 
     def test_empty_path_entries_are_dropped(self):
         # A doubled separator used to resolve to the current working directory.
@@ -172,7 +293,7 @@ class TestRblnRuntimeLibRecord(TestCase):
         # library one level deeper (rebel/lib).
         library = "/fake/site/rebel/lib/librbln.so"
         with (
-            patch.object(rbln_runtime_lib, "_rebel_package_anchor", return_value="/fake/site"),
+            patch.object(rbln_runtime_lib, "_rebel_package_anchors", return_value=["/fake/site"]),
             patch.object(
                 rbln_runtime_lib,
                 "_record_entries",

--- a/torch_rbln/_internal/rbln_runtime_lib.py
+++ b/torch_rbln/_internal/rbln_runtime_lib.py
@@ -5,11 +5,10 @@ The library is the one the ``rebel-compiler`` distribution recorded installing, 
 which is also what the install RPATH is written against, so one record answers where the library
 is, where it sits relative to the package, and where the headers are.
 
-An editable install records no library, so two statements the install itself makes answer instead:
-the import hook it registers names the files the build installed, and ``direct_url.json`` records
-the directory the install came from, whose build output sits where rebel-compiler puts it by
-default. Both are checked against the ``rebel`` package this interpreter imports, so a second
-checkout cannot answer for the one in use.
+Every candidate comes from where that package sits, because rebel-compiler loads the library
+relative to its own files too: a second copy answering here would be mapped alongside the one
+rebel loads, leaving two runtimes -- two allocators, two device registries -- in one process, which
+nothing downstream can detect when both were built from the same version.
 
 ``LD_LIBRARY_PATH`` is the override: the dynamic loader and rebel-compiler's loader both honour
 it, so all three sides land on the same file.
@@ -20,7 +19,6 @@ before torch_rbln exists, so anything it reaches for has to work then too.
 
 import ctypes
 import importlib.util
-import json
 import os
 import sys
 from collections.abc import Iterator
@@ -33,10 +31,6 @@ _COMPILER_DIST_NAME = "rebel-compiler"
 _MAPS_PATH = "/proc/self/maps"
 _DELETED_SUFFIX = " (deleted)"
 
-# PEP 610: what an installer records about where it installed a distribution from.
-_DIRECT_URL_FILE = "direct_url.json"
-_FILE_URL_PREFIX = "file://"
-
 # The distribution's record of what it installed
 
 
@@ -47,23 +41,31 @@ def _split_env_paths(name: str) -> list[str]:
 
 
 def _rebel_package_anchors() -> list[str]:
-    """Directories holding the ``rebel`` package this interpreter would import.
+    """Directories holding the ``rebel`` package this interpreter would import, first one first.
 
     ``find_spec`` because importing rebel pulls in torch. Anchoring on the imported package keeps
     an editable install, or a stray copy elsewhere, from answering for the one in use.
 
-    Every location, sorted, rather than the first one: an editable install reports its search
-    locations from a set holding both the source tree and the build tree, so which one comes first
-    changes from process to process and taking one of them made resolution a coin flip.
+    ``origin`` leads: it names the ``__init__.py`` that will run, so it says which tree provides
+    rebel even when several are on the path. The search locations follow only when there is no
+    origin -- a namespace package, which a directory left behind by an uninstall also produces.
+    They arrive from a set for an editable install, holding both the source tree and the build
+    tree, so their order changes from process to process and taking one of them was a coin flip.
     """
     try:
         spec = importlib.util.find_spec("rebel")
     except (ImportError, ValueError):
         return []
-    locations = getattr(spec, "submodule_search_locations", None) if spec else None
-    if not locations:
+    if spec is None:
         return []
-    return sorted({os.path.dirname(location) for location in locations})
+    anchors = []
+    if spec.origin:
+        anchors.append(os.path.dirname(os.path.dirname(spec.origin)))
+    for location in sorted(spec.submodule_search_locations or ()):
+        directory = os.path.dirname(location)
+        if directory not in anchors:
+            anchors.append(directory)
+    return anchors
 
 
 def _dist_files() -> list:
@@ -81,12 +83,30 @@ def _record_entries() -> list:
 
 
 def _record_candidates(entry: object, anchors: list[str]) -> Iterator[str]:
-    """Both ways a recorded entry can name a file: under an anchor, and where it was installed."""
+    """Both ways a recorded entry can name a file: under an anchor, and where it was installed.
+
+    Where it was installed counts only when that is the tree the imported package comes from. A
+    distribution recorded elsewhere -- a wheel installed in site-packages while a checkout on
+    PYTHONPATH provides the package -- names the library belonging to its own Python, and
+    rebel-compiler will load that checkout's library rather than this one.
+    """
     for anchor in anchors:
         yield os.path.join(anchor, str(entry))
     located = entry.locate()  # type: ignore[attr-defined]
-    if located is not None:
+    if located is not None and _inside_an_anchor(str(located), anchors):
         yield str(located)
+
+
+def _inside_an_anchor(path: str, anchors: list[str]) -> bool:
+    """Whether ``path`` sits in a directory the ``rebel`` package is installed in.
+
+    No anchor at all -- nothing imports rebel -- leaves a candidate standing: it is then the only
+    statement anything has made about where the library is.
+    """
+    if not anchors:
+        return True
+    resolved = os.path.realpath(path)
+    return any(resolved.startswith(os.path.realpath(anchor) + os.sep) for anchor in anchors)
 
 
 def record_relative_dir(path: str) -> str | None:
@@ -109,9 +129,10 @@ def record_include_dir() -> str | None:
     header = next((e for e in _dist_files() if str(e).endswith(".h") and marker in str(e)), None)
     if header is None:
         return None
-    under = [os.path.join(anchor, str(header).split(marker)[0], "include") for anchor in _rebel_package_anchors()]
+    anchors = _rebel_package_anchors()
+    under = [os.path.join(anchor, str(header).split(marker)[0], "include") for anchor in anchors]
     located = header.locate()
-    if located is not None:
+    if located is not None and _inside_an_anchor(str(located), anchors):
         under.append(str(located).split(marker)[0] + os.sep + "include")
     if not under:
         return None
@@ -119,84 +140,7 @@ def record_include_dir() -> str | None:
     return next((path for path in under if os.path.isdir(path)), under[0])
 
 
-# What an editable install says about itself
-
-
-def _editable_source_root() -> str | None:
-    """Directory an editable rebel-compiler install was installed from, None when it is not one.
-
-    An editable install records no library of its own, and PEP 610 leaves the directory it was
-    installed from in ``direct_url.json`` -- the one exact statement of where the checkout, and
-    with it the C++ build output, lives.
-    """
-    try:
-        recorded = distribution(_COMPILER_DIST_NAME).read_text(_DIRECT_URL_FILE)
-    except (PackageNotFoundError, OSError):
-        return None
-    try:
-        described = json.loads(recorded) if recorded else None
-    except ValueError:
-        return None
-    if not isinstance(described, dict):
-        return None
-    directory = described.get("dir_info")
-    url = described.get("url")
-    if not isinstance(directory, dict) or not directory.get("editable"):
-        return None
-    if not isinstance(url, str) or not url.startswith(_FILE_URL_PREFIX):
-        return None
-    from urllib.parse import unquote  # not at module scope: this runs at `import torch`
-
-    return unquote(url[len(_FILE_URL_PREFIX) :])
-
-
-def _import_hook_libraries() -> Iterator[str]:
-    """Library paths an editable install's import hook already holds.
-
-    A hook that redirects imports into a build tree carries the map of files the build installed,
-    and the library is one of them -- named outright, so it holds even when the build output was
-    configured somewhere this could not have guessed. Which hook it is goes unchecked here; the
-    caller decides whether what a candidate names belongs to the install in use.
-    """
-    for finder in list(sys.meta_path):
-        base = getattr(finder, "dir", None)
-        for attribute in ("known_wheel_files", "known_source_files"):
-            mapping = getattr(finder, attribute, None)
-            if not isinstance(mapping, dict):
-                continue
-            for target in mapping.values():
-                if not isinstance(target, str) or os.path.basename(target) != RUNTIME_LIB_NAME:
-                    continue
-                if os.path.isabs(target):
-                    yield target
-                elif isinstance(base, str):
-                    yield os.path.join(base, target)
-
-
 # Resolution
-
-
-# Both channels below have to answer for the install that provides the ``rebel`` in use: pairing a
-# second checkout's runtime with this interpreter's rebel is what the ABI handshake cannot catch
-# when the two were built from the same version. Which relation says so differs by channel, since
-# one names a file and the other names a directory to derive one from. No importable ``rebel`` at
-# all leaves both standing -- a candidate is then the only statement anything has made.
-
-
-def _sits_beside_the_imported_package(path: str, anchors: list[str]) -> bool:
-    """Whether ``path`` is inside the directory the ``rebel`` package is installed in."""
-    if not anchors:
-        return True
-    resolved = os.path.realpath(path)
-    return any(resolved.startswith(os.path.realpath(anchor) + os.sep) for anchor in anchors)
-
-
-def _holds_the_imported_package(root: str, anchors: list[str]) -> bool:
-    """Whether the checkout ``root`` is the one the ``rebel`` package is imported from."""
-    if not anchors:
-        return True
-    prefix = os.path.realpath(root) + os.sep
-    return any((os.path.realpath(anchor) + os.sep).startswith(prefix) for anchor in anchors)
 
 
 def _iter_runtime_library_candidates() -> Iterator[tuple[str, str]]:
@@ -218,27 +162,13 @@ def _iter_runtime_library_candidates() -> Iterator[tuple[str, str]]:
 
     anchors = _rebel_package_anchors()
 
-    # Ahead of the record: an editable install's hook takes `import rebel` over from site-packages,
-    # so what it holds is what this interpreter would load.
-    for path in _import_hook_libraries():
-        if _sits_beside_the_imported_package(path, anchors):
-            yield from emit(path, "editable install import hook")
-
     for entry in _record_entries():
         for candidate in _record_candidates(entry, anchors):
             yield from emit(candidate, f"{_COMPILER_DIST_NAME} record")
 
-    # Editable install: the record names no library, so the checkout it points at answers instead.
-    # rebel-compiler installs from <source>/python and its REBEL_BUILD_DIR defaults to ../build.
-    # Only when the imported package sits under that checkout: metadata naming a different one
-    # would pair this interpreter's rebel with another checkout's runtime.
-    root = _editable_source_root()
-    if root is not None and _holds_the_imported_package(root, anchors):
-        candidate = os.path.join(os.path.dirname(root), "build", RUNTIME_LIB_NAME)
-        yield from emit(candidate, "editable install source tree")
-
-    # Last: the same build tree derived from where the package sits, for a checkout that reached
-    # this interpreter without being installed at all. Behind everything that states a path.
+    # An editable install records no library, and neither does a checkout that reached this
+    # interpreter without being installed at all. rebel-compiler builds into <source>/build and
+    # loads it from there itself, relative to its own files.
     for anchor in anchors:
         yield from emit(os.path.join(os.path.dirname(anchor), "build", RUNTIME_LIB_NAME), "rebel source build tree")
 

--- a/torch_rbln/_internal/rbln_runtime_lib.py
+++ b/torch_rbln/_internal/rbln_runtime_lib.py
@@ -5,6 +5,10 @@ The library is the one the ``rebel-compiler`` distribution recorded installing, 
 which is also what the install RPATH is written against, so one record answers where the library
 is, where it sits relative to the package, and where the headers are.
 
+An editable install records no library, so two statements the install itself makes answer instead:
+the import hook it registers, which names the files it installed, and the source directory
+``direct_url.json`` records it was installed from. Both are exact; neither depends on a layout.
+
 ``LD_LIBRARY_PATH`` is the override: the dynamic loader and rebel-compiler's loader both honour
 it, so all three sides land on the same file.
 
@@ -14,6 +18,7 @@ before torch_rbln exists, so anything it reaches for has to work then too.
 
 import ctypes
 import importlib.util
+import json
 import os
 import sys
 from collections.abc import Iterator
@@ -26,6 +31,10 @@ _COMPILER_DIST_NAME = "rebel-compiler"
 _MAPS_PATH = "/proc/self/maps"
 _DELETED_SUFFIX = " (deleted)"
 
+# PEP 610: what an installer records about where it installed a distribution from.
+_DIRECT_URL_FILE = "direct_url.json"
+_FILE_URL_PREFIX = "file://"
+
 # The distribution's record of what it installed
 
 
@@ -35,20 +44,24 @@ def _split_env_paths(name: str) -> list[str]:
     return [entry for entry in (part.strip() for part in value.split(os.pathsep)) if entry]
 
 
-def _rebel_package_anchor() -> str | None:
-    """Directory holding the ``rebel`` package this interpreter would import, or None.
+def _rebel_package_anchors() -> list[str]:
+    """Directories holding the ``rebel`` package this interpreter would import.
 
     ``find_spec`` because importing rebel pulls in torch. Anchoring on the imported package keeps
     an editable install, or a stray copy elsewhere, from answering for the one in use.
+
+    Every location, sorted, rather than the first one: an editable install reports its search
+    locations from a set holding both the source tree and the build tree, so which one comes first
+    changes from process to process and taking one of them made resolution a coin flip.
     """
     try:
         spec = importlib.util.find_spec("rebel")
     except (ImportError, ValueError):
-        return None
+        return []
     locations = getattr(spec, "submodule_search_locations", None) if spec else None
     if not locations:
-        return None
-    return os.path.dirname(locations[0])
+        return []
+    return sorted({os.path.dirname(location) for location in locations})
 
 
 def _dist_files() -> list:
@@ -65,9 +78,9 @@ def _record_entries() -> list:
     return [entry for entry in _dist_files() if os.path.basename(str(entry)) == RUNTIME_LIB_NAME]
 
 
-def _record_candidates(entry: object, anchor: str | None) -> Iterator[str]:
-    """Both ways a recorded entry can name a file: under the anchor, and where it was installed."""
-    if anchor is not None:
+def _record_candidates(entry: object, anchors: list[str]) -> Iterator[str]:
+    """Both ways a recorded entry can name a file: under an anchor, and where it was installed."""
+    for anchor in anchors:
         yield os.path.join(anchor, str(entry))
     located = entry.locate()  # type: ignore[attr-defined]
     if located is not None:
@@ -80,9 +93,9 @@ def record_relative_dir(path: str) -> str | None:
     A recorded path already expresses the relationship the install RPATH is written against.
     """
     resolved = os.path.realpath(path)
-    anchor = _rebel_package_anchor()
+    anchors = _rebel_package_anchors()
     for entry in _record_entries():
-        for candidate in _record_candidates(entry, anchor):
+        for candidate in _record_candidates(entry, anchors):
             if os.path.realpath(candidate) == resolved:
                 return os.path.dirname(str(entry))
     return None
@@ -90,15 +103,65 @@ def record_relative_dir(path: str) -> str | None:
 
 def record_include_dir() -> str | None:
     """Include directory the distribution installed, located through a recorded header."""
-    anchor = _rebel_package_anchor()
-    if anchor is None:
-        return None
     marker = f"{os.sep}include{os.sep}"
-    for entry in _dist_files():
-        name = str(entry)
-        if name.endswith(".h") and marker in name:
-            return os.path.join(anchor, name.split(marker)[0], "include")
-    return None
+    recorded = next((str(e) for e in _dist_files() if str(e).endswith(".h") and marker in str(e)), None)
+    anchors = _rebel_package_anchors()
+    if recorded is None or not anchors:
+        return None
+    return os.path.join(anchors[0], recorded.split(marker)[0], "include")
+
+
+# What an editable install says about itself
+
+
+def _editable_source_root() -> str | None:
+    """Directory an editable rebel-compiler install was installed from, None when it is not one.
+
+    An editable install records no library of its own, and PEP 610 leaves the directory it was
+    installed from in ``direct_url.json`` -- the one exact statement of where the checkout, and
+    with it the C++ build output, lives.
+    """
+    try:
+        recorded = distribution(_COMPILER_DIST_NAME).read_text(_DIRECT_URL_FILE)
+    except (PackageNotFoundError, OSError):
+        return None
+    try:
+        described = json.loads(recorded) if recorded else None
+    except ValueError:
+        return None
+    if not isinstance(described, dict):
+        return None
+    directory = described.get("dir_info")
+    url = described.get("url")
+    if not isinstance(directory, dict) or not directory.get("editable"):
+        return None
+    if not isinstance(url, str) or not url.startswith(_FILE_URL_PREFIX):
+        return None
+    from urllib.parse import unquote  # not at module scope: this runs at `import torch`
+
+    return unquote(url[len(_FILE_URL_PREFIX) :])
+
+
+def _import_hook_libraries() -> Iterator[str]:
+    """Library paths an editable install's import hook already holds.
+
+    A hook that redirects imports into a build tree carries the map of files the build installed,
+    and the library is one of them -- named outright, so it holds even when the build output was
+    configured somewhere this could not have guessed.
+    """
+    for finder in list(sys.meta_path):
+        base = getattr(finder, "dir", None)
+        for attribute in ("known_wheel_files", "known_source_files"):
+            mapping = getattr(finder, attribute, None)
+            if not isinstance(mapping, dict):
+                continue
+            for target in mapping.values():
+                if not isinstance(target, str) or os.path.basename(target) != RUNTIME_LIB_NAME:
+                    continue
+                if os.path.isabs(target):
+                    yield target
+                elif isinstance(base, str):
+                    yield os.path.join(base, target)
 
 
 # Resolution
@@ -121,20 +184,47 @@ def _iter_runtime_library_candidates() -> Iterator[tuple[str, str]]:
     for directory in _split_env_paths("LD_LIBRARY_PATH"):
         yield from emit(os.path.join(directory, RUNTIME_LIB_NAME), "LD_LIBRARY_PATH")
 
-    anchor = _rebel_package_anchor()
+    # Ahead of the record: an editable install's hook takes `import rebel` over from site-packages,
+    # so what it holds is what this interpreter would load.
+    for path in _import_hook_libraries():
+        yield from emit(path, "editable install import hook")
+
+    anchors = _rebel_package_anchors()
     for entry in _record_entries():
-        for candidate in _record_candidates(entry, anchor):
+        for candidate in _record_candidates(entry, anchors):
             yield from emit(candidate, f"{_COMPILER_DIST_NAME} record")
 
-    # Editable install: the package is <source>/python/rebel, the library <source>/build, and the
-    # record names neither. Behind the record so a leftover build tree cannot shadow it.
-    if anchor is not None:
+    # Editable install: the record names no library, so the checkout it points at answers instead.
+    # rebel-compiler installs from <source>/python and its REBEL_BUILD_DIR defaults to ../build.
+    root = _editable_source_root()
+    if root is not None:
+        candidate = os.path.join(os.path.dirname(root), "build", RUNTIME_LIB_NAME)
+        yield from emit(candidate, "editable install source tree")
+
+    # Last: the same build tree derived from where the package sits, for a checkout that reached
+    # this interpreter without being installed at all. Behind everything that states a path.
+    for anchor in anchors:
         yield from emit(os.path.join(os.path.dirname(anchor), "build", RUNTIME_LIB_NAME), "rebel source build tree")
 
 
 def runtime_library_candidates() -> list[tuple[str, str]]:
     """Every candidate path, in order, unfiltered by existence. For diagnostics."""
     return list(_iter_runtime_library_candidates())
+
+
+def _absent_distribution_note() -> str:
+    """Say it outright when nothing was found because rebel-compiler is not installed here.
+
+    Every candidate is derived from an install, so with no install there is nothing to report but
+    where this interpreter looked -- which reads like a path problem unless it says otherwise.
+    """
+    try:
+        distribution(_COMPILER_DIST_NAME)
+    except PackageNotFoundError:
+        anchors = _rebel_package_anchors()
+        resolves = f"`rebel` resolves under {', '.join(anchors)}" if anchors else "`rebel` does not import"
+        return f" No {_COMPILER_DIST_NAME} distribution is installed for {sys.executable} ({resolves})."
+    return ""
 
 
 def resolve_runtime_library() -> tuple[str, str]:
@@ -149,12 +239,12 @@ def resolve_runtime_library() -> tuple[str, str]:
             return path, source
         tried.append((path, source))
 
-    listed = "; ".join(f"{path} (from {source})" for path, source in tried[:10])
+    listed = "; ".join(f"{path} (from {source})" for path, source in tried[:10]) or "nothing"
     env_hint = "; ".join(
         f"{name}={os.environ[name][:80]}" for name in ("LD_LIBRARY_PATH", "PYTHONPATH") if os.environ.get(name)
     )
     raise FileNotFoundError(
-        f"Could not find {RUNTIME_LIB_NAME}. Tried (in order): {listed}"
+        f"Could not find {RUNTIME_LIB_NAME}.{_absent_distribution_note()} Tried (in order): {listed}"
         + (" ..." if len(tried) > 10 else "")
         + ". Install the rebel-compiler package, or put the directory holding the library on "
         "LD_LIBRARY_PATH."

--- a/torch_rbln/_internal/rbln_runtime_lib.py
+++ b/torch_rbln/_internal/rbln_runtime_lib.py
@@ -6,8 +6,10 @@ which is also what the install RPATH is written against, so one record answers w
 is, where it sits relative to the package, and where the headers are.
 
 An editable install records no library, so two statements the install itself makes answer instead:
-the import hook it registers, which names the files it installed, and the source directory
-``direct_url.json`` records it was installed from. Both are exact; neither depends on a layout.
+the import hook it registers names the files the build installed, and ``direct_url.json`` records
+the directory the install came from, whose build output sits where rebel-compiler puts it by
+default. Both are checked against the ``rebel`` package this interpreter imports, so a second
+checkout cannot answer for the one in use.
 
 ``LD_LIBRARY_PATH`` is the override: the dynamic loader and rebel-compiler's loader both honour
 it, so all three sides land on the same file.
@@ -104,11 +106,17 @@ def record_relative_dir(path: str) -> str | None:
 def record_include_dir() -> str | None:
     """Include directory the distribution installed, located through a recorded header."""
     marker = f"{os.sep}include{os.sep}"
-    recorded = next((str(e) for e in _dist_files() if str(e).endswith(".h") and marker in str(e)), None)
-    anchors = _rebel_package_anchors()
-    if recorded is None or not anchors:
+    header = next((e for e in _dist_files() if str(e).endswith(".h") and marker in str(e)), None)
+    if header is None:
         return None
-    return os.path.join(anchors[0], recorded.split(marker)[0], "include")
+    under = [os.path.join(anchor, str(header).split(marker)[0], "include") for anchor in _rebel_package_anchors()]
+    located = header.locate()
+    if located is not None:
+        under.append(str(located).split(marker)[0] + os.sep + "include")
+    if not under:
+        return None
+    # The build links against this; a directory that does not exist fails the CMake find instead.
+    return next((path for path in under if os.path.isdir(path)), under[0])
 
 
 # What an editable install says about itself
@@ -147,7 +155,8 @@ def _import_hook_libraries() -> Iterator[str]:
 
     A hook that redirects imports into a build tree carries the map of files the build installed,
     and the library is one of them -- named outright, so it holds even when the build output was
-    configured somewhere this could not have guessed.
+    configured somewhere this could not have guessed. Which hook it is goes unchecked here; the
+    caller decides whether what a candidate names belongs to the install in use.
     """
     for finder in list(sys.meta_path):
         base = getattr(finder, "dir", None)
@@ -167,6 +176,29 @@ def _import_hook_libraries() -> Iterator[str]:
 # Resolution
 
 
+# Both channels below have to answer for the install that provides the ``rebel`` in use: pairing a
+# second checkout's runtime with this interpreter's rebel is what the ABI handshake cannot catch
+# when the two were built from the same version. Which relation says so differs by channel, since
+# one names a file and the other names a directory to derive one from. No importable ``rebel`` at
+# all leaves both standing -- a candidate is then the only statement anything has made.
+
+
+def _sits_beside_the_imported_package(path: str, anchors: list[str]) -> bool:
+    """Whether ``path`` is inside the directory the ``rebel`` package is installed in."""
+    if not anchors:
+        return True
+    resolved = os.path.realpath(path)
+    return any(resolved.startswith(os.path.realpath(anchor) + os.sep) for anchor in anchors)
+
+
+def _holds_the_imported_package(root: str, anchors: list[str]) -> bool:
+    """Whether the checkout ``root`` is the one the ``rebel`` package is imported from."""
+    if not anchors:
+        return True
+    prefix = os.path.realpath(root) + os.sep
+    return any((os.path.realpath(anchor) + os.sep).startswith(prefix) for anchor in anchors)
+
+
 def _iter_runtime_library_candidates() -> Iterator[tuple[str, str]]:
     """Yield ``(path, source)`` candidates lazily, most authoritative first.
 
@@ -184,20 +216,24 @@ def _iter_runtime_library_candidates() -> Iterator[tuple[str, str]]:
     for directory in _split_env_paths("LD_LIBRARY_PATH"):
         yield from emit(os.path.join(directory, RUNTIME_LIB_NAME), "LD_LIBRARY_PATH")
 
+    anchors = _rebel_package_anchors()
+
     # Ahead of the record: an editable install's hook takes `import rebel` over from site-packages,
     # so what it holds is what this interpreter would load.
     for path in _import_hook_libraries():
-        yield from emit(path, "editable install import hook")
+        if _sits_beside_the_imported_package(path, anchors):
+            yield from emit(path, "editable install import hook")
 
-    anchors = _rebel_package_anchors()
     for entry in _record_entries():
         for candidate in _record_candidates(entry, anchors):
             yield from emit(candidate, f"{_COMPILER_DIST_NAME} record")
 
     # Editable install: the record names no library, so the checkout it points at answers instead.
     # rebel-compiler installs from <source>/python and its REBEL_BUILD_DIR defaults to ../build.
+    # Only when the imported package sits under that checkout: metadata naming a different one
+    # would pair this interpreter's rebel with another checkout's runtime.
     root = _editable_source_root()
-    if root is not None:
+    if root is not None and _holds_the_imported_package(root, anchors):
         candidate = os.path.join(os.path.dirname(root), "build", RUNTIME_LIB_NAME)
         yield from emit(candidate, "editable install source tree")
 


### PR DESCRIPTION
## Summary of Changes

An editable `rebel-compiler` install records no library, so resolution fell through to one derived path — `<dirname of the rebel package's first search location>/build/librbln.so`. Those search locations come out of a set holding both the source tree and the build tree, so which one comes first changes from process to process and the derived path is correct for only one of them. It surfaces as `Could not find librbln.so` with a single candidate listed, per process, which is why a run could work and its workers fail.

The rule this settles on is that the library comes from the tree that provides the `rebel` in use. rebel-compiler loads it relative to its own files too, and an explicit dlopen of another file with the same SONAME is not deduplicated, so a second copy answering here maps alongside the one rebel loads and the process runs two runtimes — two allocators, two device registries — which nothing downstream detects when both were built from the same version.

- the anchor leads with `spec.origin`, the `__init__.py` that will run, so which tree provides rebel is a single value rather than the first element of a set whose order changes per process
- a recorded entry resolved through the distribution's own root counts only when that root is that tree, which a wheel in site-packages beside a checkout on PYTHONPATH is not
- the build tree is derived from the anchor, as rebel-compiler derives it from its own files
- a missing distribution is named as the reason, with the interpreter that is missing it

A wheel install still resolves from the record, and first-call resolution cost is unchanged. No new environment variable and no directory walking: `LD_LIBRARY_PATH` stays the one override.

The resolver tests synthesize every layout they check, so they run with no compiler installed and no device; the three that check the real install skip with a reason when the distribution is absent.

Layer: torch-rbln Python, import-time resolution. No op, dispatch, or copy path is touched, and nothing added here claims a device. An environment with no `rebel-compiler` installed at all is not covered — every candidate is derived from an install, and that case now says so.

---

## Type of Change

- [x] `fix` — Bug fix

---

## Affected Modules

- [x] Backend
- [x] Build/Tools

---

## How to Test

1. `uv run --no-sync pytest test/rbln/test_rbln_runtime_lib.py` — 18 pass, with no device and no NPU needed.
2. Same file with the distribution hidden (a plugin raising `PackageNotFoundError` for it) and `LD_LIBRARY_PATH` pointing at the installed library — 15 pass, 3 skip as needing an install.
3. Mutation checks, each failing only its own test: `if False:` on the `spec.origin` branch, and dropping the anchor check on `entry.locate()`.
4. `uv run --no-sync python test/run_tests.py --suite=core` — no failures.
5. `uv run --no-sync python tools/find_rebel_runtime.py` — the build helper reads the same record; `LIBRARY`, `LIBRARY_RELDIR`, `INCLUDE_DIR` unchanged on a wheel install.
6. Against a real editable install (`uv pip install -e <checkout>/python`), with the resolver loaded by path:
   - before this change, `PYTHONHASHSEED` 0 and 3 of 0-5 fail, and the message is the one reported from the field: `Could not find librbln.so. ... Tried (in order): <venv>/lib/python3.12/build/librbln.so (from rebel source build tree)`
   - after it, every seed resolves `<checkout>/build/librbln.so`, which is also what rebel-compiler's own loader reports for `librbln.so` in that environment

---

## Checklist

* [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
* [x] Linting passes — `lintrunner -m origin/dev`
* [ ] All CI tests pass
* [x] The test method is described, and the expected result is clearly stated
* [x] Relevant documentation has been updated (if applicable) — no new option or variable

---

## Notes

The failure reproduces in a real editable install, and the search locations it reports are the source tree and site-packages -- the latter because the build installs its extension modules there while the `.pth` adds the source tree. Anchoring on the wrong one derives `<venv>/lib/python3.12/build/librbln.so`, which is what the reports show.

Two divergences from rebel-compiler's own loader stay, both outside what this can decide: it reads `TVM_LIBRARY_PATH` ahead of everything, and it sweeps `PATH`. And an installed tree whose metadata is gone still fails here while rebel-compiler loads from the package layout, which needs no metadata.
