### PR TITLE
fix(ci): park bfloat16 x eager attention on ATOM behind a canary

### DIFF
--- a/constraints-build-dev.txt
+++ b/constraints-build-dev.txt
@@ -1,2 +1,2 @@
 # Build/dev dependency constraints (single source of truth).
-rebel-compiler==0.11.2
+rebel-compiler==0.11.3.dev160+g0ebb3f84.prod

--- a/test/models/test_transformers.py
+++ b/test/models/test_transformers.py
@@ -14,6 +14,8 @@ from transformers import AutoModelForCausalLM, AutoTokenizer, PreTrainedModel
 
 from test.utils import SUPPORTED_DTYPES
 
+from torch_rbln._internal.device_arch_utils import is_atom_device
+
 
 TORCH_RBLN_SAVE_PATH = os.getenv("TORCH_RBLN_SAVE_PATH", os.getcwd())
 
@@ -163,6 +165,18 @@ class TestCausalLMBase(TestCase):
         whose dtype overflows the model (e.g. fp16 BMM) are skipped — a dtype limitation,
         not an RBLN bug.
         """
+        # ATOM promotes bfloat16 to the device's custom float, whose range HuggingFace's causal
+        # mask value (torch.finfo(bfloat16).min) overflows into NaN rather than saturating, wiping
+        # out every eager-attention output. sdpa lowers to a fused kernel that never adds the
+        # mask this way, so only the eager cases go. test/rbln/test_bf16_range.py holds the
+        # cause and fails until it is fixed; drop this when that test starts passing.
+        if (
+            is_atom_device()
+            and config_kwargs.get("dtype") is torch.bfloat16
+            and config_kwargs.get("attn_implementation") == "eager"
+        ):
+            self.skipTest("bfloat16 x eager attention on ATOM: see test/rbln/test_bf16_range.py")
+
         fp32_config_kwargs = dict(config_kwargs, dtype=torch.float32)
         cpu_logits = self._prefill_logits(model_id, fp32_config_kwargs, batch_size, seq_len, self.cpu_device)
         rbln_logits = self._prefill_logits(model_id, config_kwargs, batch_size, seq_len, self.rbln_device)

--- a/test/rbln/test_bf16_range.py
+++ b/test/rbln/test_bf16_range.py
@@ -1,0 +1,53 @@
+# Owner(s): ["module: PrivateUse1"]
+
+"""bfloat16 at the edge of the format's range, on device.
+
+A second and no model download. This is the canary for the model-level
+``bfloat16 x attn_implementation="eager"`` cases that ``test/models/test_transformers.py``
+skips on ATOM: it fails for the same reason, so run it before spending an hour on a model.
+
+ATOM promotes bfloat16 to the device's custom float, whose exponent is narrower than
+bfloat16's -- about 2**32 of range against 3.4e38. A value the promotion cannot represent
+has to saturate; on ATOM it comes back NaN instead. HuggingFace builds its causal
+mask out of ``torch.finfo(dtype).min``, so every masked position turns into NaN and takes
+the attention output with it, with no error raised.
+
+``strict=True`` is the point: once the promotion saturates, this passes unexpectedly, CI
+reports it, and the model-level skip can go.
+"""
+
+import pytest
+import torch
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+from test.utils import xfail_atom
+
+
+class TestBf16Range(TestCase):
+    @pytest.mark.test_set_ci
+    @xfail_atom("the bfloat16 -> custom float promotion returns NaN instead of saturating")
+    def test_range_limit_survives_a_value_preserving_op(self, device):
+        # `+ 0` cannot change the value, so whatever comes back is the promotion's doing.
+        # (64, 64) rather than something tiny: small ops are scheduled on the host, which
+        # does not promote and so passes either way.
+        limit = torch.finfo(torch.bfloat16).min
+        operand = torch.full((64, 64), limit, dtype=torch.bfloat16, device=device)
+
+        result = (operand + torch.zeros_like(operand)).cpu()
+
+        self.assertEqual(
+            result,
+            torch.full((64, 64), limit, dtype=torch.bfloat16),
+            msg=(
+                f"{limit} came back as {result.flatten()[0]} on {device}. A bfloat16 value "
+                "the device compute type cannot hold must saturate, not become NaN."
+            ),
+        )
+
+
+instantiate_device_type_tests(TestBf16Range, globals(), only_for="privateuse1")
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/rbln/test_stream.py
+++ b/test/rbln/test_stream.py
@@ -17,7 +17,7 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 from test.utils import assert_device_resident_dtype
 
 
-# The device computes fp16 matmuls in a narrower dlfloat, so results are compared on
+# The device computes fp16 matmuls in a narrower custom float, so results are compared on
 # relative error: it is scale-free, where an absolute bound needs retuning per shape.
 REL_TOL = 0.01
 


### PR DESCRIPTION
## Summary of Changes

`bfloat16` x `attn_implementation="eager"` returns all-NaN logits on ATOM. Three model cases fail on it (`test_qwen2`, `test_llama_3b`, `test_exaone` at b2/s1024); REBEL runs the same cases and passes.

ATOM promotes bfloat16 to the device's custom float, whose exponent is narrower than bfloat16's — about `2**32` of range against `3.4e38`. HuggingFace builds its causal mask out of `torch.finfo(dtype).min`, which the promotion cannot represent and returns NaN for instead of saturating. Every masked position becomes NaN and takes the attention output with it, with no error raised. `sdpa` lowers to a fused kernel that never adds the mask this way, and REBEL keeps bfloat16 unpromoted (`compDtypeMode=auto`), so both keep running.

**The cause is in rebel-compiler, not here.** A value-preserving op on a bfloat16 tensor at the range limit is enough to show it:

```python
x = torch.full((64, 64), torch.finfo(torch.bfloat16).min, dtype=torch.bfloat16, device="rbln")
(x + torch.zeros_like(x)).cpu()      # all NaN on ATOM; CPU gives -3.38953e+38
```

`test/rbln/test_bf16_range.py` is that reproducer, marked `xfail_atom`. When the promotion starts saturating it passes unexpectedly, the strict marker fails the suite, and the model-level skip goes with it. It carries the `test_set_ci` marker, so the core lane reports it without anyone running the model suite.

The model-level guard sits in `_assert_logits_match_fp32`, one place that covers every model in the file, present and future.

The pin moves to a production build off rebel's `dev`: it carries the multi-device execution fix (`rebel_compiler#13303`) the eager path needs, and with it this promotion. Both are ahead of the next release, so it is temporary.

---

## Related Issues / Tickets

* No linked issue. The defect is rebel-compiler's; it has not been filed there, so the reproducer and this PR body are where it is recorded. Say the word and I will open one.

---

## Type of Change

- [x] `other` — test coverage scoped to an architecture, plus the pin it needs

---

## Affected Modules

- [x] Build/Tools

---

## How to Test

1. `uv pip install --constraint constraints-build-dev.txt rebel-compiler`
2. `uv pip install -e . --no-build-isolation`
3. `uv run --no-sync pytest test/rbln/test_bf16_range.py -rxX`
   Expected on ATOM: `1 xfailed`. On REBEL: `1 passed`.
4. `uv run --no-sync pytest test/models/test_transformers.py -k "qwen2 and b2_s1024" -rs`
   Expected on ATOM: the bf16 x eager case skips with a reason naming the canary; the sdpa cases still run.

Measured locally on 4x RBLN-CA25, torch-rbln at this branch, `rebel-compiler==0.11.3.dev160+g0ebb3f84.prod`:

```
test/rbln/test_bf16_range.py                        1 xfailed
test/models/... -k "qwen2 and b2_s1024" -rs         2 passed, 2 skipped
  SKIPPED bfloat16 x eager attention on ATOM: see test/rbln/test_bf16_range.py
  SKIPPED dtype torch.float16 overflows Qwen/Qwen2.5-1.5B-Instruct on CPU too   (pre-existing)
```

---

## Notes

**Not verified on REBEL.** The hardware here is ATOM only, so the inert side of `xfail_atom` and the three model cases that keep running are first exercised by the REBEL lane in CI.

**Why skip rather than `xfail_atom` at the model level.** `test_qwen2` takes its dtype from the covering array, where a per-cell decorator would work; `test_llama_3b` and `test_exaone` take theirs from the `@dtypes` harness, where a method-level marker would also cover the fp16 and sdpa cells that pass — and strict xfail would then fail on them. Rather than treat the three differently, the strict signal lives in the canary, which is where the cause is anyway, and the model cases skip with a reason that names it.

**Bisect.** `0.11.2` and `0.11.3.dev90+g405ca57d` are clean; `0.11.3.dev91+g590e158d` is the first bad build (`fix(rblnTensor): Move boundary casts by device call instead of transfer`, rebel_compiler#13138), which moved the boundary cast from host to device. The compiler's own host-side conversion saturates; the device result does not. The device kernel itself was not inspected.
