### PR TITLE
chore: update rebel-compiler version to 0.11.2

### DIFF
--- a/constraints-build-dev.txt
+++ b/constraints-build-dev.txt
@@ -1,2 +1,2 @@
 # Build/dev dependency constraints (single source of truth).
-rebel-compiler==0.11.3.dev0
+rebel-compiler==0.11.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ requires = [
   "cmake>=3.18,<4.0",
   "mypy>=1.13.0,<1.14.0",
   "ninja>=1.11.1.3,<1.11.2",
-  "rebel-compiler>=0.11.1,<0.20.0",
+  "rebel-compiler>=0.11.2,<0.20.0",
   "torch==2.11.0+cpu"
 ]
 build-backend = "hatchling.build"
@@ -153,7 +153,7 @@ rebel-compiler = { index = "rbln" }
 build = [
   "cmake>=3.18",
   "editables>=0.5",
-  "rebel-compiler>=0.11.1,<0.20.0",
+  "rebel-compiler>=0.11.2,<0.20.0",
   "setuptools-scm>=8.0",
   "hatchling>=1.25,<1.32",  # see the build-system pin
   "mypy>=1.13.0,<1.14.0",

--- a/tools/dev-setup.sh
+++ b/tools/dev-setup.sh
@@ -151,7 +151,7 @@ mode_pypi() {
         python ./tools/replace_depends.py \
             --pyproject-path ./pyproject.toml \
             --source "rebel-compiler" \
-            --target "rebel-compiler>=0.10.1,<0.20.0" \
+            --target "rebel-compiler>=0.11.2,<0.20.0" \
             --set-index rbln
         rm -f uv.lock
     fi


### PR DESCRIPTION
Pins the build/dev dependency to the released `rebel-compiler` 0.11.2 and raises the floor accordingly.

- `constraints-build-dev.txt`: `0.11.3.dev0` (dev snapshot) → `0.11.2` (release)
- `pyproject.toml` (`build-system.requires`, `dependency-groups.build`): `>=0.11.1` → `>=0.11.2`
- `tools/dev-setup.sh`: the restore target was stale at `>=0.10.1`; aligned to `>=0.11.2` so restoring from a custom wheel cannot write a lower floor back into `pyproject.toml`

Provenance: 0.11.2 on the internal index is built from `24b381bd82d3f0a29132ec5d190b7d08797f8b57` (tag `v0.11.2`) — all five wheels (cp310–cp314) embed that commit. Wheels exist for cp310–cp314, covering `requires-python >=3.10,<3.14`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
