### PR TITLE
feat(memory): pin host memory through the runtime's registration API

### DIFF
--- a/c10/rbln/RBLNFunctions.cpp
+++ b/c10/rbln/RBLNFunctions.cpp
@@ -2,6 +2,7 @@
 #include <c10/rbln/DeviceMappingManager.h>
 #include <c10/rbln/RBLNFunctions.h>
 #include <c10/rbln/RBLNLogging.h>
+#include <c10/rbln/RBLNPinnedAllocator.h>
 #include <c10/util/CallOnce.h>
 #include <rebel/runtime/memory_stats.h>
 
@@ -652,6 +653,9 @@ void memcpy_h2v(void* rbln_dst_data, const void* cpu_src_data, size_t nbytes) {
   const auto src_host_ptr = reinterpret_cast<uintptr_t>(cpu_src_data);
   const auto dst_vaddr = reinterpret_cast<uint64_t>(rbln_dst_data);
   const auto size = static_cast<uint64_t>(nbytes);
+  // A pinned source is registered with the target device (once) so the copy is
+  // recorded by DVA and skips the per-command-buffer pin.
+  ensure_pinned_registered(cpu_src_data, static_cast<int>(get_torch_device_id(rbln_dst_data)));
   RBLN_LOG_DEBUG(
       "Calling rbln_memcpy_h2v: src_host_ptr={:#x}, dst_vaddr={:#x}, size={}", src_host_ptr, dst_vaddr, size);
   RBLN_CHECK(
@@ -672,6 +676,7 @@ void memcpy_v2h(void* cpu_dst_data, const void* rbln_src_data, size_t nbytes) {
   const auto src_vaddr = reinterpret_cast<uint64_t>(rbln_src_data);
   const auto dst_host_ptr = reinterpret_cast<uintptr_t>(cpu_dst_data);
   const auto size = static_cast<uint64_t>(nbytes);
+  ensure_pinned_registered(cpu_dst_data, static_cast<int>(get_torch_device_id(rbln_src_data)));
   RBLN_LOG_DEBUG(
       "Calling rbln_memcpy_v2h: src_vaddr={:#x}, dst_host_ptr={:#x}, size={}", src_vaddr, dst_host_ptr, size);
   RBLN_CHECK(
@@ -742,6 +747,7 @@ void memcpy_h2v_async(void* rbln_dst_data, const void* cpu_src_data, size_t nbyt
   const auto dst_vaddr = reinterpret_cast<uint64_t>(rbln_dst_data);
   const auto size = static_cast<uint64_t>(nbytes);
   uint64_t handle = 0;
+  ensure_pinned_registered(cpu_src_data, static_cast<int>(get_torch_device_id(rbln_dst_data)));
   RBLN_LOG_DEBUG(
       "Calling rbln_memcpy_h2v_async: src_host_ptr={:#x}, dst_vaddr={:#x}, size={}", src_host_ptr, dst_vaddr, size);
   RBLN_CHECK(
@@ -763,6 +769,7 @@ void memcpy_v2h_async(void* cpu_dst_data, const void* rbln_src_data, size_t nbyt
   const auto dst_host_ptr = reinterpret_cast<uintptr_t>(cpu_dst_data);
   const auto size = static_cast<uint64_t>(nbytes);
   uint64_t handle = 0;
+  ensure_pinned_registered(cpu_dst_data, static_cast<int>(get_torch_device_id(rbln_src_data)));
   RBLN_LOG_DEBUG(
       "Calling rbln_memcpy_v2h_async: src_vaddr={:#x}, dst_host_ptr={:#x}, size={}", src_vaddr, dst_host_ptr, size);
   RBLN_CHECK(
@@ -1041,6 +1048,7 @@ void memcpy_h2v_multi(const std::vector<H2VCopyOp>& copies) {
     RBLN_CHECK(c.nbytes > 0, "memcpy_h2v_multi: nbytes must be positive");
     RBLN_CHECK(c.src != nullptr, "memcpy_h2v_multi: src cannot be nullptr");
     RBLN_CHECK(c.dst != nullptr, "memcpy_h2v_multi: dst cannot be nullptr");
+    ensure_pinned_registered(c.src, static_cast<int>(get_torch_device_id(c.dst)));
     rbln_copies.emplace_back(
         reinterpret_cast<uintptr_t>(c.src), reinterpret_cast<uint64_t>(c.dst), static_cast<uint64_t>(c.nbytes));
   }
@@ -1062,6 +1070,7 @@ void memcpy_v2h_multi(const std::vector<V2HCopyOp>& copies) {
     RBLN_CHECK(c.nbytes > 0, "memcpy_v2h_multi: nbytes must be positive");
     RBLN_CHECK(c.src != nullptr, "memcpy_v2h_multi: src cannot be nullptr");
     RBLN_CHECK(c.dst != nullptr, "memcpy_v2h_multi: dst cannot be nullptr");
+    ensure_pinned_registered(c.dst, static_cast<int>(get_torch_device_id(c.src)));
     rbln_copies.emplace_back(
         reinterpret_cast<uint64_t>(c.src), reinterpret_cast<uintptr_t>(c.dst), static_cast<uint64_t>(c.nbytes));
   }

--- a/c10/rbln/RBLNHostBatch.cpp
+++ b/c10/rbln/RBLNHostBatch.cpp
@@ -15,19 +15,10 @@ namespace c10::rbln {
 
 namespace {
 
-// Work one bulk call of *pageable* host memory may carry. Past it the job never
-// completes: the kernel pins every raw host operand of a command buffer at
-// rblnEndCommandBuffer(), and pinning more than this per CB runs into the device's
-// SYS_KERNEL_TIMEOUT, which cancels the context so the per-entry retry below
-// cannot recover either. Measured on lmcache's D2H store, 24 entries / 12 MiB
-// pass and 32 / 16 MiB start timing out.
-//
-// Pinned host memory (the pinned allocator, register_host_memory) is exempt: it
-// is already registered with the runtime and addressed by device VA, so End()
-// pins nothing, and the runtime splits the call into command buffers of at most
-// its own per-CB copy count itself. Handing it the whole group lets it coalesce
-// adjacent descriptors and dispatch far fewer round trips -- a 268 MiB gather
-// of 4 MiB pieces runs at 39 GB/s as one call against 28 GB/s in 8 MiB calls.
+// Caps for *pageable* host memory: the kernel pins every raw host operand at
+// rblnEndCommandBuffer(), and more than this per CB hits SYS_KERNEL_TIMEOUT (measured:
+// 24 entries / 12 MiB pass, 32 / 16 MiB time out). Pinned memory is exempt -- it is
+// addressed by device VA, and one call lets the runtime coalesce descriptors.
 constexpr size_t kMaxBulkEntries = 16;
 constexpr size_t kMaxBulkBytes = size_t{8} * 1024 * 1024;
 

--- a/c10/rbln/RBLNHostBatch.cpp
+++ b/c10/rbln/RBLNHostBatch.cpp
@@ -2,6 +2,7 @@
 #include <c10/rbln/RBLNFunctions.h>
 #include <c10/rbln/RBLNHostBatch.h>
 #include <c10/rbln/RBLNLogging.h>
+#include <c10/rbln/RBLNPinnedAllocator.h>
 #include <c10/rbln/RBLNProfiler.h>
 #include <c10/rbln/detail/RBLNCopyBatchImpl.h>
 
@@ -14,10 +15,19 @@ namespace c10::rbln {
 
 namespace {
 
-// Work one bulk call may carry. Past it the job never completes: the device
-// reports SYS_KERNEL_TIMEOUT and cancels the context, so the per-entry retry
-// below cannot recover either. Measured on lmcache's D2H store, 24 entries /
-// 12 MiB pass and 32 / 16 MiB start timing out.
+// Work one bulk call of *pageable* host memory may carry. Past it the job never
+// completes: the kernel pins every raw host operand of a command buffer at
+// rblnEndCommandBuffer(), and pinning more than this per CB runs into the device's
+// SYS_KERNEL_TIMEOUT, which cancels the context so the per-entry retry below
+// cannot recover either. Measured on lmcache's D2H store, 24 entries / 12 MiB
+// pass and 32 / 16 MiB start timing out.
+//
+// Pinned host memory (the pinned allocator, register_host_memory) is exempt: it
+// is already registered with the runtime and addressed by device VA, so End()
+// pins nothing, and the runtime splits the call into command buffers of at most
+// its own per-CB copy count itself. Handing it the whole group lets it coalesce
+// adjacent descriptors and dispatch far fewer round trips -- a 268 MiB gather
+// of 4 MiB pieces runs at 39 GB/s as one call against 28 GB/s in 8 MiB calls.
 constexpr size_t kMaxBulkEntries = 16;
 constexpr size_t kMaxBulkBytes = size_t{8} * 1024 * 1024;
 
@@ -53,16 +63,26 @@ void submit_one_call(const std::vector<Desc>& group, const char* who, const Bulk
 /**
  * @brief Flush one homogeneous group, in as few bulk calls as the cap allows.
  */
-template <typename Desc, typename BulkFn, typename OneFn>
-void flush_group(const std::vector<Desc>& group, const char* who, const BulkFn& bulk, const OneFn& one) {
+template <typename Desc, typename HostFn, typename BulkFn, typename OneFn>
+void flush_group(
+    const std::vector<Desc>& group,
+    const char* who,
+    const HostFn& host_of,
+    const BulkFn& bulk,
+    const OneFn& one) {
   if (group.empty()) {
     return;
   }
   size_t total = 0;
+  bool all_pinned = true;
   for (const auto& e : group) {
     total += e.nbytes;
+    all_pinned = all_pinned && is_pinned_ptr(host_of(e));
   }
-  if (group.size() <= kMaxBulkEntries && total <= kMaxBulkBytes) {
+  if (all_pinned || (group.size() <= kMaxBulkEntries && total <= kMaxBulkBytes)) {
+    if (all_pinned && (group.size() > kMaxBulkEntries || total > kMaxBulkBytes)) {
+      RBLN_LOG_DEBUG("{}::submit {} pinned entries / {} bytes in one call (cap waived)", who, group.size(), total);
+    }
     submit_one_call(group, who, bulk, one);
     return;
   }
@@ -104,16 +124,17 @@ void flush_group(const std::vector<Desc>& group, const char* who, const BulkFn& 
  *
  * @param device_of Returns the anchoring (device-side) pointer of an entry.
  */
-template <typename Desc, typename AnchorFn, typename BulkFn, typename OneFn>
+template <typename Desc, typename AnchorFn, typename HostFn, typename BulkFn, typename OneFn>
 void submit_grouped(
     detail::BatchState<Desc>& st,
     const char* who,
     const AnchorFn& device_of,
+    const HostFn& host_of,
     const BulkFn& bulk,
     const OneFn& one) {
   if (st.homogeneous) {
     RBLN_LOG_DEBUG("{}::submit draining {} entries (single device)", who, st.pending.size());
-    flush_group(st.pending, who, bulk, one);
+    flush_group(st.pending, who, host_of, bulk, one);
     return;
   }
   // Ordered so submit order is deterministic by device index.
@@ -124,7 +145,7 @@ void submit_grouped(
   RBLN_LOG_DEBUG(
       "{}::submit draining {} entries across {} devices (split submit)", who, st.pending.size(), by_device.size());
   for (const auto& [dev, group] : by_device) {
-    flush_group(group, who, bulk, one);
+    flush_group(group, who, host_of, bulk, one);
   }
 }
 
@@ -177,6 +198,7 @@ void H2VBatch::submit() {
       impl_->st,
       kH2VWho,
       [](const H2VCopyOp& e) { return e.dst; },
+      [](const H2VCopyOp& e) { return e.src; },
       [](const std::vector<H2VCopyOp>& g) { memcpy_h2v_multi(g); },
       [](const H2VCopyOp& e) { memcpy_h2v(e.dst, e.src, e.nbytes); });
 }
@@ -229,6 +251,7 @@ void V2HBatch::submit() {
       impl_->st,
       kV2HWho,
       [](const V2HCopyOp& e) { return e.src; },
+      [](const V2HCopyOp& e) { return e.dst; },
       [](const std::vector<V2HCopyOp>& g) { memcpy_v2h_multi(g); },
       [](const V2HCopyOp& e) { memcpy_v2h(e.dst, e.src, e.nbytes); });
 }

--- a/c10/rbln/RBLNPinnedAllocator.cpp
+++ b/c10/rbln/RBLNPinnedAllocator.cpp
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <iterator>
 #include <map>
 #include <mutex>
 #include <vector>
@@ -23,6 +24,8 @@ struct PinnedRange {
   size_t nbytes = 0;
   // Runtime (torch) device ids the range is registered with, ascending.
   std::vector<int> registered_devices;
+  // Caller-owned memory registered through register_host_memory(): never freed here.
+  bool external = false;
 };
 
 // Allocation base -> range; ordered so interior pointers match via upper_bound.
@@ -91,6 +94,29 @@ void register_range_on(uintptr_t base, size_t nbytes, int torch_device_id) noexc
   RBLN_LOG_DEBUG("Registered pinned host memory {:#x} ({} bytes) on torch_device_id={}", base, nbytes, torch_device_id);
 }
 
+// Unregister `range` (starting at `data`) from every device it was registered with. The
+// runtime drains pending transfers on unregister, so the pages are not handed back while a
+// DMA may still target them. Skipped once the runtime is torn down -- the context release
+// covered the KMD side already.
+void unregister_range_everywhere(void* data, const PinnedRange& range) noexcept {
+  if (range.registered_devices.empty() || !rbln_runtime_available()) {
+    return;
+  }
+  for (int torch_device_id : range.registered_devices) {
+    if (::rbln::rbln_host_unregister(static_cast<uint32_t>(torch_device_id), reinterpret_cast<uintptr_t>(data)) !=
+        RBLNRetCode_SUCCESS) {
+      RBLN_LOG_DEBUG("rbln_host_unregister({}) failed on torch_device_id={}", fmt::ptr(data), torch_device_id);
+    }
+  }
+}
+
+// Register [base, base + nbytes) on every device this process has initialized.
+void register_range_on_initialized_devices(uintptr_t base, size_t nbytes) noexcept {
+  for (const auto device_index : initialized_device_indices()) {
+    register_range_on(base, nbytes, static_cast<int>(device_index));
+  }
+}
+
 void raw_pinned_delete(void* data) {
   if (data == nullptr) {
     return;
@@ -105,17 +131,7 @@ void raw_pinned_delete(void* data) {
       pinned_registry.erase(it);
     }
   }
-  // Unregister before freeing: the runtime drains pending transfers on unregister, so the
-  // pages are not returned to libc while a DMA may still target them. Skipped once the
-  // runtime is torn down -- the context release covered the KMD side already.
-  if (!range.registered_devices.empty() && rbln_runtime_available()) {
-    for (int torch_device_id : range.registered_devices) {
-      if (::rbln::rbln_host_unregister(static_cast<uint32_t>(torch_device_id), reinterpret_cast<uintptr_t>(data)) !=
-          RBLNRetCode_SUCCESS) {
-        RBLN_LOG_DEBUG("rbln_host_unregister({}) failed on torch_device_id={}", fmt::ptr(data), torch_device_id);
-      }
-    }
-  }
+  unregister_range_everywhere(data, range);
   if (range.nbytes > 0) {
     munlock(data, range.nbytes); // best-effort, mirrors the mlock in allocate
     if (range.nbytes >= kHugePage) {
@@ -160,9 +176,7 @@ struct RBLNPinnedAllocator final : public c10::Allocator {
       }
       // Registration wants the whole allocation, page-multiple and aligned, which is what
       // alloc_bytes is; the tensor's nbytes may end mid-page.
-      for (const auto device_index : initialized_device_indices()) {
-        register_range_on(reinterpret_cast<uintptr_t>(data), alloc_bytes, static_cast<int>(device_index));
-      }
+      register_range_on_initialized_devices(reinterpret_cast<uintptr_t>(data), alloc_bytes);
     }
     return c10::DataPtr(data, data, &raw_pinned_delete, c10::Device(c10::kCPU));
   }
@@ -216,6 +230,56 @@ void ensure_pinned_registered(const void* data, int torch_device_id) noexcept {
     nbytes = it->second.nbytes;
   }
   register_range_on(base, nbytes, torch_device_id);
+}
+
+void register_host_memory(void* data, size_t nbytes) {
+  TORCH_CHECK(data != nullptr, "register_host_memory: data cannot be nullptr");
+  TORCH_CHECK(nbytes > 0, "register_host_memory: nbytes must be positive");
+  const auto base = reinterpret_cast<uintptr_t>(data);
+  {
+    const std::lock_guard<std::mutex> guard(pinned_registry_mutex);
+    // Overlap with any live range (allocator or external) is refused: two registrations of
+    // one page would need two runtime pins and an ambiguous reverse lookup.
+    auto next = pinned_registry.lower_bound(base);
+    TORCH_CHECK(
+        next == pinned_registry.end() || next->first >= base + nbytes,
+        "register_host_memory: [",
+        fmt::ptr(data),
+        ", +",
+        nbytes,
+        ") overlaps a registered range");
+    if (next != pinned_registry.begin()) {
+      auto prev = std::prev(next);
+      TORCH_CHECK(
+          prev->first + prev->second.nbytes <= base,
+          "register_host_memory: [",
+          fmt::ptr(data),
+          ", +",
+          nbytes,
+          ") overlaps a registered range");
+    }
+    pinned_registry.emplace(base, PinnedRange{nbytes, {}, /*external=*/true});
+  }
+  RBLN_LOG_DEBUG("Registered external host memory {} ({} bytes)", fmt::ptr(data), nbytes);
+  register_range_on_initialized_devices(base, nbytes);
+}
+
+void unregister_host_memory(void* data) {
+  TORCH_CHECK(data != nullptr, "unregister_host_memory: data cannot be nullptr");
+  PinnedRange range;
+  {
+    const std::lock_guard<std::mutex> guard(pinned_registry_mutex);
+    auto it = pinned_registry.find(reinterpret_cast<uintptr_t>(data));
+    TORCH_CHECK(
+        it != pinned_registry.end() && it->second.external,
+        "unregister_host_memory: ",
+        fmt::ptr(data),
+        " is not the start of a range registered with register_host_memory");
+    range = std::move(it->second);
+    pinned_registry.erase(it);
+  }
+  unregister_range_everywhere(data, range);
+  RBLN_LOG_DEBUG("Unregistered external host memory {}", fmt::ptr(data));
 }
 
 bool pinned_ptr_registered_on(const void* data, int torch_device_id) noexcept {

--- a/c10/rbln/RBLNPinnedAllocator.cpp
+++ b/c10/rbln/RBLNPinnedAllocator.cpp
@@ -42,9 +42,7 @@ std::map<uintptr_t, PinnedRange>::iterator find_containing_locked(uintptr_t addr
   return addr < it->first + it->second.nbytes ? it : pinned_registry.end();
 }
 
-// Whether the loaded runtime can register host memory for `torch_device_id`. Cached per
-// device: the answer only depends on the thunk, a flag read at startup, and the device
-// being real, none of which change within a process.
+// Whether the runtime can register host memory for `torch_device_id` (cached per device).
 bool host_register_supported(int torch_device_id) noexcept {
   static std::mutex mutex;
   static std::map<int, bool> cache;
@@ -66,9 +64,7 @@ bool host_register_supported(int torch_device_id) noexcept {
   return supported;
 }
 
-// Register [base, base + nbytes) on `torch_device_id`. Caller holds no lock; the range
-// entry is updated under the registry lock only on success so a concurrent copy never
-// sees a device that is not actually registered.
+// Register [base, base + nbytes) on `torch_device_id`; the range entry is updated only on success.
 void register_range_on(uintptr_t base, size_t nbytes, int torch_device_id) noexcept {
   if (!host_register_supported(torch_device_id)) {
     return;
@@ -94,10 +90,7 @@ void register_range_on(uintptr_t base, size_t nbytes, int torch_device_id) noexc
   RBLN_LOG_DEBUG("Registered pinned host memory {:#x} ({} bytes) on torch_device_id={}", base, nbytes, torch_device_id);
 }
 
-// Unregister `range` (starting at `data`) from every device it was registered with. The
-// runtime drains pending transfers on unregister, so the pages are not handed back while a
-// DMA may still target them. Skipped once the runtime is torn down -- the context release
-// covered the KMD side already.
+// Unregister `range` from every device it was registered with (skipped once the runtime is gone).
 void unregister_range_everywhere(void* data, const PinnedRange& range) noexcept {
   if (range.registered_devices.empty() || !rbln_runtime_available()) {
     return;
@@ -154,8 +147,7 @@ struct RBLNPinnedAllocator final : public c10::Allocator {
     void* data = nullptr;
     if (nbytes > 0) {
       static const size_t page_size = static_cast<size_t>(sysconf(_SC_PAGESIZE));
-      // From 2 MiB up, align to and advise huge pages: fewer, larger pins for the DMA
-      // engine and the kernel alike. Below that a page is the natural unit.
+      // From 2 MiB up, align to and advise huge pages (fewer, larger pins).
       const bool huge = nbytes >= kHugePage;
       const size_t alignment = huge ? kHugePage : page_size;
       const size_t alloc_bytes = huge ? (nbytes + kHugePage - 1) / kHugePage * kHugePage : nbytes;
@@ -174,8 +166,6 @@ struct RBLNPinnedAllocator final : public c10::Allocator {
         const std::lock_guard<std::mutex> guard(pinned_registry_mutex);
         pinned_registry.emplace(reinterpret_cast<uintptr_t>(data), PinnedRange{alloc_bytes, {}});
       }
-      // Registration wants the whole allocation, page-multiple and aligned, which is what
-      // alloc_bytes is; the tensor's nbytes may end mid-page.
       register_range_on_initialized_devices(reinterpret_cast<uintptr_t>(data), alloc_bytes);
     }
     return c10::DataPtr(data, data, &raw_pinned_delete, c10::Device(c10::kCPU));
@@ -238,8 +228,7 @@ void register_host_memory(void* data, size_t nbytes) {
   const auto base = reinterpret_cast<uintptr_t>(data);
   {
     const std::lock_guard<std::mutex> guard(pinned_registry_mutex);
-    // Overlap with any live range (allocator or external) is refused: two registrations of
-    // one page would need two runtime pins and an ambiguous reverse lookup.
+    // Overlap with a live range is refused.
     auto next = pinned_registry.lower_bound(base);
     TORCH_CHECK(
         next == pinned_registry.end() || next->first >= base + nbytes,

--- a/c10/rbln/RBLNPinnedAllocator.cpp
+++ b/c10/rbln/RBLNPinnedAllocator.cpp
@@ -1,37 +1,126 @@
+#include <c10/rbln/RBLNFunctions.h>
 #include <c10/rbln/RBLNLogging.h>
 #include <c10/rbln/RBLNPinnedAllocator.h>
+
+#include <rebel/runtime/api/rbln_runtime_api.h>
 
 #include <sys/mman.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <cstdlib>
 #include <map>
 #include <mutex>
+#include <vector>
 
 namespace c10::rbln {
 
 namespace {
 
-// Allocation base -> size; ordered so interior pointers match via upper_bound.
+constexpr size_t kHugePage = size_t{2} << 20;
+
+struct PinnedRange {
+  size_t nbytes = 0;
+  // Runtime (torch) device ids the range is registered with, ascending.
+  std::vector<int> registered_devices;
+};
+
+// Allocation base -> range; ordered so interior pointers match via upper_bound.
 std::mutex pinned_registry_mutex;
-std::map<uintptr_t, size_t> pinned_registry;
+std::map<uintptr_t, PinnedRange> pinned_registry;
+
+// Locked lookup of the allocation containing `addr`; end() when there is none.
+std::map<uintptr_t, PinnedRange>::iterator find_containing_locked(uintptr_t addr) {
+  auto it = pinned_registry.upper_bound(addr);
+  if (it == pinned_registry.begin()) {
+    return pinned_registry.end();
+  }
+  --it;
+  return addr < it->first + it->second.nbytes ? it : pinned_registry.end();
+}
+
+// Whether the loaded runtime can register host memory for `torch_device_id`. Cached per
+// device: the answer only depends on the thunk, a flag read at startup, and the device
+// being real, none of which change within a process.
+bool host_register_supported(int torch_device_id) noexcept {
+  static std::mutex mutex;
+  static std::map<int, bool> cache;
+  const std::lock_guard<std::mutex> guard(mutex);
+  auto it = cache.find(torch_device_id);
+  if (it != cache.end()) {
+    return it->second;
+  }
+  bool supported = false;
+  if (::rbln::rbln_host_register_supported(static_cast<uint32_t>(torch_device_id), supported) != RBLNRetCode_SUCCESS) {
+    supported = false;
+  }
+  if (!supported) {
+    RBLN_LOG_DEBUG(
+        "Host-memory registration unavailable on torch_device_id={}; pinned buffers stay unregistered",
+        torch_device_id);
+  }
+  cache.emplace(torch_device_id, supported);
+  return supported;
+}
+
+// Register [base, base + nbytes) on `torch_device_id`. Caller holds no lock; the range
+// entry is updated under the registry lock only on success so a concurrent copy never
+// sees a device that is not actually registered.
+void register_range_on(uintptr_t base, size_t nbytes, int torch_device_id) noexcept {
+  if (!host_register_supported(torch_device_id)) {
+    return;
+  }
+  if (::rbln::rbln_host_register(static_cast<uint32_t>(torch_device_id), base, static_cast<uint64_t>(nbytes)) !=
+      RBLNRetCode_SUCCESS) {
+    RBLN_LOG_DEBUG(
+        "rbln_host_register({:#x}, {} bytes) failed on torch_device_id={}; copies keep the per-command-buffer pin",
+        base,
+        nbytes,
+        torch_device_id);
+    return;
+  }
+  const std::lock_guard<std::mutex> guard(pinned_registry_mutex);
+  auto it = pinned_registry.find(base);
+  if (it == pinned_registry.end()) {
+    // Freed while we were registering: undo, the deleter already ran without this device.
+    ::rbln::rbln_host_unregister(static_cast<uint32_t>(torch_device_id), base);
+    return;
+  }
+  auto& devices = it->second.registered_devices;
+  devices.insert(std::upper_bound(devices.begin(), devices.end(), torch_device_id), torch_device_id);
+  RBLN_LOG_DEBUG("Registered pinned host memory {:#x} ({} bytes) on torch_device_id={}", base, nbytes, torch_device_id);
+}
 
 void raw_pinned_delete(void* data) {
   if (data == nullptr) {
     return;
   }
   RBLN_LOG_DEBUG("Freeing pinned host memory at {}", fmt::ptr(data));
-  size_t nbytes = 0;
+  PinnedRange range;
   {
     const std::lock_guard<std::mutex> guard(pinned_registry_mutex);
     auto it = pinned_registry.find(reinterpret_cast<uintptr_t>(data));
     if (it != pinned_registry.end()) {
-      nbytes = it->second;
+      range = std::move(it->second);
       pinned_registry.erase(it);
     }
   }
-  if (nbytes > 0) {
-    munlock(data, nbytes); // best-effort, mirrors the mlock in allocate
+  // Unregister before freeing: the runtime drains pending transfers on unregister, so the
+  // pages are not returned to libc while a DMA may still target them. Skipped once the
+  // runtime is torn down -- the context release covered the KMD side already.
+  if (!range.registered_devices.empty() && rbln_runtime_available()) {
+    for (int torch_device_id : range.registered_devices) {
+      if (::rbln::rbln_host_unregister(static_cast<uint32_t>(torch_device_id), reinterpret_cast<uintptr_t>(data)) !=
+          RBLNRetCode_SUCCESS) {
+        RBLN_LOG_DEBUG("rbln_host_unregister({}) failed on torch_device_id={}", fmt::ptr(data), torch_device_id);
+      }
+    }
+  }
+  if (range.nbytes > 0) {
+    munlock(data, range.nbytes); // best-effort, mirrors the mlock in allocate
+    if (range.nbytes >= kHugePage) {
+      madvise(data, range.nbytes, MADV_NOHUGEPAGE);
+    }
   }
   // Allocator deleters work on raw pointers from posix_memalign; RAII does not apply.
   std::free(data); // NOLINT(cppcoreguidelines-no-malloc)
@@ -39,7 +128,8 @@ void raw_pinned_delete(void* data) {
 
 struct RBLNPinnedAllocator final : public c10::Allocator {
   /**
-   * @brief Allocates page-aligned host memory and page-locks it (best effort).
+   * @brief Allocates page-aligned host memory, page-locks it (best effort) and registers
+   * it with the runtime on every initialized RBLN device.
    *
    * @param nbytes The number of bytes to allocate.
    * @return A data pointer to the pinned host memory (device is CPU).
@@ -48,16 +138,31 @@ struct RBLNPinnedAllocator final : public c10::Allocator {
     void* data = nullptr;
     if (nbytes > 0) {
       static const size_t page_size = static_cast<size_t>(sysconf(_SC_PAGESIZE));
-      if (posix_memalign(&data, page_size, nbytes) != 0) {
+      // From 2 MiB up, align to and advise huge pages: fewer, larger pins for the DMA
+      // engine and the kernel alike. Below that a page is the natural unit.
+      const bool huge = nbytes >= kHugePage;
+      const size_t alignment = huge ? kHugePage : page_size;
+      const size_t alloc_bytes = huge ? (nbytes + kHugePage - 1) / kHugePage * kHugePage : nbytes;
+      if (posix_memalign(&data, alignment, alloc_bytes) != 0) {
         TORCH_CHECK(false, "Failed to allocate ", nbytes, " bytes of pinned host memory");
+      }
+      if (huge && madvise(data, alloc_bytes, MADV_HUGEPAGE) != 0) {
+        RBLN_LOG_DEBUG("madvise(MADV_HUGEPAGE) of {} bytes failed (errno={}); continuing", alloc_bytes, errno);
       }
       // RLIMIT_MEMLOCK failure is non-fatal: stays semantically pinned.
       if (mlock(data, nbytes) != 0) {
         RBLN_LOG_DEBUG("mlock of {} bytes failed (errno={}); continuing unlocked", nbytes, errno);
       }
       RBLN_LOG_DEBUG("Allocated {} bytes of pinned host memory at {}", nbytes, fmt::ptr(data));
-      const std::lock_guard<std::mutex> guard(pinned_registry_mutex);
-      pinned_registry.emplace(reinterpret_cast<uintptr_t>(data), nbytes);
+      {
+        const std::lock_guard<std::mutex> guard(pinned_registry_mutex);
+        pinned_registry.emplace(reinterpret_cast<uintptr_t>(data), PinnedRange{alloc_bytes, {}});
+      }
+      // Registration wants the whole allocation, page-multiple and aligned, which is what
+      // alloc_bytes is; the tensor's nbytes may end mid-page.
+      for (const auto device_index : initialized_device_indices()) {
+        register_range_on(reinterpret_cast<uintptr_t>(data), alloc_bytes, static_cast<int>(device_index));
+      }
     }
     return c10::DataPtr(data, data, &raw_pinned_delete, c10::Device(c10::kCPU));
   }
@@ -84,14 +189,46 @@ bool is_pinned_ptr(const void* data) {
   if (data == nullptr) {
     return false;
   }
-  const auto addr = reinterpret_cast<uintptr_t>(data);
   const std::lock_guard<std::mutex> guard(pinned_registry_mutex);
-  auto it = pinned_registry.upper_bound(addr);
-  if (it == pinned_registry.begin()) {
+  return find_containing_locked(reinterpret_cast<uintptr_t>(data)) != pinned_registry.end();
+}
+
+void ensure_pinned_registered(const void* data, int torch_device_id) noexcept {
+  if (data == nullptr) {
+    return;
+  }
+  uintptr_t base = 0;
+  size_t nbytes = 0;
+  {
+    const std::lock_guard<std::mutex> guard(pinned_registry_mutex);
+    if (pinned_registry.empty()) {
+      return;
+    }
+    auto it = find_containing_locked(reinterpret_cast<uintptr_t>(data));
+    if (it == pinned_registry.end()) {
+      return;
+    }
+    const auto& devices = it->second.registered_devices;
+    if (std::binary_search(devices.begin(), devices.end(), torch_device_id)) {
+      return;
+    }
+    base = it->first;
+    nbytes = it->second.nbytes;
+  }
+  register_range_on(base, nbytes, torch_device_id);
+}
+
+bool pinned_ptr_registered_on(const void* data, int torch_device_id) noexcept {
+  if (data == nullptr) {
     return false;
   }
-  --it;
-  return addr < it->first + it->second;
+  const std::lock_guard<std::mutex> guard(pinned_registry_mutex);
+  auto it = find_containing_locked(reinterpret_cast<uintptr_t>(data));
+  if (it == pinned_registry.end()) {
+    return false;
+  }
+  const auto& devices = it->second.registered_devices;
+  return std::binary_search(devices.begin(), devices.end(), torch_device_id);
 }
 
 } // namespace c10::rbln

--- a/c10/rbln/RBLNPinnedAllocator.h
+++ b/c10/rbln/RBLNPinnedAllocator.h
@@ -3,14 +3,26 @@
 #include <c10/core/Allocator.h>
 #include <c10/rbln/RBLNMacros.h>
 
+#include <cstdint>
+
 namespace c10::rbln {
 
 /**
  * @brief Returns the host allocator backing CPU tensors created with
  * `pin_memory=True` while the RBLN backend is the active accelerator.
  *
- * The UMD has no DMA-mapped host allocation API yet, so this is page-aligned
- * host memory with best-effort `mlock`; swap in the UMD API here when it lands.
+ * Page-aligned host memory (2 MiB-aligned and THP-advised from 2 MiB up), page-locked
+ * best effort, and -- the part that makes it "pinned" to the device -- registered with
+ * the runtime through `rbln_host_register` on every RBLN device this process has
+ * initialized. A registered buffer is addressed by its device VA in every later
+ * host<->device copy, so the kernel reuses one pin instead of pinning the pages on each
+ * command buffer (the RBLN counterpart of cudaHostRegister). Registration is best
+ * effort: on a runtime without it (UMD < 3.5, RBLN_HOST_MEMORY_REGISTER=0) the tensor is
+ * still pinned in the torch sense and copies take their usual path.
+ *
+ * A device initialized after the allocation picks the buffer up lazily: the copy
+ * entry points call ensure_pinned_registered() before handing the pointer to the
+ * runtime.
  *
  * @return The pinned host allocator. Never null.
  */
@@ -24,5 +36,26 @@ C10_RBLN_API c10::Allocator* get_pinned_memory_allocator();
  * @return True if the pointer is inside a pinned allocation.
  */
 C10_RBLN_API bool is_pinned_ptr(const void* data);
+
+/**
+ * @brief Registers the pinned allocation containing `data` with the runtime for
+ * `torch_device_id`, if it is pinned and not registered there yet. No-op for a
+ * pageable pointer, a device already covered, or a runtime without registration.
+ * Never throws: registration is an optimization, the copy that follows is correct
+ * either way.
+ *
+ * Called by the host<->device copy entry points with the device the copy targets,
+ * so an allocation made before that device was initialized still gets its pin.
+ *
+ * @param data A host pointer (any offset within the allocation).
+ * @param torch_device_id The runtime device id the copy targets.
+ */
+C10_RBLN_API void ensure_pinned_registered(const void* data, int torch_device_id) noexcept;
+
+/**
+ * @brief Whether the pinned allocation containing `data` is registered with the runtime
+ * for `torch_device_id`. Diagnostic; false for anything that is not pinned.
+ */
+C10_RBLN_API bool pinned_ptr_registered_on(const void* data, int torch_device_id) noexcept;
 
 } // namespace c10::rbln

--- a/c10/rbln/RBLNPinnedAllocator.h
+++ b/c10/rbln/RBLNPinnedAllocator.h
@@ -53,6 +53,33 @@ C10_RBLN_API bool is_pinned_ptr(const void* data);
 C10_RBLN_API void ensure_pinned_registered(const void* data, int torch_device_id) noexcept;
 
 /**
+ * @brief Registers a caller-owned host buffer as pinned: the RBLN counterpart of
+ * cudaHostRegister for memory this allocator did not hand out (a shared-memory pool, a
+ * cache's slab). The range enters the same registry as allocator memory, so is_pinned_ptr()
+ * reports it (non_blocking copies go async) and it is registered with every initialized
+ * device now and with any later device on its first copy. Overlapping a live range is an
+ * error; the caller keeps ownership of the memory and must unregister before freeing it.
+ *
+ * Runtime registration is best effort as everywhere else: without it (UMD < 3.5) the range
+ * is still "pinned" for torch's purposes and copies take their usual path.
+ *
+ * @param data Start of the buffer (page alignment is not required for the pin itself, but
+ *   only page-aligned copy operands take the device-VA path).
+ * @param nbytes Length in bytes; must be positive.
+ * @throws c10::Error on a null pointer, zero length, or overlap with a registered range.
+ */
+C10_RBLN_API void register_host_memory(void* data, size_t nbytes);
+
+/**
+ * @brief Reverses register_host_memory(). `data` must be the exact start passed to it.
+ * Unregisters from every device the range was registered with (the runtime drains the
+ * device's pending transfers first).
+ *
+ * @throws c10::Error if `data` is not a live external registration.
+ */
+C10_RBLN_API void unregister_host_memory(void* data);
+
+/**
  * @brief Whether the pinned allocation containing `data` is registered with the runtime
  * for `torch_device_id`. Diagnostic; false for anything that is not pinned.
  */

--- a/test/cpp/core/RBLNPinnedAllocatorTest.cpp
+++ b/test/cpp/core/RBLNPinnedAllocatorTest.cpp
@@ -1,9 +1,11 @@
 #include <c10/rbln/RBLNFunctions.h>
 #include <c10/rbln/RBLNPinnedAllocator.h>
+#include <c10/util/Exception.h>
 #include <gtest/gtest.h>
 
 #include <cstdint>
 #include <cstring>
+#include <vector>
 
 class RBLNPinnedAllocatorTest : public ::testing::Test {};
 
@@ -142,4 +144,51 @@ TEST_F(RBLNPinnedAllocatorRegisterTest, RegisteredCopyRoundTrips) {
   c10::rbln::memcpy_v2h(d, dev, nbytes);
   c10::rbln::free(dev);
   EXPECT_EQ(std::memcmp(s, d, nbytes), 0);
+}
+
+// --- register_host_memory: caller-owned memory ---------------------------------------
+
+TEST(RBLNRegisterHostMemoryTest, RegisteredRangeIsPinnedUntilUnregistered) {
+  std::vector<uint8_t> buf(3 * 4096);
+  auto* base = buf.data();
+  EXPECT_FALSE(c10::rbln::is_pinned_ptr(base));
+  c10::rbln::register_host_memory(base, buf.size());
+  EXPECT_TRUE(c10::rbln::is_pinned_ptr(base));
+  EXPECT_TRUE(c10::rbln::is_pinned_ptr(base + buf.size() - 1));
+  EXPECT_FALSE(c10::rbln::is_pinned_ptr(base + buf.size()));
+  c10::rbln::unregister_host_memory(base);
+  EXPECT_FALSE(c10::rbln::is_pinned_ptr(base));
+}
+
+TEST(RBLNRegisterHostMemoryTest, RejectsOverlapNullAndUnknown) {
+  std::vector<uint8_t> buf(2 * 4096);
+  auto* base = buf.data();
+  c10::rbln::register_host_memory(base, buf.size());
+  EXPECT_THROW(c10::rbln::register_host_memory(base + 4096, 4096), c10::Error);
+  EXPECT_THROW(c10::rbln::register_host_memory(base - 1, 2), c10::Error);
+  EXPECT_THROW(c10::rbln::unregister_host_memory(base + 4096), c10::Error);
+  c10::rbln::unregister_host_memory(base);
+  EXPECT_THROW(c10::rbln::unregister_host_memory(base), c10::Error);
+  EXPECT_THROW(c10::rbln::register_host_memory(nullptr, 4096), c10::Error);
+  EXPECT_THROW(c10::rbln::register_host_memory(base, 0), c10::Error);
+}
+
+TEST(RBLNRegisterHostMemoryTest, AllocatorMemoryIsNotExternal) {
+  auto data_ptr = c10::rbln::get_pinned_memory_allocator()->allocate(4096);
+  EXPECT_THROW(c10::rbln::register_host_memory(data_ptr.get(), 4096), c10::Error);
+  EXPECT_THROW(c10::rbln::unregister_host_memory(data_ptr.get()), c10::Error);
+  EXPECT_TRUE(c10::rbln::is_pinned_ptr(data_ptr.get()));
+}
+
+TEST_F(RBLNPinnedAllocatorRegisterTest, ExternalRangeIsRegisteredWithTheDevice) {
+  std::vector<uint8_t> storage(3 * 4096 + 4095);
+  // Page-align the start so the device-VA path applies.
+  auto base = reinterpret_cast<uintptr_t>(storage.data());
+  base = (base + 4095) & ~uintptr_t{4095};
+  auto* data = reinterpret_cast<uint8_t*>(base);
+  c10::rbln::register_host_memory(data, 3 * 4096);
+  EXPECT_TRUE(c10::rbln::pinned_ptr_registered_on(data, 0));
+  EXPECT_TRUE(c10::rbln::pinned_ptr_registered_on(data + 4096, 0));
+  c10::rbln::unregister_host_memory(data);
+  EXPECT_FALSE(c10::rbln::pinned_ptr_registered_on(data, 0));
 }

--- a/test/cpp/core/RBLNPinnedAllocatorTest.cpp
+++ b/test/cpp/core/RBLNPinnedAllocatorTest.cpp
@@ -1,3 +1,4 @@
+#include <c10/rbln/RBLNFunctions.h>
 #include <c10/rbln/RBLNPinnedAllocator.h>
 #include <gtest/gtest.h>
 
@@ -48,4 +49,97 @@ TEST_F(RBLNPinnedAllocatorTest, ZeroByteAllocationIsNull) {
   auto data_ptr = c10::rbln::get_pinned_memory_allocator()->allocate(0);
   EXPECT_EQ(data_ptr.get(), nullptr);
   EXPECT_FALSE(c10::rbln::is_pinned_ptr(data_ptr.get()));
+}
+
+// --- Runtime registration (needs a device) -------------------------------------------
+
+class RBLNPinnedAllocatorRegisterTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    if (c10::rbln::get_device_count_nothrow() < 1) {
+      GTEST_SKIP() << "no RBLN device";
+    }
+    // Initializes device 0's context; registration needs a live one.
+    device_mem_ = c10::rbln::malloc(0, 4096);
+    ASSERT_NE(device_mem_, nullptr);
+    if (!c10::rbln::pinned_ptr_registered_on(probe(), 0)) {
+      // Either the runtime has no host registration (UMD < 3.5 / flag off) or it failed;
+      // both are the documented best-effort outcome, nothing to assert against.
+      GTEST_SKIP() << "host-memory registration unavailable on this runtime";
+    }
+  }
+  void TearDown() override {
+    if (device_mem_ != nullptr) {
+      c10::rbln::free(device_mem_);
+    }
+  }
+  // A pinned allocation made while device 0 is initialized: registered eagerly if the
+  // runtime supports it.
+  const void* probe() {
+    if (probe_.get() == nullptr) {
+      probe_ = c10::rbln::get_pinned_memory_allocator()->allocate(4096);
+    }
+    return probe_.get();
+  }
+  void* device_mem_ = nullptr;
+  c10::DataPtr probe_;
+};
+
+TEST_F(RBLNPinnedAllocatorRegisterTest, AllocateRegistersOnInitializedDevice) {
+  auto data_ptr = c10::rbln::get_pinned_memory_allocator()->allocate(3 * 4096);
+  auto* base = static_cast<const uint8_t*>(data_ptr.get());
+  EXPECT_TRUE(c10::rbln::pinned_ptr_registered_on(base, 0));
+  EXPECT_TRUE(c10::rbln::pinned_ptr_registered_on(base + 4096 + 17, 0)) << "interior pointers resolve too";
+  EXPECT_FALSE(c10::rbln::pinned_ptr_registered_on(base, 999)) << "never registered on a device that does not exist";
+  // Idempotent: asking again for a covered device changes nothing and does not throw.
+  c10::rbln::ensure_pinned_registered(base, 0);
+  EXPECT_TRUE(c10::rbln::pinned_ptr_registered_on(base, 0));
+}
+
+TEST_F(RBLNPinnedAllocatorRegisterTest, HugeAllocationIsRegistered) {
+  // >= 2 MiB takes the huge-page branch; the registration must cover the rounded size.
+  constexpr size_t nbytes = (2u << 20) + 4096;
+  auto data_ptr = c10::rbln::get_pinned_memory_allocator()->allocate(nbytes);
+  auto* base = static_cast<const uint8_t*>(data_ptr.get());
+  EXPECT_EQ(reinterpret_cast<uintptr_t>(base) % (2u << 20), 0u) << "2 MiB aligned";
+  EXPECT_TRUE(c10::rbln::pinned_ptr_registered_on(base, 0));
+  EXPECT_TRUE(c10::rbln::pinned_ptr_registered_on(base + nbytes - 1, 0));
+}
+
+TEST_F(RBLNPinnedAllocatorRegisterTest, FreeUnregisters) {
+  const void* base = nullptr;
+  {
+    auto data_ptr = c10::rbln::get_pinned_memory_allocator()->allocate(4096);
+    base = data_ptr.get();
+    ASSERT_TRUE(c10::rbln::pinned_ptr_registered_on(base, 0));
+  }
+  EXPECT_FALSE(c10::rbln::pinned_ptr_registered_on(base, 0));
+  EXPECT_FALSE(c10::rbln::is_pinned_ptr(base));
+}
+
+TEST_F(RBLNPinnedAllocatorRegisterTest, PageableAndNullAreIgnored) {
+  int local = 0;
+  c10::rbln::ensure_pinned_registered(&local, 0); // must not throw
+  c10::rbln::ensure_pinned_registered(nullptr, 0);
+  EXPECT_FALSE(c10::rbln::pinned_ptr_registered_on(&local, 0));
+  EXPECT_FALSE(c10::rbln::pinned_ptr_registered_on(nullptr, 0));
+}
+
+TEST_F(RBLNPinnedAllocatorRegisterTest, RegisteredCopyRoundTrips) {
+  constexpr size_t nbytes = 1u << 20;
+  auto src = c10::rbln::get_pinned_memory_allocator()->allocate(nbytes);
+  auto dst = c10::rbln::get_pinned_memory_allocator()->allocate(nbytes);
+  ASSERT_TRUE(c10::rbln::pinned_ptr_registered_on(src.get(), 0));
+  auto* s = static_cast<uint8_t*>(src.get());
+  auto* d = static_cast<uint8_t*>(dst.get());
+  for (size_t i = 0; i < nbytes; ++i) {
+    s[i] = static_cast<uint8_t>(i * 7 + 3);
+  }
+  std::memset(d, 0, nbytes);
+  void* dev = c10::rbln::malloc(0, nbytes);
+  ASSERT_NE(dev, nullptr);
+  c10::rbln::memcpy_h2v(dev, s, nbytes);
+  c10::rbln::memcpy_v2h(d, dev, nbytes);
+  c10::rbln::free(dev);
+  EXPECT_EQ(std::memcmp(s, d, nbytes), 0);
 }

--- a/test/rbln/test_pin_memory.py
+++ b/test/rbln/test_pin_memory.py
@@ -120,6 +120,28 @@ class TestPinMemoryCopy(TestCase):
         dev = src.to(device, non_blocking=True)
         self.assertEqual(dev.cpu(), src)
 
+    def test_pinned_huge_buffer_round_trip(self, device):
+        # >= 2 MiB pinned allocations take the huge-page branch of the pinned allocator
+        # and, on a runtime with host registration, are copied by device VA. Either way
+        # the bytes must round-trip, including a trailing partial page.
+        n = (2 << 20) // 2 + 1024  # float16 elements: 2 MiB + 2 KiB
+        src = torch.randn(n).to(torch.float16).pin_memory()
+        self.assertEqual(src.data_ptr() % (2 << 20), 0)
+        dev = src.to(device, non_blocking=True)
+        dst = torch.empty_like(src, pin_memory=True)
+        dst.copy_(dev, non_blocking=True)
+        torch.rbln.synchronize()
+        self.assertEqual(dst, src)
+
+    def test_pinned_allocated_before_device_use_round_trips(self, device):
+        # A pinned buffer that predates the device's first use is registered lazily by
+        # the copy; the result is the same as for one allocated afterwards.
+        pinned = torch.arange(4096, dtype=torch.float16).pin_memory()
+        dev = pinned.to(device)
+        back = torch.empty_like(pinned, pin_memory=True)
+        back.copy_(dev)
+        self.assertEqual(back, pinned)
+
 
 instantiate_device_type_tests(TestPinMemoryCopy, globals(), only_for="privateuse1")
 

--- a/test/rbln/test_pin_memory.py
+++ b/test/rbln/test_pin_memory.py
@@ -143,7 +143,70 @@ class TestPinMemoryCopy(TestCase):
         self.assertEqual(back, pinned)
 
 
+@pytest.mark.test_set_ci
+class TestRegisterHostMemory(TestCase):
+    """torch.rbln.register_host_memory: pinning memory torch did not allocate."""
+
+    def test_register_marks_range_pinned(self):
+        buf = torch.empty(4096 * 3, dtype=torch.uint8)  # pageable
+        self.assertFalse(buf.is_pinned())
+        torch.rbln.register_host_memory(buf.data_ptr(), buf.numel())
+        try:
+            self.assertTrue(buf.is_pinned())
+            self.assertTrue(torch.rbln.is_pinned_address(buf.data_ptr() + 4096 + 17))
+            self.assertFalse(torch.rbln.is_pinned_address(buf.data_ptr() + buf.numel()))
+        finally:
+            torch.rbln.unregister_host_memory(buf.data_ptr())
+        self.assertFalse(buf.is_pinned())
+
+    def test_overlap_and_unknown_address_are_errors(self):
+        buf = torch.empty(4096 * 2, dtype=torch.uint8)
+        torch.rbln.register_host_memory(buf.data_ptr(), buf.numel())
+        try:
+            with self.assertRaises(RuntimeError):
+                torch.rbln.register_host_memory(buf.data_ptr() + 4096, 4096)
+            with self.assertRaises(RuntimeError):
+                torch.rbln.unregister_host_memory(buf.data_ptr() + 4096)
+        finally:
+            torch.rbln.unregister_host_memory(buf.data_ptr())
+        with self.assertRaises(RuntimeError):
+            torch.rbln.unregister_host_memory(buf.data_ptr())
+        with self.assertRaises(RuntimeError):
+            torch.rbln.register_host_memory(0, 4096)
+        with self.assertRaises(RuntimeError):
+            torch.rbln.register_host_memory(buf.data_ptr(), 0)
+
+    def test_pinned_allocator_memory_cannot_be_reregistered(self):
+        t = torch.empty(4096, pin_memory=True)
+        with self.assertRaises(RuntimeError):
+            torch.rbln.register_host_memory(t.data_ptr(), 4096)
+        with self.assertRaises(RuntimeError):  # not an external registration
+            torch.rbln.unregister_host_memory(t.data_ptr())
+        self.assertTrue(t.is_pinned())
+
+
+@pytest.mark.test_set_ci
+class TestRegisterHostMemoryCopy(TestCase):
+    def test_registered_buffer_round_trips_non_blocking(self, device):
+        # A huge_host_empty slab registered after the fact behaves like pinned memory:
+        # non_blocking copies go async and the data round-trips.
+        nbytes = (2 << 20) + 4096
+        slab = torch.rbln.huge_host_empty(nbytes)
+        torch.rbln.register_host_memory(slab.data_ptr(), nbytes)
+        try:
+            src = slab.view(torch.float16)
+            src.copy_(torch.randn(src.numel(), dtype=torch.float16))
+            dev = src.to(device, non_blocking=True)
+            back = torch.empty_like(src, pin_memory=True)
+            back.copy_(dev, non_blocking=True)
+            torch.rbln.synchronize()
+            self.assertEqual(back, src)
+        finally:
+            torch.rbln.unregister_host_memory(slab.data_ptr())
+
+
 instantiate_device_type_tests(TestPinMemoryCopy, globals(), only_for="privateuse1")
+instantiate_device_type_tests(TestRegisterHostMemoryCopy, globals(), only_for="privateuse1")
 
 if __name__ == "__main__":
     run_tests()

--- a/torch_rbln/csrc/rbln/Module.cpp
+++ b/torch_rbln/csrc/rbln/Module.cpp
@@ -7,6 +7,7 @@
 #include <c10/rbln/RBLNFallbackConfig.h>
 #include <c10/rbln/RBLNFunctions.h>
 #include <c10/rbln/RBLNLogging.h>
+#include <c10/rbln/RBLNPinnedAllocator.h>
 #include <c10/rbln/RBLNProfiler.h>
 #include <c10/rbln/RBLNSupportedDtypes.h>
 #include <torch/csrc/Dtype.h>
@@ -223,6 +224,28 @@ void register_internal_api(py::module_& module) {
         c10::rbln::bind_device_memory(tensor.data_ptr(), tensor.storage().nbytes());
       },
       "Internal: give an RBLN tensor a flat single-node device allocation");
+
+  // Pin a caller-owned host buffer for device DMA (cudaHostRegister counterpart). Used by
+  // torch_rbln.register_host_memory() / unregister_host_memory().
+  module.def(
+      "_register_host_memory",
+      [](uint64_t address, uint64_t nbytes) {
+        c10::rbln::register_host_memory(
+            reinterpret_cast<void*>(address), static_cast<size_t>(nbytes)); // NOLINT(performance-no-int-to-ptr)
+      },
+      "Internal: register a host address range as pinned for RBLN DMA");
+  module.def(
+      "_unregister_host_memory",
+      [](uint64_t address) {
+        c10::rbln::unregister_host_memory(reinterpret_cast<void*>(address)); // NOLINT(performance-no-int-to-ptr)
+      },
+      "Internal: undo _register_host_memory");
+  module.def(
+      "_is_pinned_ptr",
+      [](uint64_t address) {
+        return c10::rbln::is_pinned_ptr(reinterpret_cast<const void*>(address)); // NOLINT(performance-no-int-to-ptr)
+      },
+      "Internal: whether a host address lies in a pinned (allocator or registered) range");
 
   // Set target's device-allocation layout to match ref's, without copying data.
   // Used by torch_rbln.set_device_layout_like().

--- a/torch_rbln/memory.py
+++ b/torch_rbln/memory.py
@@ -346,37 +346,19 @@ def huge_host_empty(nbytes: int) -> torch.Tensor:
 
 def register_host_memory(address: int, nbytes: int) -> None:
     """
-    Pin a caller-owned host buffer for RBLN DMA -- the counterpart of ``cudaHostRegister``.
+    Pin a caller-owned host buffer for RBLN DMA (the counterpart of ``cudaHostRegister``).
 
-    ``torch.empty(..., pin_memory=True)`` pins memory it allocates; this pins memory that
-    already exists -- a shared-memory pool another process created, a cache's slab, a
-    ``HugeHostBuffer``. Afterwards the range counts as pinned: ``Tensor.is_pinned()`` is true
-    for a tensor over it, a ``non_blocking`` copy goes asynchronous, and every host<->device
-    copy whose page-aligned operand lies inside it is recorded against the buffer's device VA,
-    so the kernel reuses one pin instead of pinning the pages on each command buffer. The
-    range is registered with every RBLN device this process has initialized, and with a
-    device initialized later on its first copy.
-
-    The pin is best effort on the runtime side: without host registration in the runtime
-    (UMD < 3.5, ``RBLN_HOST_MEMORY_REGISTER=0``) the range is still pinned for torch's
-    purposes and copies take their usual path.
-
-    The caller keeps ownership of the memory: unregister before freeing it, and only after
-    every copy that references it has completed (as with ``cudaHostUnregister``).
+    The range then counts as pinned (``is_pinned()``, async ``non_blocking`` copies) and is
+    registered with the runtime on every initialized RBLN device, so copies inside it reuse
+    one pin instead of pinning per command buffer. Unregister before freeing the memory and
+    only after the copies that reference it completed.
 
     Args:
-        address: Start of the buffer (e.g. ``tensor.data_ptr()`` or ``HugeHostBuffer.address``).
+        address: Start of the buffer (``tensor.data_ptr()``, ``HugeHostBuffer.address``).
         nbytes: Length in bytes.
 
     Raises:
         RuntimeError: on a null address, zero length, or overlap with a live pinned range.
-
-    Example::
-
-        pool = torch.frombuffer(shm.buf, dtype=torch.uint8)
-        torch.rbln.register_host_memory(pool.data_ptr(), pool.numel())
-        ...
-        torch.rbln.unregister_host_memory(pool.data_ptr())
     """
     torch_rbln._C._register_host_memory(operator.index(address), operator.index(nbytes))
 
@@ -394,11 +376,7 @@ def unregister_host_memory(address: int) -> None:
 
 
 def is_pinned_address(address: int) -> bool:
-    """
-    Whether ``address`` lies inside a pinned host range -- one from the pinned allocator
-    (``pin_memory=True``) or one registered with :func:`register_host_memory`. Any offset
-    inside the range counts. Never raises; a null or foreign address is ``False``.
-    """
+    """Whether ``address`` lies inside a pinned or registered host range (never raises)."""
     return bool(torch_rbln._C._is_pinned_ptr(operator.index(address)))
 
 

--- a/torch_rbln/memory.py
+++ b/torch_rbln/memory.py
@@ -19,6 +19,9 @@ __all__ = [
     "bind_device_memory",
     "empty_cache",
     "huge_host_empty",
+    "is_pinned_address",
+    "register_host_memory",
+    "unregister_host_memory",
     "set_device_layout_like",
     "max_memory_allocated",
     "max_memory_reserved",
@@ -339,6 +342,64 @@ def huge_host_empty(nbytes: int) -> torch.Tensor:
     # allocation alive for as long as the tensor is: HugeHostBuffer frees itself
     # on collection and nothing else holds it.
     return torch.frombuffer(HugeHostBuffer(nbytes), dtype=torch.uint8)
+
+
+def register_host_memory(address: int, nbytes: int) -> None:
+    """
+    Pin a caller-owned host buffer for RBLN DMA -- the counterpart of ``cudaHostRegister``.
+
+    ``torch.empty(..., pin_memory=True)`` pins memory it allocates; this pins memory that
+    already exists -- a shared-memory pool another process created, a cache's slab, a
+    ``HugeHostBuffer``. Afterwards the range counts as pinned: ``Tensor.is_pinned()`` is true
+    for a tensor over it, a ``non_blocking`` copy goes asynchronous, and every host<->device
+    copy whose page-aligned operand lies inside it is recorded against the buffer's device VA,
+    so the kernel reuses one pin instead of pinning the pages on each command buffer. The
+    range is registered with every RBLN device this process has initialized, and with a
+    device initialized later on its first copy.
+
+    The pin is best effort on the runtime side: without host registration in the runtime
+    (UMD < 3.5, ``RBLN_HOST_MEMORY_REGISTER=0``) the range is still pinned for torch's
+    purposes and copies take their usual path.
+
+    The caller keeps ownership of the memory: unregister before freeing it, and only after
+    every copy that references it has completed (as with ``cudaHostUnregister``).
+
+    Args:
+        address: Start of the buffer (e.g. ``tensor.data_ptr()`` or ``HugeHostBuffer.address``).
+        nbytes: Length in bytes.
+
+    Raises:
+        RuntimeError: on a null address, zero length, or overlap with a live pinned range.
+
+    Example::
+
+        pool = torch.frombuffer(shm.buf, dtype=torch.uint8)
+        torch.rbln.register_host_memory(pool.data_ptr(), pool.numel())
+        ...
+        torch.rbln.unregister_host_memory(pool.data_ptr())
+    """
+    torch_rbln._C._register_host_memory(operator.index(address), operator.index(nbytes))
+
+
+def unregister_host_memory(address: int) -> None:
+    """
+    Undo :func:`register_host_memory`. ``address`` must be the exact start passed to it.
+
+    Pending transfers on the registered devices are drained first.
+
+    Raises:
+        RuntimeError: if ``address`` is not the start of a live registration.
+    """
+    torch_rbln._C._unregister_host_memory(operator.index(address))
+
+
+def is_pinned_address(address: int) -> bool:
+    """
+    Whether ``address`` lies inside a pinned host range -- one from the pinned allocator
+    (``pin_memory=True``) or one registered with :func:`register_host_memory`. Any offset
+    inside the range counts. Never raises; a null or foreign address is ``False``.
+    """
+    return bool(torch_rbln._C._is_pinned_ptr(operator.index(address)))
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
## What

Part 2/2 of a stacked KV-transfer optimization (rebel_compiler → torch-rbln → LMCache); full
context, cross-repo branch map and measured A/B numbers at
https://github.com/rebellions-sw/fsw-inference/issues/540. Stacked on #225 (compiled permute).
Depends on rebel_compiler's host-memory registration PR (rebellions-sw/rebel_compiler#13291).

- `torch.rbln.register_host_memory(address, nbytes)` / `unregister_host_memory` -- registers a
  caller-owned host buffer with the runtime (`rbln_host_register`), the RBLN counterpart of
  `cudaHostRegister`.
- The pinned allocator backing `pin_memory=True` CPU tensors now also registers its allocations,
  best effort (a runtime without registration -- UMD < 3.5 -- still pins in the torch sense and
  copies take their usual path).
- Pinned host groups bypass the bulk-copy caps: those caps exist because the kernel pins a
  command buffer's pageable host operands at `rblnEndCommandBuffer()`; a registered operand is
  already pinned and addressed by DVA, so the whole group goes to the runtime as one call
  instead of being split into small bulk calls.

## Why

Registration pins the pages once; every later host<->device copy whose page-aligned operand
lies inside the range is recorded against the buffer's device VA, so the kernel reuses that pin
instead of pinning per command buffer. Measured on CR13: D2H into a registered buffer 13.8 ->
36.6 GB/s. A 268 MiB gather of 4 MiB pieces into pinned memory: 9.4 -> 7.3 ms as one bulk call.

## Tests

`test/cpp/core/RBLNPinnedAllocatorTest.cpp`, `test/rbln/test_pin_memory.py`.

## Stack

1. #225 -- compiled permutation as a `copy_()` fast path
2. **This PR** -- host memory registration