### PR TITLE
fix(core): let a moved get_npu_name raise instead of answering "unknown"

### DIFF
--- a/.github/workflows/nightly-torch.yaml
+++ b/.github/workflows/nightly-torch.yaml
@@ -206,8 +206,10 @@ jobs:
           print(f"::notice::Smoke test passed: torch-rbln=={torch_rbln.__version__} on torch {torch.__version__}")
           PY
 
-      # Both suites manage RBLN_DUMMY_DEVICE themselves: test_dummy_device sets it per
-      # subprocess, and test_no_device requires device_count() == 0.
+      # The first two manage RBLN_DUMMY_DEVICE themselves: test_dummy_device sets it per
+      # subprocess, and test_no_device requires device_count() == 0. test_device_arch
+      # runs here because the architecture gates it covers are evaluated at collection,
+      # and this is the only runner where they see a host with no NPU.
       - name: Run no-NPU test suites
         run: |
           set -euo pipefail
@@ -215,6 +217,7 @@ jobs:
           "${TEST_VENV}/bin/python" -m pytest \
             test/rbln/test_dummy_device.py \
             test/distributed/test_no_device.py \
+            test/internal/test_device_arch.py \
             -m test_set_ci \
             --numprocesses=1
 

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -167,7 +167,7 @@ Steps:
 3. **Build** the wheel with the same container, compiler setup, and `constraints-build-dev.txt` build constraint as [`_build-wheel.yaml`](../.github/workflows/_build-wheel.yaml), but **without publishing** it to the internal package index.
 4. **Test** on a CPU-only runner with no NPU attached, using `RBLN_DUMMY_DEVICE=1` (see [Configuration](CONFIGURATION.md#rbln_dummy_device)):
    - a smoke script that installs the built wheel into a clean venv and checks the versions, the dummy device topology, a host↔device round-trip, and one eager op;
-   - the no-NPU test suites `test/rbln/test_dummy_device.py` and `test/distributed/test_no_device.py` (each manages `RBLN_DUMMY_DEVICE` itself, so it is not set for this step).
+   - the no-NPU test suites `test/rbln/test_dummy_device.py` and `test/distributed/test_no_device.py` (each manages `RBLN_DUMMY_DEVICE` itself, so it is not set for this step), and `test/internal/test_device_arch.py`, whose architecture gates only see a host with no NPU here.
 5. **Report** the resolved `torch` version, the built `torch-rbln` version, and the outcome to the job summary, with an error annotation on failure.
 
 ---

--- a/test/internal/test_device_arch.py
+++ b/test/internal/test_device_arch.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: PrivateUse1"]
 
+import sys
 from unittest.mock import patch
 
 import pytest
@@ -7,7 +8,7 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 from test.utils import xfail_atom, xfail_rebel
 
-from torch_rbln._internal.device_arch_utils import _arch_from_npu_name, is_atom_device, is_rebel_device
+from torch_rbln._internal.device_arch_utils import _arch_from_npu_name, get_device_arch, is_atom_device, is_rebel_device
 
 
 @pytest.mark.test_set_ci
@@ -77,6 +78,31 @@ class TestArchXfailMarkers(TestCase):
         with patch("torch_rbln._internal.device_arch_utils.get_device_arch", return_value="rebel"):
             mark = xfail_atom("ATOM: feature not yet supported")
         self.assertFalse(mark.mark.kwargs["condition"])
+
+
+@pytest.mark.test_set_ci
+class TestArchResolutionFailure(TestCase):
+    """A host with no NPU and a moved ``get_npu_name`` must not look alike.
+
+    Both used to answer ``"unknown"``, and every caller of ``get_device_arch``
+    is an architecture gate, so the second one turns all of them off at once
+    with nothing failing. Only the first is a legitimate ``"unknown"``.
+    """
+
+    def setUp(self) -> None:
+        get_device_arch.cache_clear()
+        self.addCleanup(get_device_arch.cache_clear)
+
+    def test_no_device_answers_unknown(self) -> None:
+        # What rebel returns for an index no device claims.
+        with patch("rebel.device_info.get_npu_name", return_value=None):
+            self.assertEqual(get_device_arch(), "unknown")
+
+    def test_moved_entry_point_raises(self) -> None:
+        # None in sys.modules is what CPython turns a moved module into.
+        with patch.dict(sys.modules, {"rebel.device_info": None}):
+            with self.assertRaises(ImportError):
+                get_device_arch()
 
 
 if __name__ == "__main__":

--- a/test/internal/test_device_arch.py
+++ b/test/internal/test_device_arch.py
@@ -82,14 +82,16 @@ class TestArchXfailMarkers(TestCase):
 
 @pytest.mark.test_set_ci
 class TestArchResolutionFailure(TestCase):
-    """A host with no NPU and a moved ``get_npu_name`` must not look alike.
+    """Only ``None`` from the runtime is ``"unknown"``; any failure propagates.
 
-    Both used to answer ``"unknown"``, and every caller of ``get_device_arch``
-    is an architecture gate, so the second one turns all of them off at once
-    with nothing failing. Only the first is a legitimate ``"unknown"``.
+    A host with no NPU and a broken lookup used to answer the same
+    ``"unknown"``, and every caller of ``get_device_arch`` is an architecture
+    gate, so the second one turned all of them off at once with nothing
+    failing.
     """
 
     def setUp(self) -> None:
+        super().setUp()
         get_device_arch.cache_clear()
         self.addCleanup(get_device_arch.cache_clear)
 
@@ -102,6 +104,11 @@ class TestArchResolutionFailure(TestCase):
         # None in sys.modules is what CPython turns a moved module into.
         with patch.dict(sys.modules, {"rebel.device_info": None}):
             with self.assertRaises(ImportError):
+                get_device_arch()
+
+    def test_lookup_error_propagates(self) -> None:
+        with patch("rebel.device_info.get_npu_name", side_effect=RuntimeError("device query failed")):
+            with self.assertRaises(RuntimeError):
                 get_device_arch()
 
 

--- a/torch_rbln/_internal/device_arch_utils.py
+++ b/torch_rbln/_internal/device_arch_utils.py
@@ -21,15 +21,21 @@ def _arch_from_npu_name(name: str) -> str:
 @functools.lru_cache(maxsize=1)
 def get_device_arch() -> str:
     """Identify the current NPU family (``"atom"``/``"rebel"``/``"unknown"``) via
-    ``get_npu_name`` from ``rebel-compiler`` (cached). Returns ``"unknown"`` if the
-    NPU name can't be queried.
-    """
-    try:
-        from rebel.device_info import get_npu_name
+    ``get_npu_name`` from ``rebel-compiler`` (cached).
 
-        return _arch_from_npu_name(get_npu_name(0) or "")
-    except Exception:
-        return "unknown"
+    ``"unknown"`` is what a host with no NPU gets on its own: ``get_npu_name``
+    answers ``None`` for an index no device claims, which maps to ``"unknown"``
+    without raising. So nothing here has to catch that case.
+
+    A ``get_npu_name`` that moved is the opposite, and must not arrive as the
+    same answer. Every caller of this is an architecture gate -- ``xfail_atom``,
+    ``xfail_rebel``, the per-lineup branches in the model tests -- so one
+    ``"unknown"`` turns all of them off at once, and the suite goes on
+    asserting something other than what it says it does. Let it raise.
+    """
+    from rebel.device_info import get_npu_name
+
+    return _arch_from_npu_name(get_npu_name(0) or "")
 
 
 def is_atom_device() -> bool:

--- a/torch_rbln/_internal/device_arch_utils.py
+++ b/torch_rbln/_internal/device_arch_utils.py
@@ -23,15 +23,15 @@ def get_device_arch() -> str:
     """Identify the current NPU family (``"atom"``/``"rebel"``/``"unknown"``) via
     ``get_npu_name`` from ``rebel-compiler`` (cached).
 
-    ``"unknown"`` is what a host with no NPU gets on its own: ``get_npu_name``
-    answers ``None`` for an index no device claims, which maps to ``"unknown"``
-    without raising. So nothing here has to catch that case.
+    ``"unknown"`` is reserved for a host with no NPU: the runtime's query API
+    answers ``None`` for an index no device claims and never raises for it, and
+    ``None`` maps to ``"unknown"`` without any catch here.
 
-    A ``get_npu_name`` that moved is the opposite, and must not arrive as the
-    same answer. Every caller of this is an architecture gate -- ``xfail_atom``,
-    ``xfail_rebel``, the per-lineup branches in the model tests -- so one
-    ``"unknown"`` turns all of them off at once, and the suite goes on
-    asserting something other than what it says it does. Let it raise.
+    Anything else -- the import failing, the lookup raising -- propagates.
+    Every caller of this is an architecture gate (``xfail_atom``,
+    ``xfail_rebel``, the per-lineup branches in the model tests), and a
+    swallowed failure would turn all of them off at once while the suite
+    goes on passing.
     """
     from rebel.device_info import get_npu_name
 


### PR DESCRIPTION
## Summary of Changes

`get_device_arch()` wrapped its whole body in `except Exception: return "unknown"`. Every caller of it is an architecture gate — `xfail_atom` and `xfail_rebel` take their `condition` from it, and the per-lineup branches in the model tests read it directly — so a swallowed failure turned all of them off at once: strict xfails went inert, the model tests configured themselves for the other lineup, and nothing failed while the suite went on asserting something other than what it says it does.

The catch covered nothing a healthy host needs. rebel's query API (`device_count` / `npu_is_available` / `get_npu_name`) is written to never raise: a host with no NPU, a missing driver library, or an index no device claims all answer `None`, which `_arch_from_npu_name` maps to `"unknown"` without any catch here. That contract is stated in `rebel/src/common/device_handle.cc` (rebel-compiler #12904, included in the pinned build) and in the `get_npu_name` binding docstring, and rebel's own `compiled_model.py` relies on it.

So: drop the catch. `None` stays the one legitimate `"unknown"`. Anything else — the import failing because `get_npu_name` moved, the lookup raising — now propagates where it is called, which for the gates means collection fails instead of a silently mis-gated run.

The nightly no-NPU lane now also runs `test/internal/test_device_arch.py`. It is the only runner where the gates see a host with no NPU, so it is where the `"unknown"` path is exercised on real absence rather than through a mock.

Layer: torch-rbln Python. No native change.

---

## Related Issues / Tickets

* Related to `rebellions-sw/fsw-inference#535` — torch-rbln's dependency on rebel internals. `get_npu_name` was the one entry in that inventory whose loss was silent. The dependency on the internal path `rebel.device_info` itself is unchanged by this PR.

---

## Type of Change

- [x] `core` — Changes to RBLN backend, device layer, C++ extension, op registration, or `torch.compile` integration
- [x] `ci` — Workflow changes

---

## Affected Modules

- [x] Device
- [x] CI (`nightly-torch.yaml`, no-NPU test step)

---

## How to Test

1. `uv run --no-sync pytest test/internal/test_device_arch.py -q` — 16 passed.
2. `TestArchResolutionFailure` covers the three outcomes: `None` from the runtime stays `"unknown"`; a module missing from `sys.modules` raises `ImportError`; a lookup raising `RuntimeError` propagates.
3. The two raising tests fail without the change: with `torch_rbln/_internal/device_arch_utils.py` at `origin/dev`, the run gives `AssertionError: ImportError not raised` and `AssertionError: RuntimeError not raised`; the `None` test passes either way, as it should..
4. `uv run --no-sync pytest test/internal/ -q` — 76 passed.
5. `uv run --no-sync pytest test/ --collect-only -q` — 76512 collected; the 3 collection errors are `test/models/test_optimum_llm.py`, `test_transformers.py`, `test_vllm_llm.py`, each a `ModuleNotFoundError` for an optional dependency not installed in this venv. The gates are evaluated at decoration, so collection across the whole tree is what shows the change did not break them.
6. `uv run --no-sync lintrunner -m origin/dev -a` — no lint issues.

No-device behaviour, verified on a REBEL host by hiding what the runtime looks at (user+mount namespace, bind-mounting `/dev/null` over the path), with the PR's code path (no catch):

| Host as seen by the runtime | `get_npu_name(0)` | `get_device_arch()` |
|---|---|---|
| `/dev/rbln*` hidden (SDK present, no NPU) | `None` | `"unknown"` |
| `librbln-thunk.so` hidden (no driver library) | `None` | `"unknown"` |
| `librbln-thunk.so` hidden, `RBLN_DUMMY_DEVICE=1` (the nightly runner's smoke-step environment) | `None` | `"unknown"`, `test_device_arch.py` collects |

`import rebel._C` and `import torch_rbln` also succeed with the driver library hidden; in a deploy build the library version check only runs when the library did load, so it does not turn a missing driver into an import failure either.

---

## Notes

Python only; no rebuild involved.

**Not verified:** the full `core` suite was not run — the change is one expression and collection across the whole tree covers the way these callers reach it. The no-device table above is a namespace simulation on a host that has NPUs, not a machine without one; the nightly lane addition is what runs it on real absence.

**Behaviour change to be aware of:** on a host where `rebel.device_info` cannot be imported, or where `get_npu_name` raises, test collection now fails instead of quietly running with every architecture gate inert. That is the point, but it is a louder failure than before.

**Found on the way, out of scope (layer 3):** with the driver library absent and `RBLN_DUMMY_DEVICE` unset, `rebel.device_info.device_count()` segfaults instead of answering 0, and `torch.rbln.physical_device_count()` with it. `get_npu_name` and `npu_is_available` on the same host answer `None` / `False` as documented. To be reported to rebel-compiler separately. It does not touch this PR's path: `get_npu_name` is the only runtime query the gates make, and the nightly no-NPU step already runs `test_no_device.py` in that environment.
