### PR TITLE
perf(eager): shim _softmax.out and drop the attention kernels' out-tensor global

### DIFF
--- a/test/rbln/test_torch_compile_patch.py
+++ b/test/rbln/test_torch_compile_patch.py
@@ -5,7 +5,6 @@ Test suite for torch_compile_patch_helpers module.
 """
 
 import types
-from contextlib import nullcontext
 from unittest.mock import Mock, patch
 
 import pytest
@@ -981,6 +980,18 @@ class TestTorchCompileMonkeyPatch(TestCase):
         block_size = 16
         return (q, k, v, k_cache, v_cache, seq, scale, block_table, block_size)
 
+    def _make_flash_attention_naive_inputs(self):
+        q = torch.zeros((1, 1, 1, 1, 64), device="rbln:0", dtype=torch.float16)
+        k = torch.zeros((1, 1, 1, 1, 64), device="rbln:0", dtype=torch.float16)
+        v = torch.zeros((1, 1, 1, 1, 64), device="rbln:0", dtype=torch.float16)
+        kv_cache = torch.zeros((1, 1, 1, 64), device="rbln:0", dtype=torch.float16)
+        mask = torch.zeros((1, 1, 1), device="rbln:0", dtype=torch.float16)
+        scale = torch.tensor(1.0)
+        seq_idx = torch.zeros((1, 1), dtype=torch.int32)
+        block_tables = torch.zeros((1, 1), dtype=torch.int32)
+        slot_mapping = torch.zeros((1, 1), dtype=torch.int32)
+        return (q, k, v, kv_cache, mask, scale, seq_idx, block_tables, slot_mapping)
+
     def test_patch_torch_compile_idempotent(self):
         """Test that patching multiple times is safe."""
         patch_torch_compile()
@@ -1097,8 +1108,8 @@ class TestTorchCompileMonkeyPatch(TestCase):
         self.assertEqual(mock_compile.call_count, 2)
 
     @requires_logical_devices(1)
-    def test_paged_attn_custom_kernel_paths_reuse_singleton_modules(self):
-        """Custom paged-attn kernels should pass stable module singletons into the compile cache."""
+    def test_custom_attn_kernel_paths_reuse_singleton_modules(self):
+        """Custom attention kernels should hand a stable module singleton to the compile cache."""
         cases = [
             (
                 register_custom_ops.paged_attn_prefill_rbln,
@@ -1120,22 +1131,28 @@ class TestTorchCompileMonkeyPatch(TestCase):
                 register_custom_ops._paged_causal_attn_decode_op_module,
                 self._make_paged_causal_attn_decode_inputs,
             ),
+            (
+                register_custom_ops.flash_attention_naive_prefill_rbln,
+                register_custom_ops._flash_attention_naive_prefill_op_module,
+                self._make_flash_attention_naive_inputs,
+            ),
+            (
+                register_custom_ops.flash_attention_naive_decode_rbln,
+                register_custom_ops._flash_attention_naive_decode_op_module,
+                self._make_flash_attention_naive_inputs,
+            ),
         ]
-
-        def fake_out_tensor_context(out_tensor=None):
-            return nullcontext()
 
         for kernel_fn, expected_module, make_inputs in cases:
             seen_models = []
 
-            def fake_compile(model, **kwargs):
-                seen_models.append(model)
-                return lambda *args, **inner_kwargs: args[0].clone()
+            def fake_dispatch(op_module, args, view_recipes):
+                seen_models.append(op_module)
+                return args[0].clone()
 
-            with patch.object(register_custom_ops, "compile_rbln_cached", side_effect=fake_compile):
-                with patch("torch_rbln.device.context_holder.out_tensor_context", new=fake_out_tensor_context):
-                    kernel_fn(*make_inputs())
-                    kernel_fn(*make_inputs())
+            with patch.object(register_custom_ops, "_dispatch_custom_kernel", side_effect=fake_dispatch):
+                kernel_fn(*make_inputs())
+                kernel_fn(*make_inputs())
 
             self.assertEqual(len(seen_models), 2)
             self.assertIs(seen_models[0], expected_module)

--- a/tools/codegen/config.py
+++ b/tools/codegen/config.py
@@ -138,6 +138,12 @@ class OpCategories:
         "max",
         "min",
     }
+    # Softmax .out: shape-preserving, with an int dim and a bool flag. The
+    # pointwise pre-check applies unchanged (fp16, not-all-scalar, no contig
+    # offset); the scalars ride in the warm-cache key like any other shim op.
+    SHIM_SOFTMAX: Set[str] = {
+        "_softmax.out",
+    }
     # Matmul family. Earlier benches showed a small device-path overhead
     # (~2% in pybind-heavy hot loops) which is now well below noise after
     # the warm-cache path skips Python entirely on warm hits. Coverage gain
@@ -159,6 +165,7 @@ class OpCategories:
         | SHIM_REDUCTION
         | SHIM_REDUCTION_FULL
         | SHIM_MATMUL
+        | SHIM_SOFTMAX
     )
 
     # Per-op overrides of the dispatch-shim dtype check: positional arg indices

--- a/torch_rbln/_internal/register_custom_ops.py
+++ b/torch_rbln/_internal/register_custom_ops.py
@@ -72,6 +72,17 @@ def pow_tensor_scalar_out_rbln(self, exponent, *, out):
     finalize_output_tensor(out, result_tensor, result_tensor.shape, (self,), {})
 
 
+def _dispatch_custom_kernel(op_module, args, view_recipes):
+    """Compile the kernel module through the rebel backend and run it."""
+    compiled = compile_rbln_cached(
+        op_module,
+        dynamic=False,
+        options={"disable_logger": True, "num_devices": 1},
+        device_cache_key=(extract_device_id_from_inputs(*args), view_recipes),
+    )
+    return compiled(*args)
+
+
 class custom_rbln_paged_attn_prefill(torch.nn.Module):
     def forward(self, *args, **kwargs):
         # TODO: rtosa.multiply cannot accept tensor scalar value. scale must be constant tensor.
@@ -94,8 +105,6 @@ _paged_attn_prefill_op_module = custom_rbln_paged_attn_prefill().eval()
 
 
 def paged_attn_prefill_rbln(*args, **kwargs):
-    from torch_rbln.device.context_holder import out_tensor_context
-
     if len(args) != 10:
         raise RuntimeError("paged_attn_prefill takes 10 inputs.")
 
@@ -124,25 +133,10 @@ def paged_attn_prefill_rbln(*args, **kwargs):
     # warning emitted via ``_maybe_warn_view_fallback``).
     (view_args, view_kwargs), view_recipes, _ = prepare_args_view_aware(args, kwargs)
 
-    # Result shape, dtype, and device match Q's user-visible (post-view) form.
-    result_tensor = torch.empty_like(args[0], memory_format=torch.contiguous_format)
-    assert result_tensor.size(-1) % 64 == 0
+    assert args[0].size(-1) % 64 == 0
 
-    with out_tensor_context(result_tensor):
-        op_module = get_view_op_module(_paged_attn_prefill_op_module, view_recipes)
-        compiled = compile_rbln_cached(
-            op_module,
-            dynamic=False,
-            options={"disable_logger": True, "num_devices": 1},
-            device_cache_key=(extract_device_id_from_inputs(*view_args, **view_kwargs), view_recipes),
-        )
-        external_result = compiled(*view_args, **view_kwargs)
-        if result_tensor is None:
-            result_tensor = external_result
-        elif isinstance(external_result, torch.Tensor) and (external_result.data_ptr() != result_tensor.data_ptr()):
-            result_tensor.copy_(external_result)
-
-    return result_tensor
+    op_module = get_view_op_module(_paged_attn_prefill_op_module, view_recipes)
+    return _dispatch_custom_kernel(op_module, view_args, view_recipes)
 
 
 class custom_rbln_paged_attn_decode(torch.nn.Module):
@@ -167,8 +161,6 @@ _paged_attn_decode_op_module = custom_rbln_paged_attn_decode().eval()
 
 
 def paged_attn_decode_rbln(*args, **kwargs):
-    from torch_rbln.device.context_holder import out_tensor_context
-
     if len(args) != 10:
         raise RuntimeError("paged_attn_prefill takes 10 inputs.")
 
@@ -181,24 +173,10 @@ def paged_attn_decode_rbln(*args, **kwargs):
 
     (view_args, view_kwargs), view_recipes, _ = prepare_args_view_aware(args, kwargs)
 
-    result_tensor = torch.empty_like(args[0], memory_format=torch.contiguous_format)
-    assert result_tensor.size(-1) % 64 == 0
+    assert args[0].size(-1) % 64 == 0
 
-    with out_tensor_context(result_tensor):
-        op_module = get_view_op_module(_paged_attn_decode_op_module, view_recipes)
-        compiled = compile_rbln_cached(
-            op_module,
-            dynamic=False,
-            options={"disable_logger": True, "num_devices": 1},
-            device_cache_key=(extract_device_id_from_inputs(*view_args, **view_kwargs), view_recipes),
-        )
-        external_result = compiled(*view_args, **view_kwargs)
-        if result_tensor is None:
-            result_tensor = external_result
-        elif isinstance(external_result, torch.Tensor) and (external_result.data_ptr() != result_tensor.data_ptr()):
-            result_tensor.copy_(external_result)
-
-    return result_tensor
+    op_module = get_view_op_module(_paged_attn_decode_op_module, view_recipes)
+    return _dispatch_custom_kernel(op_module, view_args, view_recipes)
 
 
 class custom_rbln_paged_causal_attn_prefill(torch.nn.Module):
@@ -230,8 +208,6 @@ _paged_causal_attn_prefill_op_module = custom_rbln_paged_causal_attn_prefill().e
 
 
 def paged_causal_attn_prefill_rbln(*args, **kwargs):
-    from torch_rbln.device.context_holder import out_tensor_context
-
     # paged_causal_attn_prefill: q, k, v, kcache, vcache, seq, scale, block_table, block_size, is_bidirectional, mask (optional)
     if len(args) < 10 or len(args) > 11:
         raise RuntimeError(f"paged_causal_attn_prefill takes 10 or 11 inputs, but got {len(args)}.")
@@ -251,24 +227,10 @@ def paged_causal_attn_prefill_rbln(*args, **kwargs):
 
     (view_args, view_kwargs), view_recipes, _ = prepare_args_view_aware(args, kwargs)
 
-    result_tensor = torch.empty_like(args[0], memory_format=torch.contiguous_format)
-    assert result_tensor.size(-1) % 64 == 0
+    assert args[0].size(-1) % 64 == 0
 
-    with out_tensor_context(result_tensor):
-        op_module = get_view_op_module(_paged_causal_attn_prefill_op_module, view_recipes)
-        compiled = compile_rbln_cached(
-            op_module,
-            dynamic=False,
-            options={"disable_logger": True, "num_devices": 1},
-            device_cache_key=(extract_device_id_from_inputs(*view_args, **view_kwargs), view_recipes),
-        )
-        external_result = compiled(*view_args, **view_kwargs)
-        if result_tensor is None:
-            result_tensor = external_result
-        elif isinstance(external_result, torch.Tensor) and (external_result.data_ptr() != result_tensor.data_ptr()):
-            result_tensor.copy_(external_result)
-
-    return result_tensor
+    op_module = get_view_op_module(_paged_causal_attn_prefill_op_module, view_recipes)
+    return _dispatch_custom_kernel(op_module, view_args, view_recipes)
 
 
 class custom_rbln_paged_causal_attn_decode(torch.nn.Module):
@@ -299,8 +261,6 @@ _paged_causal_attn_decode_op_module = custom_rbln_paged_causal_attn_decode().eva
 
 
 def paged_causal_attn_decode_rbln(*args, **kwargs):
-    from torch_rbln.device.context_holder import out_tensor_context
-
     # paged_causal_attn_decode: q, k, v, kcache, vcache, seq, scale, block_table, block_size, mask (optional)
     if len(args) < 9 or len(args) > 10:
         raise RuntimeError(f"paged_causal_attn_decode takes 9 or 10 inputs, but got {len(args)}.")
@@ -314,24 +274,10 @@ def paged_causal_attn_decode_rbln(*args, **kwargs):
 
     (view_args, view_kwargs), view_recipes, _ = prepare_args_view_aware(args, kwargs)
 
-    result_tensor = torch.empty_like(args[0], memory_format=torch.contiguous_format)
-    assert result_tensor.size(-1) % 64 == 0
+    assert args[0].size(-1) % 64 == 0
 
-    with out_tensor_context(result_tensor):
-        op_module = get_view_op_module(_paged_causal_attn_decode_op_module, view_recipes)
-        compiled = compile_rbln_cached(
-            op_module,
-            dynamic=False,
-            options={"disable_logger": True, "num_devices": 1},
-            device_cache_key=(extract_device_id_from_inputs(*view_args, **view_kwargs), view_recipes),
-        )
-        external_result = compiled(*view_args, **view_kwargs)
-        if result_tensor is None:
-            result_tensor = external_result
-        elif isinstance(external_result, torch.Tensor) and (external_result.data_ptr() != result_tensor.data_ptr()):
-            result_tensor.copy_(external_result)
-
-    return result_tensor
+    op_module = get_view_op_module(_paged_causal_attn_decode_op_module, view_recipes)
+    return _dispatch_custom_kernel(op_module, view_args, view_recipes)
 
 
 class custom_rbln_flash_attention_naive_prefill(torch.nn.Module):
@@ -353,9 +299,10 @@ class custom_rbln_flash_attention_naive_prefill(torch.nn.Module):
         return torch.ops.rbln_custom_ops.flash_attention_naive_prefill(*call_args)
 
 
-def flash_attention_naive_prefill_rbln(*args, **kwargs):
-    from torch_rbln.device.context_holder import helper
+_flash_attention_naive_prefill_op_module = custom_rbln_flash_attention_naive_prefill().eval()
 
+
+def flash_attention_naive_prefill_rbln(*args, **kwargs):
     if len(args) < 9 or len(args) > 10:
         raise RuntimeError(f"flash_attention_naive_prefill takes 9 or 10 inputs (optional sinks), but got {len(args)}.")
 
@@ -371,26 +318,10 @@ def flash_attention_naive_prefill_rbln(*args, **kwargs):
 
     (view_args, view_kwargs), view_recipes, _ = prepare_args_view_aware(args, kwargs)
 
-    result_tensor = torch.empty_like(args[0], memory_format=torch.contiguous_format)
-    assert result_tensor.size(-1) % 64 == 0
+    assert args[0].size(-1) % 64 == 0
 
-    helper.set_out_tensor(result_tensor)
-    base_module = custom_rbln_flash_attention_naive_prefill()
-    op_module = get_view_op_module(base_module, view_recipes)
-    compiled = torch.compile(
-        op_module,
-        backend="rbln",
-        dynamic=False,
-        options={"disable_logger": True, "num_devices": 1},
-    )
-    external_result = compiled(*view_args, **view_kwargs)
-    if result_tensor is None:
-        result_tensor = external_result
-    elif isinstance(external_result, torch.Tensor) and (external_result.data_ptr() != result_tensor.data_ptr()):
-        result_tensor.copy_(external_result)
-    helper.clear_out_tensor()
-
-    return result_tensor
+    op_module = get_view_op_module(_flash_attention_naive_prefill_op_module, view_recipes)
+    return _dispatch_custom_kernel(op_module, view_args, view_recipes)
 
 
 class custom_rbln_flash_attention_naive_decode(torch.nn.Module):
@@ -412,9 +343,10 @@ class custom_rbln_flash_attention_naive_decode(torch.nn.Module):
         return torch.ops.rbln_custom_ops.flash_attention_naive_decode(*call_args)
 
 
-def flash_attention_naive_decode_rbln(*args, **kwargs):
-    from torch_rbln.device.context_holder import helper
+_flash_attention_naive_decode_op_module = custom_rbln_flash_attention_naive_decode().eval()
 
+
+def flash_attention_naive_decode_rbln(*args, **kwargs):
     if len(args) < 9 or len(args) > 10:
         raise RuntimeError(f"flash_attention_naive_decode takes 9 or 10 inputs (optional sinks), but got {len(args)}.")
 
@@ -424,26 +356,10 @@ def flash_attention_naive_decode_rbln(*args, **kwargs):
 
     (view_args, view_kwargs), view_recipes, _ = prepare_args_view_aware(args, kwargs)
 
-    result_tensor = torch.empty_like(args[0], memory_format=torch.contiguous_format)
-    assert result_tensor.size(-1) % 64 == 0
+    assert args[0].size(-1) % 64 == 0
 
-    helper.set_out_tensor(result_tensor)
-    base_module = custom_rbln_flash_attention_naive_decode()
-    op_module = get_view_op_module(base_module, view_recipes)
-    compiled = torch.compile(
-        op_module,
-        backend="rbln",
-        dynamic=False,
-        options={"disable_logger": True, "num_devices": 1},
-    )
-    external_result = compiled(*view_args, **view_kwargs)
-    if result_tensor is None:
-        result_tensor = external_result
-    elif isinstance(external_result, torch.Tensor) and (external_result.data_ptr() != result_tensor.data_ptr()):
-        result_tensor.copy_(external_result)
-    helper.clear_out_tensor()
-
-    return result_tensor
+    op_module = get_view_op_module(_flash_attention_naive_decode_op_module, view_recipes)
+    return _dispatch_custom_kernel(op_module, view_args, view_recipes)
 
 
 rbln_custom_impl = torch.library.Library("rbln_custom_ops", "IMPL")  # noqa: TOR901


### PR DESCRIPTION
## Summary of Changes

Two eager-dispatch paths that went through Python on every call.

**The six paged- and flash-attention kernels.** Each allocated an output with `empty_like`, published it on the process-global out-tensor helper in `rebel.core.torch_eager` so the runtime would write there, and copied when it had not. That buffer was never the caller's `out=` — it was allocated one line above and returned unchanged — so letting the runtime keep its own output is the same tensor with the same single allocation, and the copy had nothing to do. Two of the six set and cleared the global by hand rather than through the context manager, leaking it on any exception in between, and built a module instance per call which handed the compile cache a new identity every time; they use a singleton and the shared cache like the other four.

**`aten::_softmax.out`.** It was the only `out=` op still off the C++ dispatch shim, so every dispatch paid the Python wrapper and Dynamo's guards. On the shim a warm dispatch reaches the runtime from C++ with the caller's out address and Python is not involved at all.

Neither change touches how a caller's `out=` is filled: on the shim the runtime writes into it directly, and on the miss path the helper still binds it. Removing that helper is a separate change and needs `DynamoRuntime.run` to accept a device tensor in `out` first — the released compiler validates `out` as host-only, so today the only alternative to the helper is a copy, and a copy is not an acceptable substitute.

## Related Issues / Tickets

* Related to #

## Type of Change

- [x] `perf` — Performance improvement
- [x] `refactor` — Code improvement without behavior change

## Affected Modules

- [x] Ops/Kernels
- [x] `torch.compile`
- [x] Build/Tools

## How to Test

`rbln_custom_ops` is registered when `rebel` is imported, which the suite does not do on its own; without it the custom-kernel tests fail on `dev` too.

1. `uv run --no-sync python -c "import rebel, pytest, sys; sys.exit(pytest.main(['test/rbln/test_custom_kernel.py', 'test/rbln/test_torch_compile_patch.py', 'test/rbln/test_op_caching.py', 'test/internal/test_warm_cache_internals.py', 'test/rbln/test_warm_cache_view_on_device.py', 'test/rbln/test_internal_op_utils.py', 'test/rbln/test_registered_ops.py', 'test/rbln/test_graph_eager_mode.py', '-q']))"`
2. `uv run --no-sync lintrunner -m origin/dev`

`test_graph_eager_mode.py` is the one that matters for the shim change: softmax must give the same numbers eager and inside a graph.

## Checklist

* [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
* [ ] This PR is linked to a corresponding issue
* [x] Linting passes
* [ ] All CI tests pass
* [x] The test method is described, and the expected result is clearly stated
* [ ] Relevant documentation has been updated (if applicable)

## Notes

**Performance.** `_softmax.out` is several times cheaper per dispatch on the shim. The attention kernels are neutral within run-to-run drift — the global they dropped was not buying them anything, which is the point: it was a channel with no traffic. Absolute figures are on an internal channel.

**Measurement method, and two traps in it.** One runtime per process: two resident on the same device inflate each other's execution time several-fold, so an interleaved A/B is meaningless. Device execution time drifts run to run, so the comparison is host-side — total minus the runtime's own `Run()`, from the shim's segment counters for the C++ path and from an instrumented `DynamoRuntime.run` for the Python path. `register_ops.py` is generated and gitignored, so it does not move when the tree is stashed to measure the base; it has to be regenerated on both sides or the base runs with this change still in it.

**Not done.** No rebuild: nothing here touches `aten/`, `c10/`, or `torch_rbln/csrc/`. The codegen change was applied by running `tools/run_codegen.py` directly, and the result is byte-identical to the file the tests ran against. The extension in the working venv predates `dec534a`, which touches `c10/rbln/RBLNFunctions.cpp` — unrelated to this change, but the results describe a build without it.

**Rebel-compiler.** Nothing new is needed from it and nothing here reaches past its public surface: the compile still goes through the rbln backend, which owns the artifact cache, weight-free weights, the thread policy and the device checks.
