### PR TITLE
feat(memory): serve a strided device copy as one compiled program

### DIFF
--- a/aten/src/ATen/native/RBLNRegisterOps.cpp
+++ b/aten/src/ATen/native/RBLNRegisterOps.cpp
@@ -130,6 +130,16 @@ TORCH_LIBRARY_IMPL(_, AutogradPrivateUse1, m) {
   m.fallback(torch::CppFunction::makeFromBoxedFunction<&autograd_fallback>());
 }
 
+// Operators this backend owns. `rbln_custom_ops` belongs to rebel-compiler, whose names
+// mirror the aten op each one converts -- `view_copy` is taken there the moment it adds a
+// converter for `aten::view_copy`, and two defs of one schema abort at import.
+TORCH_LIBRARY(torch_rbln, m) {
+  // `copy_` reaches this from C++ for a device->device copy whose source is a classifiable
+  // view; the implementation is Python because it drives the compile path. Answers false
+  // when the view cannot be replayed, leaving the caller on its existing route.
+  m.def("copy_strided_view(Tensor src, Tensor(a!) out) -> bool");
+}
+
 // ATen operations registration for the RBLN backend (PrivateUse1)
 TORCH_LIBRARY_IMPL(aten, PrivateUse1, m) {
   // Operations that use the device runtime API

--- a/aten/src/ATen/native/rbln/RBLNCopy.cpp
+++ b/aten/src/ATen/native/rbln/RBLNCopy.cpp
@@ -16,6 +16,7 @@
 
 #include <c10/rbln/RBLNProfiler.h>
 #include <rebel/runtime/api/rbln_runtime_api.h>
+#include <torch/library.h>
 
 #include <cstddef>
 #include <optional>
@@ -25,6 +26,47 @@
 namespace at::native::rbln {
 
 namespace {
+
+// A strided device->device copy whose source is a classifiable view runs as one compiled
+// device program (``torch_rbln::copy_strided_view``) instead of one descriptor per contiguous
+// run. Two conditions decide whether that program is worth reaching for, and both are
+// facts about the compiler rather than tuning knobs:
+//
+//   dtype -- everything the device does not keep as-is is rewritten to a narrower float
+//     (rebel_compiler ``isDeviceSupportedDtype``), which changes the values. ``copy_`` is
+//     not a compute op, so the compiled path has to return what the strided walk returns.
+//     Of the two dtypes the compile path dispatches, only bf16 survives that; f16 loses
+//     a mantissa bit.
+//   alignment -- the compiler lowers a tensor to the device only when its last dim is a
+//     multiple of 64 elements (``checkLastDim128BAligned``: "regardless of dtype, if
+//     greater than 8 bits, we align last dim to 64"). Unaligned, the op path falls back to
+//     a host round-trip, which is what we are trying to avoid.
+//
+// Whether the view itself can be replayed is not decided here -- the shared detector
+// answers that, and returns false through the op when it cannot.
+bool try_view_copy(const at::Tensor& dst, const at::Tensor& src) {
+  if (src.is_contiguous() || !dst.is_contiguous())
+    return false;
+  // One program reads and writes one device; a copy that crosses them is not ours.
+  if (src.device() != dst.device())
+    return false;
+  if (src.scalar_type() != at::kBFloat16 || dst.scalar_type() != src.scalar_type())
+    return false;
+  if (src.dim() == 0 || src.size(-1) % 64 != 0 || dst.size(-1) % 64 != 0)
+    return false;
+
+  // `import torch_rbln` registers the op, and an RBLN tensor cannot exist without that
+  // import, so a missing schema is a broken build rather than a case to route around --
+  // which is why this throws instead of returning false. Looked up per call, the way
+  // upstream reaches an op from C++ (ATen/native/CPUFallback.h): an OperatorHandle points
+  // into the dispatcher's table, and caching one in a static outlives nothing useful here
+  // -- the lookup is a hash probe in front of a copy of at least a full device tile.
+  const auto op = c10::Dispatcher::singleton()
+                      .findSchemaOrThrow("torch_rbln::copy_strided_view", "")
+                      .typed<bool(const at::Tensor&, at::Tensor&)>();
+  at::Tensor out = dst; // a Tensor is a handle; the schema's Tensor(a!) wants a mutable one
+  return op.call(src, out);
+}
 
 // Recursion guard: a non-direct rbln->rbln copy_ services itself by a v2h
 // (get_cpu_copy_of_rbln_tensor) followed by a cpu->rbln copy. We count that
@@ -308,6 +350,14 @@ void tensor_copy_from_rbln_to_rbln(const at::Tensor& rbln_src, const at::Tensor&
     const auto* src_data = rbln_src.data_ptr();
     const auto nbytes = at::detail::computeStorageNbytes(rbln_src.sizes(), rbln_src.strides(), rbln_src.element_size());
     c10::rbln::memcpy_v2v(dst_data, src_data, nbytes);
+    return;
+  }
+
+  // One compiled program beats both routes below when the source view is classifiable:
+  // the strided engine pays a descriptor per contiguous run, and a KV block read head-major
+  // and written token-major breaks into runs of a single row -- far past the cap, so the
+  // real alternative is the host bounce.
+  if (try_view_copy(rbln_dst, rbln_src)) {
     return;
   }
 

--- a/test/rbln/test_view_copy.py
+++ b/test/rbln/test_view_copy.py
@@ -1,0 +1,221 @@
+# Owner(s): ["module: PrivateUse1"]
+
+"""``copy_`` from a strided device source, served by one compiled device program.
+
+A device->device copy whose source is a view had two routes: the strided v2v engine,
+which spends a descriptor per contiguous run, and above its cap a host round-trip.
+Neither fits a copy that is one reshape away from contiguous -- a KV block read
+head-major and written token-major breaks into runs of a single head_size row, far past
+the cap. Replaying the view inside a compiled graph moves it in one program instead.
+
+Which route ran is observable, and it takes two counters, not one. Every shape here is
+past the strided engine's cap, so without the program the copy round-trips the host and
+the profiler records a bounce -- that separates "served" from "declined", which the
+result cannot, since the slow routes are correct too. But a served copy can still reach
+the host: below the compiler's last-dim alignment the program is lowered with its input
+on the host, and the runtime feeds it there without any bounce being recorded. So the
+served cases also assert that the runtime ran no host primitive.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from torch.testing._internal.common_device_type import dtypes, instantiate_device_type_tests
+from torch.testing._internal.common_utils import parametrize, run_tests, TestCase
+
+from test.utils import requires_logical_devices
+from test.utils_v2v import to_dev as _to_dev
+
+
+# Past ::rbln::kMaxV2VMultiCopies once permuted: the strided engine declines and the
+# alternative is a host bounce, which is what makes the route observable.
+_ROWS, _HEADS, _BLOCK, _DIM = 2, 4, 256, 128
+
+
+_HOST_PRIMITIVES = ("v2h", "h2v")
+
+
+def _bounces(report: dict) -> int:
+    return int(report["hidden_host_bounce"]["total_count"])
+
+
+def _host_primitives(report: dict) -> dict:
+    """The runtime's own host transfers, which a bounce count does not cover."""
+    by_primitive = report["rebel_runtime"]["by_primitive"]
+    return {k: v for k, v in by_primitive.items() if k in _HOST_PRIMITIVES}
+
+
+def _copy_and_count(dst: torch.Tensor, src: torch.Tensor) -> tuple[int, dict]:
+    with torch.rbln.explain() as p:
+        dst.copy_(src)
+    report = p.dump()
+    return _bounces(report), _host_primitives(report)
+
+
+# View chains the detector classifies. Each maps a contiguous host tensor to the view
+# whose copy is under test; the reference is the same chain taken on the host.
+_CHAINS = {
+    "permute": (
+        (_ROWS, _HEADS, _BLOCK, _DIM),
+        lambda t: t.permute(0, 2, 1, 3),
+    ),
+    # leading dims merged before the permute -- what a KV transfer writes
+    "reshape_then_permute": (
+        (2, _ROWS, _HEADS, _BLOCK, _DIM),
+        lambda t: t.reshape(2 * _ROWS, _HEADS, _BLOCK, _DIM).permute(0, 2, 1, 3),
+    ),
+    # one dim split instead of merged
+    "split_then_permute": (
+        (_ROWS * _HEADS, _BLOCK, _DIM),
+        lambda t: t.reshape(_ROWS, _HEADS, _BLOCK, _DIM).permute(0, 2, 1, 3),
+    ),
+    # a slice of a larger buffer: the recipe carries select and narrow too
+    "select_then_permute": (
+        (2, _ROWS, _HEADS, _BLOCK, _DIM),
+        lambda t: t[1].permute(0, 2, 1, 3),
+    ),
+    "narrow_then_permute": (
+        (2 * _ROWS, _HEADS, _BLOCK, _DIM),
+        lambda t: t[:_ROWS].permute(0, 2, 1, 3),
+    ),
+    # not a permutation of the leading dims at all
+    "transpose_last_two": (
+        (_ROWS, _HEADS, _BLOCK, _DIM),
+        lambda t: t.transpose(-1, -2),
+    ),
+}
+
+
+@pytest.mark.test_set_ci
+class TestViewCopy(TestCase):
+    """Device->device ``copy_`` whose source is a view."""
+
+    def _run(self, shape, view_fn, dtype=torch.bfloat16):
+        """Returns (bounces, device result, host reference)."""
+        host = torch.randint(-1000, 1000, shape).to(dtype)
+        src = view_fn(_to_dev(host))
+        dst = torch.empty(src.shape, dtype=dtype, device=src.device)
+        bounces, host_primitives = _copy_and_count(dst, src)
+        return (bounces, host_primitives), dst.cpu(), view_fn(host).contiguous()
+
+    # ---- chains the program serves ----
+
+    @parametrize("chain", sorted(_CHAINS))
+    def test_a_classifiable_view_is_served_by_the_program(self, device, chain):
+        shape, view_fn = _CHAINS[chain]
+        (bounces, host_primitives), got, want = self._run(shape, view_fn)
+        self.assertEqual(bounces, 0, f"{chain} must not round-trip the host")
+        self.assertEqual(host_primitives, {}, f"{chain} ran on the host, not the device")
+        self.assertTrue(torch.equal(got, want), f"{chain} returned different values")
+
+    @parametrize("chain", sorted(_CHAINS))
+    def test_a_repeated_copy_stays_on_the_program(self, device, chain):
+        """The program is cached per view pattern; a repeat must not fall off it."""
+        shape, view_fn = _CHAINS[chain]
+        host = torch.randint(-1000, 1000, shape).to(torch.bfloat16)
+        src = view_fn(_to_dev(host))
+        dst = torch.empty(src.shape, dtype=torch.bfloat16, device=src.device)
+        for i in range(3):
+            bounces, host_primitives = _copy_and_count(dst, src)
+            self.assertEqual(bounces, 0, f"{chain} bounced on call {i}")
+            self.assertEqual(host_primitives, {}, f"{chain} reached the host on call {i}")
+        self.assertTrue(torch.equal(dst.cpu(), view_fn(host).contiguous()))
+
+    def test_the_detector_classifies_every_served_chain(self, device):
+        """A route regression surfaces here first: once the detector stops classifying a
+        chain, its copy drops back to the slow route and only the timing shows it."""
+        from torch_rbln._internal.ops_utils import _detect_view_recipe
+
+        for chain, (shape, view_fn) in sorted(_CHAINS.items()):
+            view = view_fn(torch.empty(shape, dtype=torch.bfloat16))
+            self.assertIsNotNone(_detect_view_recipe(view), f"{chain} is no longer classified")
+
+    # ---- what stays on the existing route ----
+
+    @dtypes(torch.float16, torch.float32, torch.int32, torch.bool)
+    def test_a_dtype_the_device_rewrites_keeps_the_slow_route(self, device, dtype):
+        """Only bf16 reaches the device as itself; the rest are rewritten to a narrower
+        float, and ``copy_`` is not a compute op -- both routes have to agree."""
+        shape, view_fn = _CHAINS["permute"]
+        (bounces, _), got, want = self._run(shape, view_fn, dtype=dtype)
+        self.assertGreater(bounces, 0, f"{dtype} must not take the program")
+        self.assertTrue(torch.equal(got, want))
+
+    @parametrize("last_dim", [96, 127, 1])
+    def test_an_unaligned_last_dim_keeps_the_slow_route(self, device, last_dim):
+        """Below the compiler's last-dim alignment the tensor stays on the host, where
+        the program is orders of magnitude slower than the walk it would replace."""
+        shape = (_ROWS, _HEADS, _BLOCK, last_dim)
+        (bounces, _), got, want = self._run(shape, lambda t: t.permute(0, 2, 1, 3))
+        self.assertGreater(bounces, 0, f"last dim {last_dim} must not take the program")
+        self.assertTrue(torch.equal(got, want))
+
+    def test_a_strided_destination_keeps_the_slow_route(self, device):
+        """The program writes a contiguous buffer; scattering into a strided destination
+        is not something the out-tensor path can express."""
+        host = torch.randint(-1000, 1000, (_ROWS, _HEADS, _BLOCK, _DIM)).to(torch.bfloat16)
+        src = _to_dev(host)
+        dst = torch.empty((_ROWS, _BLOCK, _HEADS, _DIM), dtype=torch.bfloat16, device=src.device).permute(0, 2, 1, 3)
+        bounces, _ = _copy_and_count(dst, src)
+        self.assertGreater(bounces, 0, "a strided destination must not take the program")
+        self.assertTrue(torch.equal(dst.contiguous().cpu(), host))
+
+    def test_an_unclassifiable_view_keeps_the_slow_route(self, device):
+        """The op has to answer before ``prepare_args_view_aware`` would reach for
+        ``.contiguous()``, which re-enters ``copy_``."""
+        host = torch.randint(-1000, 1000, (_ROWS, _HEADS, _BLOCK, _DIM)).to(torch.bfloat16)
+        # Strides no chain of view ops produces: the middle one is not a product of the
+        # sizes below it, so the rows overlap rather than tile.
+        sizes, strides = (_ROWS, _HEADS, _BLOCK, _DIM), (100000, 20000, _DIM + 1, 1)
+        src = _to_dev(host).as_strided(sizes, strides, 0)
+        dst = torch.empty(sizes, dtype=torch.bfloat16, device=src.device)
+        bounces, _ = _copy_and_count(dst, src)
+        self.assertGreater(bounces, 0, "an unclassified view must not take the program")
+        self.assertTrue(torch.equal(dst.cpu(), host.as_strided(sizes, strides, 0).contiguous()))
+
+    def test_a_contiguous_copy_is_untouched(self, device):
+        host = torch.randint(-1000, 1000, (_ROWS, _HEADS, _BLOCK, _DIM)).to(torch.bfloat16)
+        src = _to_dev(host)
+        dst = torch.empty_like(src)
+        self.assertEqual(_copy_and_count(dst, src), (0, {}), "a direct copy must not bounce")
+        self.assertTrue(torch.equal(dst.cpu(), host))
+
+    def test_a_destination_at_a_storage_offset_is_served(self, device):
+        """The compile path writes the caller's buffer only when it starts at offset 0;
+        otherwise it hands back its own and the result is moved across. Still on device --
+        the move is a v2v -- but it is the one branch where the two buffers differ."""
+        host = torch.randint(-1000, 1000, (_ROWS, _HEADS, _BLOCK, _DIM)).to(torch.bfloat16)
+        src = _to_dev(host).permute(0, 2, 1, 3)
+        storage = torch.empty((2 * _ROWS, _BLOCK, _HEADS, _DIM), dtype=torch.bfloat16, device=src.device)
+        dst = storage[_ROWS:]
+        self.assertNotEqual(dst.storage_offset(), 0)
+        bounces, host_primitives = _copy_and_count(dst, src)
+        self.assertEqual(bounces, 0, "an offset destination must not round-trip the host")
+        self.assertEqual(host_primitives, {}, "an offset destination must stay on device")
+        self.assertTrue(torch.equal(dst.cpu(), host.permute(0, 2, 1, 3).contiguous()))
+
+    @requires_logical_devices(2)
+    def test_a_copy_across_devices_is_untouched(self, device):
+        """One program reads and writes one device, so a copy that crosses them is not
+        this path's -- and taking it anyway writes the wrong buffer, not just a slow one."""
+        host = torch.randint(-1000, 1000, (_ROWS, _HEADS, _BLOCK, _DIM)).to(torch.bfloat16)
+        src = host.to("rbln:0").permute(0, 2, 1, 3)
+        dst = torch.empty(src.shape, dtype=torch.bfloat16, device="rbln:1")
+        dst.copy_(src)
+        torch.rbln.synchronize()
+        self.assertTrue(torch.equal(dst.cpu(), host.permute(0, 2, 1, 3).contiguous()))
+
+    def test_a_device_to_host_copy_is_untouched(self, device):
+        host = torch.randint(-1000, 1000, (_ROWS, _HEADS, _BLOCK, _DIM)).to(torch.bfloat16)
+        src = _to_dev(host).permute(0, 2, 1, 3)
+        dst = torch.empty(src.shape, dtype=torch.bfloat16)
+        dst.copy_(src)
+        torch.rbln.synchronize()
+        self.assertTrue(torch.equal(dst, host.permute(0, 2, 1, 3).contiguous()))
+
+
+instantiate_device_type_tests(TestViewCopy, globals(), only_for="privateuse1")
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch_rbln/_internal/ops_utils.py
+++ b/torch_rbln/_internal/ops_utils.py
@@ -998,6 +998,14 @@ def _construct_synthetic_base(t: torch.Tensor):
 # ============================================================================
 
 
+def _contiguous_strides(shape):
+    """Row-major strides for ``shape``."""
+    st = [1] * len(shape)
+    for i in range(len(shape) - 2, -1, -1):
+        st[i] = st[i + 1] * shape[i + 1]
+    return tuple(st)
+
+
 def _simulate_recipe(shape, stride, offset, recipe):
     """Apply each step in ``recipe`` to (shape, stride, offset) metadata
     and return the new ``(shape, stride, offset)`` tuple.
@@ -1048,6 +1056,23 @@ def _simulate_recipe(shape, stride, offset, recipe):
                 return None
             del s[d]
             del st[d]
+        elif op == "reshape":
+            # Only a pure view when the current layout is contiguous from offset 0 --
+            # that is exactly when the new shape's strides follow from its sizes. On any
+            # other layout a reshape has to copy, which a recipe cannot express.
+            new_shape = tuple(step[1])
+            if tuple(_contiguous_strides(tuple(s))) != tuple(st) or o != 0:
+                return None
+            total = 1
+            for x in s:
+                total *= x
+            new_total = 1
+            for x in new_shape:
+                new_total *= x
+            if new_total != total or any(x < 1 for x in new_shape):
+                return None
+            s = list(new_shape)
+            st = list(_contiguous_strides(new_shape))
         elif op == "unsqueeze":
             d = step[1]
             if d < 0 or d > len(s):
@@ -1202,6 +1227,22 @@ def _gen_step_candidates(cur, target):
             if cur_s[d] == 1:
                 for new_size in target_expand_sizes:
                     yield ("expand", d, new_size)
+
+    # Reshape. A merge or a split is a pure view only on a contiguous, offset-0
+    # layout, so that is the only state worth proposing one from -- which is also the
+    # common one, since a base is contiguous by construction and a leading reshape is
+    # how callers flatten before permuting (``kv.view(rows, heads, block, dim)``).
+    # Both families are bounded by the target's own shape, so the frontier stays small.
+    if cur_o == 0 and cur_st == _contiguous_strides(cur_s):
+        if len(cur_s) > len(tgt_s) and len(cur_s) >= 2:
+            for d in range(len(cur_s) - 1):
+                yield ("reshape", cur_s[:d] + (cur_s[d] * cur_s[d + 1],) + cur_s[d + 2 :])
+        if len(cur_s) < len(tgt_s):
+            tgt_sizes = {x for x in tgt_s if x > 1}
+            for d, sz in enumerate(cur_s):
+                for a in tgt_sizes:
+                    if a < sz and sz % a == 0 and (sz // a) in tgt_sizes:
+                        yield ("reshape", cur_s[:d] + (a, sz // a) + cur_s[d + 1 :])
 
     # Select: cur has more dims, a non-size-1 dim is being indexed away.
     if len(cur_s) > len(tgt_s):

--- a/torch_rbln/_internal/register_custom_ops.py
+++ b/torch_rbln/_internal/register_custom_ops.py
@@ -4,6 +4,7 @@ import torch
 
 from torch_rbln._internal.compile_cache import compile_rbln_cached
 from torch_rbln._internal.ops_utils import (
+    _detect_view_recipe,
     compile_and_run_view_aware,
     cpu_fallback_path,
     extract_device_id_from_inputs,
@@ -446,6 +447,41 @@ def flash_attention_naive_decode_rbln(*args, **kwargs):
     return result_tensor
 
 
+def _materialize(t: torch.Tensor) -> torch.Tensor:
+    """The op under the view recipe: lay the replayed view out contiguously.
+
+    ``torch.clone`` would be the obvious choice and is wrong here -- it preserves the
+    source's memory format, so cloning a permuted view hands back the same strides, not
+    the contiguous destination layout ``copy_`` was asked for.
+    """
+    return t.contiguous()
+
+
+def copy_strided_view_rbln(src, out) -> bool:
+    """``out.copy_(src)`` for a strided device ``src``, as one compiled device program.
+
+    ``copy_``'s device->device path calls this instead of walking the copy one contiguous
+    run at a time. The view chain is replayed *inside* the compiled graph by the same
+    machinery every other view-aware op uses (``prepare_args_view_aware`` classifies it,
+    ``get_view_op_module`` replays it), so the device reads the base buffer and writes
+    ``out`` in one program -- no descriptor per run, no host round-trip. Nothing here is
+    specific to a permutation: whatever the detector can classify, this covers.
+
+    Returns False when the detector cannot classify ``src``, leaving ``copy_`` on its
+    existing route. That check has to happen before ``compile_and_run_view_aware``:
+    unclassified views take ``.contiguous()`` in there, which re-enters ``copy_``.
+    """
+    if _detect_view_recipe(src) is None:
+        return False
+    result = compile_and_run_view_aware(_materialize, "torch_rbln::copy_strided_view", (src,), {}, out)
+    if result is not None and result.data_ptr() != out.data_ptr():
+        # The compile path only writes the caller's buffer for dtypes in
+        # SupportedDtypes.dispatch; otherwise it hands back its own. Both are contiguous
+        # here, so this lands on copy_'s direct memcpy and cannot recurse.
+        out.copy_(result)
+    return True
+
+
 rbln_custom_impl = torch.library.Library("rbln_custom_ops", "IMPL")  # noqa: TOR901
 rbln_custom_impl.impl("paged_attn_prefill", paged_attn_prefill_rbln, "PrivateUse1")
 rbln_custom_impl.impl("paged_attn_decode", paged_attn_decode_rbln, "PrivateUse1")
@@ -453,3 +489,8 @@ rbln_custom_impl.impl("paged_causal_attn_prefill", paged_causal_attn_prefill_rbl
 rbln_custom_impl.impl("paged_causal_attn_decode", paged_causal_attn_decode_rbln, "PrivateUse1")
 rbln_custom_impl.impl("flash_attention_naive_prefill", flash_attention_naive_prefill_rbln, "PrivateUse1")
 rbln_custom_impl.impl("flash_attention_naive_decode", flash_attention_naive_decode_rbln, "PrivateUse1")
+
+# The schema is declared in RBLNRegisterOps.cpp, in the namespace this backend owns; only
+# the implementation lives here, because it drives the compile path.
+torch_rbln_impl = torch.library.Library("torch_rbln", "IMPL")  # noqa: TOR901
+torch_rbln_impl.impl("copy_strided_view", copy_strided_view_rbln, "PrivateUse1")


### PR DESCRIPTION
## Summary of Changes

A device→device `copy_` whose source is a view has two routes: the strided v2v engine, which spends a descriptor per contiguous run, and above its cap a host round-trip. Neither fits a copy that is one reshape away from contiguous — a paged KV block read head-major and written token-major breaks into runs of a single row, far past the cap, so what it actually gets is the bounce.

This routes such a copy through the view machinery the compile path already has. `prepare_args_view_aware` classifies the chain, `get_view_op_module` replays it *inside* the compiled graph, and the device reads the base buffer and writes the destination in one program. Nothing in the new code knows what a permutation is: whatever the detector classifies — a slice, a reshape, a select, or any composition — this covers.

**`feat(memory): teach the view detector to merge and split dims`**

`_apply_view_step` has always known how to replay a `reshape`, but nothing ever produced one: the candidate generator offers permute, squeeze, unsqueeze, narrow, expand and select, and the simulator rejects any step it does not recognise. A chain that flattens before it permutes — `kv.view(rows, heads, block, dim).permute(0, 2, 1, 3)`, the shape a paged KV transfer writes — came back unclassified and fell through to `.contiguous()`.

A merge or a split is a pure view exactly when the layout is contiguous from offset 0, which is where the new shape's strides follow from its sizes. The simulator now checks that, and the generator proposes one only from such a state. Both families are bounded by the target's own shape, so the search frontier does not grow.

This stands on its own — every consumer of the detector picks it up, since an unclassified view is materialised on the host.

**`feat(memory): serve a strided device copy as one compiled program`**

`torch_rbln::copy_strided_view` — schema declared in `RBLNRegisterOps.cpp`, implementation in Python because it drives the compile path — plus one branch in `tensor_copy_from_rbln_to_rbln`, ahead of the strided walk. `copy_` reaches it through the dispatcher rather than a hand-installed function pointer.

The namespace is this backend's own, not `rbln_custom_ops`: that one belongs to rebel-compiler and its names mirror the aten op each converts, so a `view_copy` there collides the moment it grows a converter for `aten::view_copy`, and two defs of one schema abort at import.

Two conditions decide whether to reach for it, and both are facts about the compiler quoted at the call site rather than tuning knobs:

- **dtype** — of the two dtypes the compile path dispatches, only bf16 reaches the device as itself; f16 is rewritten to a narrower float. `copy_` is not a compute op, so the fast and slow routes have to return the same values.
- **last-dim alignment** — below the compiler's threshold the tensor stays on the host, where the program is far slower than the walk it would replace.

Whether the view itself can be replayed is not a condition here: the shared detector answers that, and `view_copy` returns false when it cannot. That check runs *before* `compile_and_run_view_aware`, because an unclassified view takes `.contiguous()` in there, which re-enters `copy_`.

Not covered, each with a test asserting the existing route still serves it: a strided *destination* (the program writes a contiguous buffer, and scattering into a view is not something the out-tensor path can express) and a copy that crosses devices (one program reads and writes one device).

---

## Related Issues / Tickets

* Related to rebellions-sw/torch-rbln-internal#38
* Related to rebellions-sw/fsw-inference#540

---

## Type of Change

- [x] `perf` — Performance improvement
- [x] `core` — Changes to RBLN backend, device layer, C++ extension, op registration, or `torch.compile` integration

---

## Affected Modules

- [x] Backend
- [x] Ops/Kernels
- [x] `torch.compile`
- [x] Memory

---

## How to Test

```bash
uv run --no-sync pytest test/rbln/test_view_copy.py
uv run --no-sync python test/run_tests.py --suite=core
```

`test_view_copy.py` asserts the **route**, not only the result — the strided walk and the host bounce are correct too, so a result alone cannot tell them apart. It takes two counters. Every shape in it is past the strided engine's cap, so the host-bounce counter separates served from declined. That is not sufficient on its own: a served copy can still reach the host, because below the compiler's last-dim alignment the program is lowered with its input on the host and the runtime feeds it there without recording a bounce — confirmed by calling the op directly on an unaligned shape, which reports no bounce and a `v2h`/`h2v` pair. So the served cases also assert the runtime ran no host primitive.

- six classifiable chains (permute, reshape-then-permute, split-then-permute, select-, narrow-, transpose-last-two) take the program, on the first call and on repeats
- f16 / f32 / i32 / bool, three unaligned last dims, a strided destination, an unclassifiable `as_strided`, a contiguous copy and a device→host copy all keep the existing route and return the right values
- a copy across two logical devices keeps the existing route and returns the right values
- a destination at a non-zero storage offset is served but through the compile path's own buffer, so the result is moved across with a device-to-device copy rather than written in place
- one test asserts the detector still classifies every chain the others rely on, so a detector regression names itself instead of showing up as a slowdown

Verified that the tests fail without the change: 12 of 26 fail with the `copy_` branch disabled, 5 with the detector's reshape candidates removed, the three unaligned cases with the alignment gate removed, and the cross-device case with the device-equality gate removed.

Regression run (copy / view / profiler / warm-cache / graph-eager / op-caching / registered-ops): **3101 passed, 7 skipped.** The 16 failures in `test_add_mixed_devices` are not from this change — every logical device above `rbln:0` returns wrong values for a plain `add`, on a build containing none of this; reported separately. `lintrunner -m origin/dev -a` clean.

---

## Notes

**Measured on the KV-transfer benchmark in rebellions-sw/fsw-inference#540** — paired runs, alternating branches, n=9 each, one logical device, `rebel-compiler 0.11.3.dev108` (inside the `pyproject.toml` range, above the `constraints-build-dev.txt` pin). The compiler carried the `DynamoRuntime.run(out=)` change from rebellions-sw/rebel_compiler#13290 because the bespoke arm does not run without it; this branch does not use that path — it reaches the compile path through `out_tensor_context`, and its `out` argument stays `None`, which is also why it runs on a stock compiler at all (verified: the KV transfer's two copies come back bit-exact with no host primitive). Against a bespoke compiled-permute implementation of the same idea, total throughput is indistinguishable — the mean paired difference is under half a percent, and run-to-run spread on this benchmark is several times that. Split by direction, this one is ahead on gather and behind on scatter by similar margins; the scatter side is reproducible and its cause is not identified. What this buys over the bespoke version is that it needs no compiled-permute module, no C++ hook, and no compiler-side change, and it generalises past permutations.

Against the routes it replaces, a classifiable strided copy that used to round-trip the host is now two orders of magnitude cheaper.

The compile path is reached through `out_tensor_context`, so this needs nothing from `DynamoRuntime.run(out=)` — verified against a stock compiler build.