### PR TITLE
fix(memory): no-op the device-side cache-mgmt calls in dummy mode

### DIFF
--- a/c10/rbln/RBLNFunctions.cpp
+++ b/c10/rbln/RBLNFunctions.cpp
@@ -1238,6 +1238,9 @@ void empty_cache(const c10::Device& device) {
   if (!device_context_initialized(device_index)) {
     return;
   }
+  if (is_dummy_device()) {
+    return;
+  }
   const auto device_id = to_device_id(device_index);
   RBLN_LOG_DEBUG("Calling rbln_empty_cache: device_id={}", device_id);
   // Live context: surface a genuine failure (CUDA parity — an initialized allocator
@@ -1287,6 +1290,9 @@ void reset_accumulated_memory_stats(const c10::Device& device) {
   if (!device_context_initialized(device_index)) {
     return;
   }
+  if (is_dummy_device()) {
+    return;
+  }
   const auto device_id = to_device_id(device_index);
   RBLN_LOG_DEBUG("Calling rbln_reset_accumulated_memory_stats: device_id={}", device_id);
   // Live context: surface a genuine failure (a silent success would mislead the caller).
@@ -1308,6 +1314,9 @@ void reset_peak_memory_stats(const c10::Device& device) {
   const auto device_index = device.index();
   check_device_index(device_index);
   if (!device_context_initialized(device_index)) {
+    return;
+  }
+  if (is_dummy_device()) {
     return;
   }
   const auto device_id = to_device_id(device_index);

--- a/test/rbln/test_dummy_device.py
+++ b/test/rbln/test_dummy_device.py
@@ -322,6 +322,23 @@ def test_offload_runs_in_dummy_mode():
     assert "OK" in proc.stdout
 
 
+def test_cache_management_is_a_noop_in_dummy_mode():
+    proc = _run_with_dummy(
+        """
+        import torch, torch_rbln
+        t = torch.zeros(1 << 20, device="rbln:0")  # marks the device context initialized
+        del t
+        torch.rbln.empty_cache(0)
+        torch.accelerator.empty_cache()
+        torch.rbln.reset_accumulated_memory_stats(0)
+        torch.rbln.reset_peak_memory_stats(0)
+        print("OK")
+        """
+    )
+    _assert_ok(proc)
+    assert "OK" in proc.stdout
+
+
 @pytest.mark.parametrize("npus_per_device", [1, 2, 4, 8])
 def test_npus_per_device_sets_single_group_tp(npus_per_device):
     # RBLN_NPUS_PER_DEVICE=N (no RBLN_DEVICE_MAP) -> one logical device of size N (TP=N).


### PR DESCRIPTION
## Summary of Changes

### Summary

`torch.accelerator.empty_cache()` raises on a host with no NPU under `RBLN_DUMMY_DEVICE=1`. vLLM calls it from `cleanup_dist_env_and_memory()` during EngineCore teardown, so every compile-only run on the vLLM dynamo CI lane ends with an uncaught `RuntimeError` and a non-zero exit instead of a clean shutdown.

This makes the three cache-management entry points no-op in dummy mode, which is what `get_physical_device_count()` already does for the same reason ("Dummy mode must not touch the runtime … there is no physical NPU").

### Details

- **The gate lets dummy mode through, the runtime does not** — `runtime_available()` deliberately returns true for `is_dummy_device()`, and a dummy allocation sets the per-device context bit, so `empty_cache()` reaches `rbln_empty_cache()`. The runtime range-checks that id against the *physical* device count, which is 0 with no NPU, and returns `RBLNRetCode_FAILURE` from the range check alone. That branch logs nothing, so the failure leaves no trace on the rebel side. `RBLN_CHECK` then throws.

- **Teardown turns it into a crash** — `cleanup_dist_env_and_memory()` runs inside the `SystemExit` handling of vLLM's SIGTERM path. A raise there replaces a clean `SystemExit` with an uncaught `RuntimeError`, so the EngineCore process prints a 52-frame C++ backtrace plus a Python traceback and exits non-zero. The job still passes, so this has been sitting in every PR's logs rather than failing anything.

- **`reset_accumulated_memory_stats` / `reset_peak_memory_stats` share the bug** — same gate, and `rbln_reset_accumulated_memory_stats` / `rbln_reset_peak_memory_stats` carry the same range check. They do not fail today only because nothing calls them during teardown. Guarded as well, rather than leaving two loaded guns behind.

### Next Steps

- The runtime side is untouched. `rbln_empty_cache()` returns a bare `RBLNRetCode_FAILURE` from its range check with no log, while the line right below it treats "no live context" as success — the two should agree, and a genuine failure should say why. Worth a separate rebel_compiler change; not filed yet.

---

## Related Issues / Tickets

* Resolves #
* Related to #

---

## Type of Change

- [ ] `feature` — New capability or functionality
- [x] `core` — Changes to RBLN backend, device layer, C++ extension, op registration, or `torch.compile` integration
- [x] `fix` — Bug fix
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code improvement without behavior change
- [ ] `docs` — Documentation only
- [ ] `other` — Other (describe below)

---

## Affected Modules

- [ ] Backend
- [x] Device
- [ ] Ops/Kernels
- [ ] `torch.compile`
- [ ] C++ extension (`torch_rbln/csrc`)
- [x] Memory
- [ ] Build/Tools
- [ ] Docs

---

## How to Test (if applicable)

1. `pytest test/rbln/test_dummy_device.py::test_cache_management_is_a_noop_in_dummy_mode`
2. Expected: passes. The case allocates on `rbln:0` (which sets the context bit the gate checks), then calls `torch.rbln.empty_cache(0)`, `torch.accelerator.empty_cache()`, and both `reset_*` entry points.

**This case only goes red without the fix on a host with no physical NPU.** Where an NPU is visible the runtime's range check passes and the calls succeed either way, so on an NPU box it is a smoke test, not a regression guard.

---

## Notes

- `clang-tidy` was not run locally — it needs the build-pinned `rebel-compiler` headers from the internal index. `clang-format` (19.1.4, the pinned version), `flake8`, and `ruff check` / `ruff format` all pass on the two changed files.
- Original report: `compiler-pr-ci` build 9914, job `:hammer: Compile - GPT-OSS-120b-b1-dp1-l4-CR13`, log rows 665-748. The traceback's `RBLNFunctions.cpp:1246` is the `RBLN_CHECK` in `empty_cache` on this base.
