### PR TITLE
feat(memory): run large permuted device copies as compiled programs

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -5,6 +5,7 @@ set(sources
   native/rbln/RBLNCopy.cpp
   native/rbln/RBLNRepeat.cpp
   native/rbln/RBLNResize.cpp
+  native/rbln/RBLNCompiledPermute.cpp
   native/rbln/RBLNStridedV2V.cpp
   native/rbln/RBLNTensorAdvancedIndexing.cpp
   native/rbln/RBLNTensorFactories.cpp
@@ -23,6 +24,7 @@ set(headers
   native/rbln/RBLNIndexUtils.h
   native/rbln/RBLNRepeat.h
   native/rbln/RBLNResize.h
+  native/rbln/RBLNCompiledPermute.h
   native/rbln/RBLNStridedV2V.h
   native/rbln/RBLNStrideUtils.h
   native/rbln/RBLNTensorAdvancedIndexing.h

--- a/aten/src/ATen/native/rbln/RBLNCompiledPermute.cpp
+++ b/aten/src/ATen/native/rbln/RBLNCompiledPermute.cpp
@@ -1,0 +1,81 @@
+#include <ATen/native/rbln/RBLNCompiledPermute.h>
+#include <c10/util/Exception.h>
+
+#include <algorithm>
+#include <map>
+#include <numeric>
+
+namespace at::native::rbln {
+
+namespace {
+
+CompiledPermuteImpl g_impl = nullptr;
+
+// A program binds its operands once and rebinding costs ~2 ms for a 117 MB buffer, so a
+// caller that alternates buffers (a double-buffered pipeline) needs one program per buffer.
+// Slots are handed out per source address, capped so an unbounded caller cannot grow the
+// cache without limit.
+constexpr int64_t kMaxSlots = 8;
+
+int64_t slot_for(const void* src) {
+  static thread_local std::map<const void*, int64_t> slots;
+  auto it = slots.find(src);
+  if (it == slots.end()) {
+    it = slots.emplace(src, static_cast<int64_t>(slots.size()) % kMaxSlots).first;
+  }
+  return it->second;
+}
+
+// Below this a strided copy is cheap enough that a compiled program (and its one-time
+// compilation) is not worth it.
+constexpr int64_t kMinBytes = int64_t{16} << 20;
+
+// `src` is a pure permutation of a contiguous tensor exactly when ordering its dimensions by
+// descending stride yields a contiguous view. Returns that ordering's inverse -- the dims a
+// permute of the contiguous base needs to reproduce `src` -- or an empty vector.
+std::vector<int64_t> permutation_of_contiguous(const at::Tensor& src) {
+  const int64_t dim = src.dim();
+  std::vector<int64_t> order(dim);
+  std::iota(order.begin(), order.end(), 0);
+  std::stable_sort(order.begin(), order.end(), [&](int64_t a, int64_t b) { return src.stride(a) > src.stride(b); });
+  if (!src.permute(order).is_contiguous())
+    return {};
+  std::vector<int64_t> dims(dim);
+  for (int64_t i = 0; i < dim; ++i)
+    dims[order[i]] = i;
+  return dims;
+}
+
+} // namespace
+
+void set_compiled_permute_impl(CompiledPermuteImpl impl) {
+  g_impl = impl;
+}
+
+bool try_compiled_permute_copy(const at::Tensor& dst, const at::Tensor& src) {
+  if (g_impl == nullptr)
+    return false;
+  if (!src.device().is_privateuseone() || dst.device() != src.device())
+    return false;
+  if (dst.scalar_type() != src.scalar_type() || !dst.is_contiguous())
+    return false;
+  if (src.is_contiguous() || src.storage_offset() != 0)
+    return false;
+  if (src.numel() * src.element_size() < kMinBytes)
+    return false;
+  const std::vector<int64_t> dims = permutation_of_contiguous(src);
+  if (dims.empty())
+    return false;
+  std::vector<int64_t> order(dims.size());
+  for (size_t i = 0; i < dims.size(); ++i)
+    order[dims[i]] = static_cast<int64_t>(i);
+  try {
+    // A program the compiler miscomputes throws; the strided walk is always right.
+    g_impl(src.permute(order).contiguous(), dims, slot_for(src.data_ptr()), dst);
+  } catch (const std::exception&) {
+    return false;
+  }
+  return true;
+}
+
+} // namespace at::native::rbln

--- a/aten/src/ATen/native/rbln/RBLNCompiledPermute.h
+++ b/aten/src/ATen/native/rbln/RBLNCompiledPermute.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <ATen/core/Tensor.h>
+
+#ifdef TORCH_RBLN_BUILD_MAIN_LIB
+#define TORCH_RBLN_PERMUTE_API __attribute__((visibility("default")))
+#else
+#define TORCH_RBLN_PERMUTE_API
+#endif
+
+namespace at::native::rbln {
+
+// A permuted device-to-device copy walks one strided range per contiguous inner block, which
+// for a head<->token swap is a 256 B block and runs at ~1.3 GB/s. Running the permutation as a
+// compiled device program instead moves 117 MB in ~0.4 ms. The program is compiled once per
+// (shape, dtype, dims) and cached on disk (TORCH_RBLN_CACHE_DIR).
+
+// `dst.copy_(src)` for a large permuted RBLN source: runs the program straight into `dst`.
+// False when it does not apply -- the caller falls back to strided_v2v_copy.
+TORCH_RBLN_PERMUTE_API bool try_compiled_permute_copy(const at::Tensor& dst, const at::Tensor& src);
+
+using CompiledPermuteImpl = void (*)(const at::Tensor&, at::IntArrayRef, int64_t, const at::Tensor&);
+TORCH_RBLN_PERMUTE_API void set_compiled_permute_impl(CompiledPermuteImpl impl);
+
+} // namespace at::native::rbln

--- a/aten/src/ATen/native/rbln/RBLNCopy.cpp
+++ b/aten/src/ATen/native/rbln/RBLNCopy.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 
 #include <ATen/MemoryOverlap.h>
+#include <ATen/native/rbln/RBLNCompiledPermute.h>
 #include <ATen/native/rbln/RBLNCopy.h>
 #include <ATen/native/rbln/RBLNStrideUtils.h>
 #include <ATen/native/rbln/RBLNStridedV2V.h>
@@ -317,6 +318,11 @@ void tensor_copy_from_rbln_to_rbln(const at::Tensor& rbln_src, const at::Tensor&
   // a host fallback anyway, so bounce via host here.
   if (rbln_src.sizes() == rbln_dst.sizes() && rbln_src.scalar_type() == rbln_dst.scalar_type() &&
       rbln_src.device() == rbln_dst.device()) {
+    // A large permuted source walks one strided range per contiguous inner block (256 B for a
+    // head<->token swap); a compiled program moves the same bytes ~100x faster.
+    if (try_compiled_permute_copy(rbln_dst, rbln_src)) {
+      return;
+    }
     const auto inner_start = common_inner_start(rbln_src.sizes(), rbln_src.strides(), rbln_dst.strides());
     int64_t outer_count = 1;
     for (int64_t i = 0; i < inner_start; ++i) {

--- a/test/rbln/test_compiled_permute.py
+++ b/test/rbln/test_compiled_permute.py
@@ -1,0 +1,93 @@
+import pytest
+import torch
+
+import torch_rbln  # noqa: F401
+
+pytestmark = pytest.mark.skipif(not torch.rbln.is_available(), reason="needs an RBLN device")
+
+DIMS = [0, 2, 1, 3]
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.int32])
+def test_compiled_permute_is_bit_exact(dtype):
+    src = torch.randint(-1000, 1000, (3, 4, 16, 8)).to(dtype).to("rbln:0")
+    for _ in range(2):  # the second call reuses the cached program and its output buffer
+        out = torch.rbln.compiled_permute(src, DIMS)
+        torch.rbln.synchronize()
+        assert torch.equal(out.cpu(), src.cpu().permute(DIMS))
+
+
+def test_compiled_permute_writes_a_caller_buffer():
+    src = torch.randint(-1000, 1000, (3, 4, 16, 8)).to(torch.bfloat16).to("rbln:0")
+    out = torch.empty((3, 16, 4, 8), dtype=torch.bfloat16, device="rbln:0")
+    for _ in range(2):
+        assert torch.rbln.compiled_permute(src, DIMS, out=out) is out
+        torch.rbln.synchronize()
+        assert torch.equal(out.cpu(), src.cpu().permute(DIMS))
+
+
+def test_compiled_permute_rejects_a_mismatched_out():
+    src = torch.zeros((3, 4, 16, 8), dtype=torch.bfloat16, device="rbln:0")
+    with pytest.raises(ValueError, match="out must be"):
+        torch.rbln.compiled_permute(
+            src, DIMS, out=torch.empty((3, 4, 16, 8), dtype=torch.bfloat16, device="rbln:0")
+        )
+
+
+def test_compiled_permute_slots_are_independent():
+    a = torch.randint(-1000, 1000, (2, 3, 4, 8)).to(torch.bfloat16).to("rbln:0")
+    b = torch.randint(-1000, 1000, (2, 3, 4, 8)).to(torch.bfloat16).to("rbln:0")
+    out_a = torch.rbln.compiled_permute(a, DIMS, slot=0)
+    out_b = torch.rbln.compiled_permute(b, DIMS, slot=1)
+    torch.rbln.synchronize()
+    assert torch.equal(out_a.cpu(), a.cpu().permute(DIMS))
+    assert torch.equal(out_b.cpu(), b.cpu().permute(DIMS))
+
+
+@pytest.mark.parametrize("dims", [[1, 0, 2], [1, 0, 2, 3], [2, 1, 0, 3]])
+def test_compiled_permute_handles_other_permutations(dims):
+    shape = [2, 3, 4, 5][: len(dims)]
+    src = torch.randint(-1000, 1000, shape).to(torch.bfloat16).to("rbln:0")
+    out = torch.rbln.compiled_permute(src, dims)
+    torch.rbln.synchronize()
+    assert torch.equal(out.cpu(), src.cpu().permute(dims))
+
+
+@pytest.mark.parametrize("dims", [[2, 0, 1, 3], [0, 3, 1, 2, 4]])
+def test_a_miscompiled_permutation_raises_instead_of_returning_wrong_data(dims):
+    """The compiler gets these wrong silently (the eager path is correct); we must not pass
+    that on. Delete this test once the compiler handles them."""
+    shape = [2, 3, 4, 5, 6][: len(dims)]
+    src = torch.randint(-1000, 1000, shape).to(torch.bfloat16).to("rbln:0")
+    with pytest.raises(RuntimeError, match="miscomputes"):
+        torch.rbln.compiled_permute(src, dims)
+
+
+def test_a_miscompiled_permutation_falls_back_in_copy_():
+    """copy_ must still be right: it drops back to the strided walk."""
+    src = torch.randint(-1000, 1000, (64, 8, 128, 64)).to(torch.bfloat16)
+    dev = src.to("rbln:0")
+    out = torch.empty((128, 64, 8, 64), dtype=torch.bfloat16, device="rbln:0")
+    out.copy_(dev.permute([2, 0, 1, 3]))
+    torch.rbln.synchronize()
+    assert torch.equal(out.cpu(), src.permute([2, 0, 1, 3]))
+
+
+@pytest.mark.parametrize(
+    "dims, message",
+    [([0, 1, 2], "permutation"), ([0, 1, 3, 2], "last")],
+)
+def test_compiled_permute_rejects_bad_dims(dims, message):
+    src = torch.zeros((2, 3, 4, 8), dtype=torch.bfloat16, device="rbln:0")
+    with pytest.raises(ValueError, match=message):
+        torch.rbln.compiled_permute(src, dims)
+
+
+def test_large_permuted_copy_matches_the_strided_path():
+    """copy_ from a permuted source takes the compiled path above 16 MiB; result is unchanged."""
+    src = torch.randint(-1000, 1000, (64, 8, 512, 64)).to(torch.bfloat16)
+    dev = src.to("rbln:0")
+    out = torch.empty((64, 512, 8, 64), dtype=torch.bfloat16, device="rbln:0")
+    out.copy_(dev.permute(DIMS))
+    torch.rbln.synchronize()
+    assert torch.equal(out.cpu(), src.permute(DIMS))

--- a/torch_rbln/compiled_permute.py
+++ b/torch_rbln/compiled_permute.py
@@ -1,0 +1,93 @@
+"""Permutations run as compiled device programs (see RBLNCompiledPermute.h)."""
+
+import threading
+
+import torch
+
+__all__ = ["compiled_permute"]
+
+_lock = threading.Lock()
+_entries: dict = {}
+_verified: set = set()
+
+
+def _integer_view(t: torch.Tensor) -> torch.Tensor:
+    # The compiler rounds floating point through a 16-bit device format; integers move verbatim.
+    row_bytes = t.shape[-1] * t.element_size()
+    for dtype in (torch.int32, torch.int16, torch.uint8):
+        if row_bytes % torch.empty((), dtype=dtype).element_size() == 0:
+            return t.view(dtype)
+    raise AssertionError("unreachable")
+
+
+def _entry(shape: tuple, dtype: torch.dtype, device: torch.device, dims: tuple, slot: int):
+    """The compiled program for this permutation and the holder its runtime lands in."""
+    key = (shape, dtype, device.index, dims, slot)
+    with _lock:
+        entry = _entries.get(key)
+        if entry is None:
+            # torch.compile caches on the code object, so each (dims, slot) is compiled from
+            # its own source with the dims baked in as constants.
+            body = "    return x.permute(" + repr(list(dims)) + ").contiguous()"
+            source = "def compiled_permute(x):\n" + body + "\n"
+            namespace: dict = {}
+            exec(compile(source, f"<compiled_permute {dims} slot {slot}>", "exec"), {}, namespace)
+            holder: list = []
+            program = torch.compile(
+                namespace["compiled_permute"],
+                backend="rbln",
+                dynamic=False,
+                options={"use_static_output": True, "_runtime_holder": holder},
+            )
+            entry = _entries[key] = (program, holder)
+        return entry
+
+
+def compiled_permute(
+    src: torch.Tensor, dims: list[int], slot: int = 0, out: torch.Tensor | None = None
+) -> torch.Tensor:
+    """``src.permute(dims).contiguous()`` as a compiled device program, bit-exact for any dtype.
+
+    With ``out`` the result lands in the caller's tensor; without it the program's own buffer is
+    returned, borrowed until the next call with the same shape, dtype, ``dims`` and ``slot``.
+
+    A program binds its operands on first use and rebinding a large buffer costs milliseconds,
+    so a caller that alternates buffers (a double-buffered pipeline) gives each its own
+    ``slot``; ``copy_``'s fast path does that by source address.
+
+    Each program is checked against a host reference on its first use: the compiler miscomputes
+    some permutations (``[2, 0, 1, 3]`` among them) without reporting anything, and one that
+    fails the check raises here rather than returning wrong data.
+    """
+    if src.device.type != "rbln":
+        raise ValueError("compiled_permute: an RBLN tensor is required")
+    if not src.is_contiguous():
+        raise ValueError("compiled_permute: a contiguous tensor is required")
+    if sorted(dims) != list(range(src.dim())):
+        raise ValueError(f"compiled_permute: {dims} is not a permutation of {src.dim()} dims")
+    if dims[-1] != src.dim() - 1:
+        raise ValueError("compiled_permute: the last dimension must stay last")
+    shape = [src.shape[d] for d in dims]
+    if out is not None and (list(out.shape) != shape or out.dtype != src.dtype):
+        raise ValueError(f"compiled_permute: out must be {shape} of {src.dtype}")
+
+    packed = _integer_view(src)
+    program, holder = _entry(tuple(packed.shape), packed.dtype, src.device, tuple(dims), slot)
+    if out is None:
+        result = program(packed).view(src.dtype).view(shape)
+    else:
+        if not holder:
+            program(packed)  # compiles, and publishes the runtime this call needs
+        holder[0].run(packed, out=[_integer_view(out)])
+        result = out
+
+    key = (tuple(packed.shape), packed.dtype, tuple(dims))
+    if key not in _verified:
+        if not torch.equal(result.cpu(), src.cpu().permute(dims)):
+            raise RuntimeError(
+                f"compiled_permute: the compiler miscomputes permute({dims}) for shape "
+                f"{tuple(src.shape)}; use the eager path for this permutation"
+            )
+        with _lock:
+            _verified.add(key)
+    return result

--- a/torch_rbln/csrc/rbln/Module.cpp
+++ b/torch_rbln/csrc/rbln/Module.cpp
@@ -1,5 +1,6 @@
 #include <ATen/native/rbln/RBLNCPUFallback.h>
 #include <ATen/native/rbln/RBLNCPUFastPaths.h>
+#include <ATen/native/rbln/RBLNCompiledPermute.h>
 #include <ATen/native/rbln/RBLNCopy.h>
 #include <ATen/native/rbln/RBLNTensorUtils.h>
 #include <c10/core/impl/VirtualGuardImpl.h>
@@ -201,6 +202,12 @@ void check_base_rbln_tensor(const at::Tensor& t, const char* api, const char* na
  * @param module The Python module to register the functions with
  */
 void register_internal_api(py::module_& module) {
+  // The compiler is driven from Python, so the native side reaches it through this hook.
+  at::native::rbln::set_compiled_permute_impl(
+      [](const at::Tensor& src, at::IntArrayRef dims, int64_t slot, const at::Tensor& out) {
+        py::gil_scoped_acquire gil;
+        py::module_::import("torch_rbln.compiled_permute").attr("compiled_permute")(src, dims.vec(), slot, out);
+      });
   // Tensor creation and manipulation functions
   module.def(
       "_create_tensor_from_ptr", &at::native::rbln::create_tensor_from_ptr, "Internal: create tensor from device ptr");

--- a/torch_rbln/device/__init__.py
+++ b/torch_rbln/device/__init__.py
@@ -2,4 +2,5 @@ from torch_rbln.device.device import *  # noqa: F403
 from torch_rbln.device.device_tensor_utils import *  # noqa: F403
 from torch_rbln.device.streams import *  # noqa: F403
 from torch_rbln.memory import *  # noqa: F403
+from torch_rbln.compiled_permute import *  # noqa: F403
 from torch_rbln.profiler import *  # noqa: F403


### PR DESCRIPTION
## What

Part 1/2 of a stacked KV-transfer optimization (rebel_compiler → torch-rbln → LMCache); full
context, cross-repo branch map and measured A/B numbers at
https://github.com/rebellions-sw/fsw-inference/issues/540. Depends on rebel_compiler's identity-
transform planning fix (rebellions-sw/rebel_compiler#13290).

`copy_()` now recognises a large permuted RBLN source (a pure permutation of a contiguous
tensor, above a 16 MiB threshold, last dim preserved) and runs the permutation as a compiled
device program instead of a strided walk.

- A program binds its operands once; rebinding a 117 MB buffer costs ~2 ms, so a caller that
  alternates buffers (a double-buffered pipeline) gets one program per source address (`slot`,
  capped at 8).
- Compiled once per (shape, dtype, dims) and cached on disk (`TORCH_RBLN_CACHE_DIR`).
- The compiler silently miscomputes some permutations (`[2, 0, 1, 3]` among them). Each program
  is checked against a host reference on first use; one that fails raises rather than returning
  wrong data, and the caller falls back to the strided walk.

## Why

A permuted device-to-device copy walks one strided range per contiguous inner block -- 256 B
for a head<->token swap -- at ~1.3 GB/s. The compiled program moves the same 117 MB in ~0.4 ms
(~100x). This is the single biggest factor in LMCache's KV-transfer speedup (see issue #540
§3, "device transpose" line).

## Tests

`test/rbln/test_compiled_permute.py`.

## Stack

1. **This PR** -- compiled permutation as a `copy_()` fast path
2. #TBD -- pinned host memory (`register_host_memory` / `unregister_host_memory`)