### PR TITLE
feat(memory): add torch.rbln.physical_layout()

### DIFF
--- a/c10/rbln/RBLNFunctions.cpp
+++ b/c10/rbln/RBLNFunctions.cpp
@@ -352,13 +352,52 @@ c10::DeviceIndex get_torch_device_id(const void* data) {
   return static_cast<c10::DeviceIndex>(torch_device_id);
 }
 
+std::optional<c10::ScalarType> to_scalar_type(::rbln::DataType rbln_dtype) {
+  switch (rbln_dtype) {
+    case ::rbln::DataType::Bool:
+      return c10::kBool;
+    case ::rbln::DataType::UInt8:
+      return c10::kByte;
+    case ::rbln::DataType::Int8:
+      return c10::kChar;
+    case ::rbln::DataType::Int16:
+      return c10::kShort;
+    case ::rbln::DataType::Int32:
+      return c10::kInt;
+    case ::rbln::DataType::Int64:
+      return c10::kLong;
+    case ::rbln::DataType::Float16:
+      return c10::kHalf;
+    case ::rbln::DataType::Float32:
+      return c10::kFloat;
+    case ::rbln::DataType::Float64:
+      return c10::kDouble;
+    case ::rbln::DataType::Float8_e4m3:
+      return c10::kFloat8_e4m3fn;
+    case ::rbln::DataType::Float8_e5m2:
+      return c10::kFloat8_e5m2;
+    case ::rbln::DataType::BFloat16:
+      return c10::kBFloat16;
+    case ::rbln::DataType::Complex32:
+      return c10::kComplexHalf;
+    case ::rbln::DataType::Complex64:
+      return c10::kComplexFloat;
+    case ::rbln::DataType::Complex128:
+      return c10::kComplexDouble;
+    case ::rbln::DataType::Undefined:
+    case ::rbln::DataType::CustomFloat16:
+      return std::nullopt;
+  }
+  return std::nullopt;
+}
+
 ::rbln::MemoryInfo get_memory_info(const void* data) {
   RBLN_LOG_DEBUG("data={}", fmt::ptr(data));
   RBLN_CHECK(data != nullptr, "data cannot be nullptr");
   // get_memory_info() does a full VMemory JSON serialize+parse round-trip on
-  // every call. Warn so unexpected hot-path callers are easy to spot in logs;
-  // when only the device id is needed, get_torch_device_id() is the cheap path.
-  RBLN_LOG_WARN(
+  // every call; when only the device id is needed, get_torch_device_id() is the
+  // cheap path. Debug (not warn): torch.rbln.physical_layout() calls this on purpose.
+  RBLN_LOG_DEBUG(
       "get_memory_info({}) performs a full VMemory JSON round-trip (slow) — avoid on performance hot paths; "
       "use get_torch_device_id() when only the device id is needed",
       fmt::ptr(data));

--- a/c10/rbln/RBLNFunctions.h
+++ b/c10/rbln/RBLNFunctions.h
@@ -25,6 +25,13 @@ namespace c10::rbln {
 C10_RBLN_API ::rbln::DataType to_rbln_dtype(c10::ScalarType dtype);
 
 /**
+ * @brief Inverse of to_rbln_dtype(): the PyTorch dtype an RBLN data type maps back to.
+ *
+ * @return std::nullopt for RBLN data types torch has no dtype for (Undefined, CustomFloat16).
+ */
+C10_RBLN_API std::optional<c10::ScalarType> to_scalar_type(::rbln::DataType rbln_dtype);
+
+/**
  * @brief Converts memory information to a human-readable string.
  *
  * @param memory_info The memory information to convert.

--- a/test/cpp/core/RBLNFunctionsTest.cpp
+++ b/test/cpp/core/RBLNFunctionsTest.cpp
@@ -27,6 +27,29 @@ class RBLNFunctionsTest : public ::testing::Test {
   const size_t size_16gib_ = 1ULL << 34; // The memory capacity of ATOM is 15.7 GiB.
 };
 
+TEST_F(RBLNFunctionsTest, ToScalarTypeInvertsToRblnDtype) {
+  for (const auto scalar_type :
+       {c10::kBool,
+        c10::kByte,
+        c10::kChar,
+        c10::kShort,
+        c10::kInt,
+        c10::kLong,
+        c10::kHalf,
+        c10::kFloat,
+        c10::kDouble,
+        c10::kComplexHalf,
+        c10::kComplexFloat,
+        c10::kComplexDouble,
+        c10::kBFloat16,
+        c10::kFloat8_e5m2,
+        c10::kFloat8_e4m3fn}) {
+    EXPECT_EQ(c10::rbln::to_scalar_type(c10::rbln::to_rbln_dtype(scalar_type)), scalar_type);
+  }
+  EXPECT_FALSE(c10::rbln::to_scalar_type(::rbln::DataType::Undefined).has_value());
+  EXPECT_FALSE(c10::rbln::to_scalar_type(::rbln::DataType::CustomFloat16).has_value());
+}
+
 TEST_F(RBLNFunctionsTest, GetDeviceCount) {
   const auto device_count = c10::rbln::get_device_count();
   EXPECT_GE(device_count, 1);

--- a/test/rbln/test_physical_layout.py
+++ b/test/rbln/test_physical_layout.py
@@ -1,0 +1,86 @@
+# Owner(s): ["module: PrivateUse1"]
+
+"""Tests for ``torch.rbln.physical_layout(tensor)``.
+
+A device tensor's bytes live in one device-memory area per (node, chiplet) the
+runtime placed it on. ``physical_layout`` reports those areas -- the byte
+footprint of a tensor per chiplet -- for a tensor whose device allocation has
+been materialized (a bound buffer or a compiled-op output).
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+
+import torch_rbln  # noqa: F401  # binds the RBLN device + torch.rbln namespace
+
+
+DEVICE = torch.device("rbln:0")
+
+
+@pytest.mark.test_set_ci
+class TestPhysicalLayout:
+    def test_api_visible(self):
+        assert callable(torch.rbln.physical_layout)
+
+    def test_bound_flat_buffer_is_one_shard(self):
+        nbytes = 1 << 20
+        t = torch.empty(nbytes, dtype=torch.uint8, device=DEVICE)
+        torch.rbln.bind_device_memory(t)
+
+        layout = torch.rbln.physical_layout(t)
+
+        assert layout.logical_shape == (nbytes,)
+        assert layout.logical_dtype == torch.uint8
+        # flat 1:1 binding: no transform, so the physical view is the logical one
+        assert layout.physical_shape == (nbytes,)
+        assert layout.physical_dtype == torch.uint8
+        assert len(layout.shards) == 1
+        (shard,) = layout.shards
+        assert shard.node_id == 0
+        assert shard.nbytes == nbytes
+        assert isinstance(shard.device_addr, int)
+        assert shard.shape == ()  # flat byte buffer: not a tensor placement
+        assert layout.nbytes_per_chiplet() == {(shard.node_id, shard.chiplet_id): nbytes}
+
+    def test_compiled_op_output_covers_its_bytes(self):
+        out = torch.matmul(
+            torch.randn(128, 512, dtype=torch.float16, device=DEVICE),
+            torch.randn(512, 64, dtype=torch.float16, device=DEVICE),
+        )
+
+        layout = torch.rbln.physical_layout(out)
+
+        assert layout.logical_shape == (128, 64)
+        assert layout.shards
+        assert all(s.nbytes > 0 for s in layout.shards)
+
+        physical_numel = math.prod(layout.physical_shape)
+        physical_itemsize = torch.empty((), dtype=layout.physical_dtype).element_size()
+        assert physical_numel >= out.numel()
+        # each shard's shape is the slice of the physical tensor that fills its area
+        for shard in layout.shards:
+            assert len(shard.shape) == len(layout.physical_shape)
+            assert math.prod(shard.shape) * physical_itemsize == shard.nbytes
+        # every area holds whole physical elements; sharded or replicated, the total is a
+        # multiple of one physical copy
+        total = sum(layout.nbytes_per_chiplet().values())
+        assert total % (physical_numel * physical_itemsize) == 0
+
+    def test_unbound_tensor_raises(self):
+        t = torch.empty(16, dtype=torch.float16, device=DEVICE)
+        with pytest.raises(RuntimeError, match="no device memory"):
+            torch.rbln.physical_layout(t)
+
+    def test_cpu_tensor_raises(self):
+        with pytest.raises(RuntimeError, match="RBLN tensor"):
+            torch.rbln.physical_layout(torch.empty(16))
+
+    def test_interior_view_raises(self):
+        t = torch.empty(64, dtype=torch.uint8, device=DEVICE)
+        torch.rbln.bind_device_memory(t)
+        with pytest.raises(RuntimeError, match="whole storage"):
+            torch.rbln.physical_layout(t[8:32])

--- a/test/rbln/test_physical_layout.py
+++ b/test/rbln/test_physical_layout.py
@@ -16,16 +16,26 @@ import pytest
 import torch
 
 import torch_rbln  # noqa: F401  # binds the RBLN device + torch.rbln namespace
+from test.utils import requires_logical_devices
 
 
 DEVICE = torch.device("rbln:0")
 
 
 @pytest.mark.test_set_ci
-class TestPhysicalLayout:
-    def test_api_visible(self):
-        assert callable(torch.rbln.physical_layout)
+def test_api_visible():
+    assert callable(torch.rbln.physical_layout)
 
+
+@pytest.mark.test_set_ci
+def test_cpu_tensor_raises():
+    with pytest.raises(RuntimeError, match="RBLN tensor"):
+        torch.rbln.physical_layout(torch.empty(16))
+
+
+@pytest.mark.test_set_ci
+@requires_logical_devices(1)
+class TestPhysicalLayoutOnDevice:
     def test_bound_flat_buffer_is_one_shard(self):
         nbytes = 1 << 20
         t = torch.empty(nbytes, dtype=torch.uint8, device=DEVICE)
@@ -38,6 +48,7 @@ class TestPhysicalLayout:
         # flat 1:1 binding: no transform, so the physical view is the logical one
         assert layout.physical_shape == (nbytes,)
         assert layout.physical_dtype == torch.uint8
+        assert layout.physical_itemsize == 1
         assert len(layout.shards) == 1
         (shard,) = layout.shards
         assert shard.node_id == 0
@@ -59,7 +70,7 @@ class TestPhysicalLayout:
         assert all(s.nbytes > 0 for s in layout.shards)
 
         physical_numel = math.prod(layout.physical_shape)
-        physical_itemsize = torch.empty((), dtype=layout.physical_dtype).element_size()
+        physical_itemsize = layout.physical_itemsize  # physical_dtype may be a runtime-only name
         assert physical_numel >= out.numel()
         # each shard's shape is the slice of the physical tensor that fills its area
         for shard in layout.shards:
@@ -74,10 +85,6 @@ class TestPhysicalLayout:
         t = torch.empty(16, dtype=torch.float16, device=DEVICE)
         with pytest.raises(RuntimeError, match="no device memory"):
             torch.rbln.physical_layout(t)
-
-    def test_cpu_tensor_raises(self):
-        with pytest.raises(RuntimeError, match="RBLN tensor"):
-            torch.rbln.physical_layout(torch.empty(16))
 
     def test_interior_view_raises(self):
         t = torch.empty(64, dtype=torch.uint8, device=DEVICE)

--- a/test/rbln/test_physical_layout.py
+++ b/test/rbln/test_physical_layout.py
@@ -4,8 +4,8 @@
 
 A device tensor's bytes live in one device-memory area per (node, chiplet) the
 runtime placed it on. ``physical_layout`` reports those areas -- the byte
-footprint of a tensor per chiplet -- for a tensor whose device allocation has
-been materialized (a bound buffer or a compiled-op output).
+footprint of a tensor per chiplet and the slice of the physical tensor each one
+holds -- for a tensor whose device allocation has been materialized.
 """
 
 from __future__ import annotations
@@ -14,12 +14,10 @@ import math
 
 import pytest
 import torch
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import run_tests, TestCase
 
 import torch_rbln  # noqa: F401  # binds the RBLN device + torch.rbln namespace
-from test.utils import requires_logical_devices
-
-
-DEVICE = torch.device("rbln:0")
 
 
 @pytest.mark.test_set_ci
@@ -34,60 +32,62 @@ def test_cpu_tensor_raises():
 
 
 @pytest.mark.test_set_ci
-@requires_logical_devices(1)
-class TestPhysicalLayoutOnDevice:
-    def test_bound_flat_buffer_is_one_shard(self):
+class TestPhysicalLayout(TestCase):
+    def test_bound_flat_buffer_is_one_shard(self, device):
         nbytes = 1 << 20
-        t = torch.empty(nbytes, dtype=torch.uint8, device=DEVICE)
+        t = torch.empty(nbytes, dtype=torch.uint8, device=device)
         torch.rbln.bind_device_memory(t)
 
         layout = torch.rbln.physical_layout(t)
 
-        assert layout.logical_shape == (nbytes,)
-        assert layout.logical_dtype == torch.uint8
-        # flat 1:1 binding: no transform, so the physical view is the logical one
-        assert layout.physical_shape == (nbytes,)
-        assert layout.physical_dtype == torch.uint8
-        assert layout.physical_itemsize == 1
-        assert len(layout.shards) == 1
+        self.assertEqual(layout.logical_shape, (nbytes,))
+        self.assertEqual(layout.logical_dtype, torch.uint8)
+        # flat 1:1 binding has no tensor transform: nothing physical to describe
+        self.assertIsNone(layout.physical_shape)
+        self.assertIsNone(layout.physical_dtype)
+        self.assertIsNone(layout.physical_itemsize)
+        self.assertEqual(len(layout.shards), 1)
         (shard,) = layout.shards
-        assert shard.node_id == 0
-        assert shard.nbytes == nbytes
-        assert isinstance(shard.device_addr, int)
-        assert shard.shape == ()  # flat byte buffer: not a tensor placement
-        assert layout.nbytes_per_chiplet() == {(shard.node_id, shard.chiplet_id): nbytes}
+        self.assertEqual(shard.node_id, 0)
+        self.assertEqual(shard.nbytes, nbytes)
+        self.assertIsInstance(shard.device_addr, int)
+        self.assertIsNone(shard.shape)
+        self.assertEqual(layout.nbytes_per_chiplet(), {(shard.node_id, shard.chiplet_id): nbytes})
 
-    def test_compiled_op_output_covers_its_bytes(self):
+    def test_compiled_op_output_covers_its_bytes(self, device):
         out = torch.matmul(
-            torch.randn(128, 512, dtype=torch.float16, device=DEVICE),
-            torch.randn(512, 64, dtype=torch.float16, device=DEVICE),
+            torch.randn(128, 512, dtype=torch.float16, device=device),
+            torch.randn(512, 64, dtype=torch.float16, device=device),
         )
 
         layout = torch.rbln.physical_layout(out)
 
-        assert layout.logical_shape == (128, 64)
-        assert layout.shards
-        assert all(s.nbytes > 0 for s in layout.shards)
-
-        physical_numel = math.prod(layout.physical_shape)
-        physical_itemsize = layout.physical_itemsize  # physical_dtype may be a runtime-only name
-        assert physical_numel >= out.numel()
+        self.assertEqual(layout.logical_shape, (128, 64))
+        self.assertTrue(layout.shards)
+        self.assertIsNotNone(layout.physical_shape)
+        self.assertIsNotNone(layout.physical_itemsize)  # set even when physical_dtype is None (DLFloat16)
+        self.assertGreaterEqual(math.prod(layout.physical_shape), out.numel())
         # each shard's shape is the slice of the physical tensor that fills its area
         for shard in layout.shards:
-            assert len(shard.shape) == len(layout.physical_shape)
-            assert math.prod(shard.shape) * physical_itemsize == shard.nbytes
-        # every area holds whole physical elements; sharded or replicated, the total is a
-        # multiple of one physical copy
+            self.assertEqual(len(shard.shape), len(layout.physical_shape))
+            self.assertEqual(math.prod(shard.shape) * layout.physical_itemsize, shard.nbytes)
+        # sharded or replicated, the total is a multiple of one physical copy
         total = sum(layout.nbytes_per_chiplet().values())
-        assert total % (physical_numel * physical_itemsize) == 0
+        self.assertEqual(total % (math.prod(layout.physical_shape) * layout.physical_itemsize), 0)
 
-    def test_unbound_tensor_raises(self):
-        t = torch.empty(16, dtype=torch.float16, device=DEVICE)
-        with pytest.raises(RuntimeError, match="no device memory"):
+    def test_unbound_tensor_raises(self, device):
+        t = torch.empty(16, dtype=torch.float16, device=device)
+        with self.assertRaisesRegex(RuntimeError, "no device memory"):
             torch.rbln.physical_layout(t)
 
-    def test_interior_view_raises(self):
-        t = torch.empty(64, dtype=torch.uint8, device=DEVICE)
+    def test_interior_view_raises(self, device):
+        t = torch.empty(64, dtype=torch.uint8, device=device)
         torch.rbln.bind_device_memory(t)
-        with pytest.raises(RuntimeError, match="whole storage"):
+        with self.assertRaisesRegex(RuntimeError, "whole storage"):
             torch.rbln.physical_layout(t[8:32])
+
+
+instantiate_device_type_tests(TestPhysicalLayout, globals(), only_for="privateuse1")
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch_rbln/csrc/rbln/Module.cpp
+++ b/torch_rbln/csrc/rbln/Module.cpp
@@ -9,6 +9,7 @@
 #include <c10/rbln/RBLNLogging.h>
 #include <c10/rbln/RBLNProfiler.h>
 #include <c10/rbln/RBLNSupportedDtypes.h>
+#include <rebel/runtime/api/rbln_runtime_api.h>
 #include <torch/csrc/Dtype.h>
 #include <torch/csrc/utils/pybind.h>
 #include <torch_rbln/csrc/distributed/c10d/rbln/ProcessGroupRBLNModule.hpp>
@@ -191,6 +192,46 @@ void check_base_rbln_tensor(const at::Tensor& t, const char* api, const char* na
       " must cover its whole storage (contiguous, storage_offset 0)");
 }
 
+const char* rbln_data_type_name(::rbln::DataType dtype) {
+  switch (dtype) {
+    case ::rbln::DataType::Undefined:
+      return "Undefined";
+    case ::rbln::DataType::Bool:
+      return "Bool";
+    case ::rbln::DataType::UInt8:
+      return "UInt8";
+    case ::rbln::DataType::Int8:
+      return "Int8";
+    case ::rbln::DataType::Int16:
+      return "Int16";
+    case ::rbln::DataType::Int32:
+      return "Int32";
+    case ::rbln::DataType::Int64:
+      return "Int64";
+    case ::rbln::DataType::Float16:
+      return "Float16";
+    case ::rbln::DataType::Float32:
+      return "Float32";
+    case ::rbln::DataType::Float64:
+      return "Float64";
+    case ::rbln::DataType::Float8_e4m3:
+      return "Float8_e4m3";
+    case ::rbln::DataType::Float8_e5m2:
+      return "Float8_e5m2";
+    case ::rbln::DataType::BFloat16:
+      return "BFloat16";
+    case ::rbln::DataType::CustomFloat16:
+      return "CustomFloat16";
+    case ::rbln::DataType::Complex32:
+      return "Complex32";
+    case ::rbln::DataType::Complex64:
+      return "Complex64";
+    case ::rbln::DataType::Complex128:
+      return "Complex128";
+  }
+  return "Undefined";
+}
+
 /**
  * @brief Register internal API functions with Python
  *
@@ -223,6 +264,31 @@ void register_internal_api(py::module_& module) {
         c10::rbln::bind_device_memory(tensor.data_ptr(), tensor.storage().nbytes());
       },
       "Internal: give an RBLN tensor a flat single-node device allocation");
+
+  // Physical placement of a tensor's device allocation (areas per (node, chiplet) plus the
+  // user/physical tensor meta of its transform). Used by torch_rbln.physical_layout().
+  module.def(
+      "_get_memory_info",
+      [](const at::Tensor& tensor) {
+        check_base_rbln_tensor(tensor, "physical_layout", "tensor");
+        ::rbln::MemoryInfo info;
+        TORCH_CHECK(
+            ::rbln::rbln_get_memory_info(reinterpret_cast<uint64_t>(tensor.data_ptr()), info) == RBLNRetCode_SUCCESS,
+            "physical_layout: rbln_get_memory_info failed for tensor on ",
+            tensor.device());
+        py::list areas;
+        for (const auto& area : info.device_areas) {
+          areas.append(py::make_tuple(area.node_id, area.chiplet_id, area.device_addr, area.size, area.shape));
+        }
+        py::dict out;
+        out["user_dtype"] = rbln_data_type_name(info.user_dtype);
+        out["user_shape"] = info.user_shape;
+        out["physical_dtype"] = rbln_data_type_name(info.physical_dtype);
+        out["physical_shape"] = info.physical_shape;
+        out["device_areas"] = areas;
+        return out;
+      },
+      "Internal: device areas and tensor meta of an RBLN tensor's allocation");
 
   // Set target's device-allocation layout to match ref's, without copying data.
   // Used by torch_rbln.set_device_layout_like().

--- a/torch_rbln/csrc/rbln/Module.cpp
+++ b/torch_rbln/csrc/rbln/Module.cpp
@@ -9,7 +9,6 @@
 #include <c10/rbln/RBLNLogging.h>
 #include <c10/rbln/RBLNProfiler.h>
 #include <c10/rbln/RBLNSupportedDtypes.h>
-#include <rebel/runtime/api/rbln_runtime_api.h>
 #include <torch/csrc/Dtype.h>
 #include <torch/csrc/utils/pybind.h>
 #include <torch_rbln/csrc/distributed/c10d/rbln/ProcessGroupRBLNModule.hpp>
@@ -192,46 +191,6 @@ void check_base_rbln_tensor(const at::Tensor& t, const char* api, const char* na
       " must cover its whole storage (contiguous, storage_offset 0)");
 }
 
-const char* rbln_data_type_name(::rbln::DataType dtype) {
-  switch (dtype) {
-    case ::rbln::DataType::Undefined:
-      return "Undefined";
-    case ::rbln::DataType::Bool:
-      return "Bool";
-    case ::rbln::DataType::UInt8:
-      return "UInt8";
-    case ::rbln::DataType::Int8:
-      return "Int8";
-    case ::rbln::DataType::Int16:
-      return "Int16";
-    case ::rbln::DataType::Int32:
-      return "Int32";
-    case ::rbln::DataType::Int64:
-      return "Int64";
-    case ::rbln::DataType::Float16:
-      return "Float16";
-    case ::rbln::DataType::Float32:
-      return "Float32";
-    case ::rbln::DataType::Float64:
-      return "Float64";
-    case ::rbln::DataType::Float8_e4m3:
-      return "Float8_e4m3";
-    case ::rbln::DataType::Float8_e5m2:
-      return "Float8_e5m2";
-    case ::rbln::DataType::BFloat16:
-      return "BFloat16";
-    case ::rbln::DataType::CustomFloat16:
-      return "CustomFloat16";
-    case ::rbln::DataType::Complex32:
-      return "Complex32";
-    case ::rbln::DataType::Complex64:
-      return "Complex64";
-    case ::rbln::DataType::Complex128:
-      return "Complex128";
-  }
-  return "Undefined";
-}
-
 /**
  * @brief Register internal API functions with Python
  *
@@ -265,27 +224,37 @@ void register_internal_api(py::module_& module) {
       },
       "Internal: give an RBLN tensor a flat single-node device allocation");
 
-  // Physical placement of a tensor's device allocation (areas per (node, chiplet) plus the
-  // user/physical tensor meta of its transform). Used by torch_rbln.physical_layout().
+  // Physical placement of a tensor's device allocation: one dict per area, keyed like
+  // torch_rbln.memory.PhysicalShard, plus the physical tensor meta of its transform.
+  // Used by torch_rbln.physical_layout().
   module.def(
       "_get_memory_info",
       [](const at::Tensor& tensor) {
         check_base_rbln_tensor(tensor, "physical_layout", "tensor");
         const ::rbln::MemoryInfo info = c10::rbln::get_memory_info(tensor.data_ptr());
-        // Tuple order matches torch_rbln.memory.PhysicalShard(node_id, chiplet_id, nbytes, device_addr, shape).
         py::list areas;
         for (const auto& area : info.device_areas) {
-          areas.append(py::make_tuple(area.node_id, area.chiplet_id, area.size, area.device_addr, area.shape));
+          py::dict shard;
+          shard["node_id"] = area.node_id;
+          shard["chiplet_id"] = area.chiplet_id;
+          shard["nbytes"] = area.size;
+          shard["device_addr"] = area.device_addr;
+          shard["shape"] = area.shape;
+          areas.append(std::move(shard));
         }
         py::dict out;
-        out["user_dtype"] = rbln_data_type_name(info.user_dtype);
-        out["user_shape"] = info.user_shape;
-        out["physical_dtype"] = rbln_data_type_name(info.physical_dtype);
         out["physical_shape"] = info.physical_shape;
+        if (const auto scalar_type = c10::rbln::to_scalar_type(info.physical_dtype)) {
+          // Borrowed reference to a process-wide singleton, as in register_supported_dtypes_api.
+          out["physical_dtype"] =
+              py::reinterpret_borrow<py::object>(reinterpret_cast<PyObject*>(torch::getTHPDtype(*scalar_type)));
+        } else {
+          out["physical_dtype"] = py::none();
+        }
         out["device_areas"] = areas;
         return out;
       },
-      "Internal: device areas and tensor meta of an RBLN tensor's allocation");
+      "Internal: device areas and physical tensor meta of an RBLN tensor's allocation");
 
   // Set target's device-allocation layout to match ref's, without copying data.
   // Used by torch_rbln.set_device_layout_like().

--- a/torch_rbln/csrc/rbln/Module.cpp
+++ b/torch_rbln/csrc/rbln/Module.cpp
@@ -271,14 +271,11 @@ void register_internal_api(py::module_& module) {
       "_get_memory_info",
       [](const at::Tensor& tensor) {
         check_base_rbln_tensor(tensor, "physical_layout", "tensor");
-        ::rbln::MemoryInfo info;
-        TORCH_CHECK(
-            ::rbln::rbln_get_memory_info(reinterpret_cast<uint64_t>(tensor.data_ptr()), info) == RBLNRetCode_SUCCESS,
-            "physical_layout: rbln_get_memory_info failed for tensor on ",
-            tensor.device());
+        const ::rbln::MemoryInfo info = c10::rbln::get_memory_info(tensor.data_ptr());
+        // Tuple order matches torch_rbln.memory.PhysicalShard(node_id, chiplet_id, nbytes, device_addr, shape).
         py::list areas;
         for (const auto& area : info.device_areas) {
-          areas.append(py::make_tuple(area.node_id, area.chiplet_id, area.device_addr, area.size, area.shape));
+          areas.append(py::make_tuple(area.node_id, area.chiplet_id, area.size, area.device_addr, area.shape));
         }
         py::dict out;
         out["user_dtype"] = rbln_data_type_name(info.user_dtype);

--- a/torch_rbln/memory.py
+++ b/torch_rbln/memory.py
@@ -8,6 +8,7 @@ import contextlib
 import operator
 import sys
 import threading
+from dataclasses import dataclass
 from typing import Dict, Iterator, Optional, Union  # noqa: UP035
 
 import torch
@@ -26,6 +27,9 @@ __all__ = [
     "memory_reserved",
     "memory_stats",
     "offload",
+    "physical_layout",
+    "PhysicalLayout",
+    "PhysicalShard",
     "release_offload_temp_storage",
     "reset_accumulated_memory_stats",
     "reset_peak_memory_stats",
@@ -288,6 +292,124 @@ def bind_device_memory(tensor: torch.Tensor) -> None:
         torch.rbln.bind_device_memory(staging)
     """
     torch_rbln._C._bind_device_memory(tensor)
+
+
+@dataclass(frozen=True)
+class PhysicalShard:
+    """One device-memory area a tensor occupies: where it sits, how many bytes, and which
+    part of the physical tensor -- its sliced shape when sharded, the whole physical shape
+    when replicated, ``()`` for a flat byte buffer."""
+
+    node_id: int
+    chiplet_id: int
+    nbytes: int
+    device_addr: int
+    shape: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class PhysicalLayout:
+    """Where a tensor's bytes physically sit on the device, per (node, chiplet) area."""
+
+    logical_shape: tuple[int, ...]
+    logical_dtype: torch.dtype
+    physical_shape: tuple[int, ...]
+    physical_dtype: Union[torch.dtype, str]
+    shards: tuple[PhysicalShard, ...]
+
+    def nbytes_per_chiplet(self) -> Dict[tuple[int, int], int]:
+        """Bytes occupied per ``(node_id, chiplet_id)``; chiplets holding no shard are absent."""
+        out: Dict[tuple[int, int], int] = {}
+        for shard in self.shards:
+            key = (shard.node_id, shard.chiplet_id)
+            out[key] = out.get(key, 0) + shard.nbytes
+        return out
+
+
+def physical_layout(tensor: torch.Tensor) -> PhysicalLayout:
+    """
+    Report where ``tensor``'s bytes physically sit on the device.
+
+    A device tensor is one virtual allocation whose bytes the runtime places in
+    one device-memory area per (node, chiplet) -- sharded across chiplets,
+    replicated, or a single flat area. This returns those areas as
+    :class:`PhysicalShard` entries. ``nbytes`` is the exact byte count of the
+    area as the runtime sized it; the allocator rounds each area up to its own
+    granularity (2 MiB on REBEL) when it carves device DRAM, so the footprint on
+    the device is at least that.
+
+    The layout exists only once the allocation has been materialized -- after a
+    torch op or compiled graph has bound the tensor, or after
+    :func:`bind_device_memory`. A freshly created tensor has no layout yet.
+
+    The counterpart of ``DTensor.placements``: per-chiplet sizing (e.g. KV cache
+    blocks per chiplet) and placement diagnostics read it instead of inferring
+    the split from the logical shape.
+
+    Args:
+        tensor: An RBLN tensor covering its whole storage: contiguous, with zero
+            storage offset. A slice or an interior view is rejected, since its
+            address is not the allocation's.
+
+    ``physical_shape`` / ``physical_dtype`` describe the tensor as the device
+    stores it -- after the compiler's pad / cast / reshape transform and before
+    it is split into areas -- so they can differ from the logical ones; a flat
+    1:1 binding has no transform and reports the logical values. Each shard's
+    ``shape`` is the part of that physical tensor placed in its area, so a
+    4-way head split of ``(4, 16, 1, 128, 2048)`` reports ``(4, 4, 1, 128, 2048)``
+    per shard while a 4-way replication reports the full shape four times. A physical
+    dtype torch has no equivalent for (``DLFloat16``) is returned by its runtime
+    name.
+
+    Returns:
+        PhysicalLayout: logical and physical shape/dtype plus one shard per area.
+
+    Raises:
+        RuntimeError: if ``tensor`` is not an RBLN tensor, does not cover its
+            whole storage, or has no device memory yet.
+
+    Example::
+
+        kv = torch.empty(2, num_blocks, heads, block, head_dim, dtype=torch.bfloat16, device="rbln")
+        ...  # run / warm up the compiled graph that binds it
+        per_chiplet = torch.rbln.physical_layout(kv).nbytes_per_chiplet()
+    """
+    info = torch_rbln._C._get_memory_info(tensor)
+    if not info["device_areas"]:
+        raise RuntimeError(
+            "physical_layout: tensor has no device memory yet -- run the graph that binds it or "
+            "call bind_device_memory() first"
+        )
+    shards = tuple(
+        PhysicalShard(node, chiplet, nbytes, addr, tuple(shape))
+        for node, chiplet, nbytes, addr, shape in info["device_areas"]
+    )
+    if info["physical_shape"]:
+        physical_shape = tuple(info["physical_shape"])
+        physical_dtype = _RUNTIME_DTYPE_TO_TORCH.get(info["physical_dtype"], info["physical_dtype"])
+    else:
+        physical_shape, physical_dtype = tuple(tensor.shape), tensor.dtype
+    return PhysicalLayout(tuple(tensor.shape), tensor.dtype, physical_shape, physical_dtype, shards)
+
+
+_RUNTIME_DTYPE_TO_TORCH: Dict[str, torch.dtype] = {
+    "Bool": torch.bool,
+    "UInt8": torch.uint8,
+    "Int8": torch.int8,
+    "Int16": torch.int16,
+    "Int32": torch.int32,
+    "Int64": torch.int64,
+    "Float16": torch.float16,
+    "Float32": torch.float32,
+    "Float64": torch.float64,
+    "Float8_e4m3": torch.float8_e4m3fn,
+    "Float8_e5m2": torch.float8_e5m2,
+    "BFloat16": torch.bfloat16,
+    # CustomFloat16 (DLFloat16) has no torch dtype; it falls through as its runtime name
+    "Complex32": torch.complex32,
+    "Complex64": torch.complex64,
+    "Complex128": torch.complex128,
+}
 
 
 def huge_host_empty(nbytes: int) -> torch.Tensor:

--- a/torch_rbln/memory.py
+++ b/torch_rbln/memory.py
@@ -315,6 +315,7 @@ class PhysicalLayout:
     logical_dtype: torch.dtype
     physical_shape: tuple[int, ...]
     physical_dtype: Union[torch.dtype, str]
+    physical_itemsize: int
     shards: tuple[PhysicalShard, ...]
 
     def nbytes_per_chiplet(self) -> Dict[tuple[int, int], int]:
@@ -357,12 +358,16 @@ def physical_layout(tensor: torch.Tensor) -> PhysicalLayout:
     1:1 binding has no transform and reports the logical values. Each shard's
     ``shape`` is the part of that physical tensor placed in its area, so a
     4-way head split of ``(4, 16, 1, 128, 2048)`` reports ``(4, 4, 1, 128, 2048)``
-    per shard while a 4-way replication reports the full shape four times. A physical
-    dtype torch has no equivalent for (``DLFloat16``) is returned by its runtime
-    name.
+    per shard while a 4-way replication reports the full shape four times.
+    fp16 / bf16 tensors are usually stored as ``CustomFloat16`` (DLFloat16) on
+    the device, which torch has no dtype for: ``physical_dtype`` is then the
+    runtime name, and ``physical_itemsize`` carries the element size either way.
+
+    Diagnostic call: the runtime answers it through a full serialization of the
+    allocation's bookkeeping. Read it once after warm-up, not per step.
 
     Returns:
-        PhysicalLayout: logical and physical shape/dtype plus one shard per area.
+        PhysicalLayout: logical and physical shape/dtype/itemsize plus one shard per area.
 
     Raises:
         RuntimeError: if ``tensor`` is not an RBLN tensor, does not cover its
@@ -387,10 +392,31 @@ def physical_layout(tensor: torch.Tensor) -> PhysicalLayout:
     if info["physical_shape"]:
         physical_shape = tuple(info["physical_shape"])
         physical_dtype = _RUNTIME_DTYPE_TO_TORCH.get(info["physical_dtype"], info["physical_dtype"])
+        physical_itemsize = _RUNTIME_DTYPE_ITEMSIZE[info["physical_dtype"]]
     else:
         physical_shape, physical_dtype = tuple(tensor.shape), tensor.dtype
-    return PhysicalLayout(tuple(tensor.shape), tensor.dtype, physical_shape, physical_dtype, shards)
+        physical_itemsize = tensor.element_size()
+    return PhysicalLayout(tuple(tensor.shape), tensor.dtype, physical_shape, physical_dtype, physical_itemsize, shards)
 
+
+_RUNTIME_DTYPE_ITEMSIZE: Dict[str, int] = {
+    "Bool": 1,
+    "UInt8": 1,
+    "Int8": 1,
+    "Int16": 2,
+    "Int32": 4,
+    "Int64": 8,
+    "Float16": 2,
+    "Float32": 4,
+    "Float64": 8,
+    "Float8_e4m3": 1,
+    "Float8_e5m2": 1,
+    "BFloat16": 2,
+    "CustomFloat16": 2,
+    "Complex32": 4,
+    "Complex64": 8,
+    "Complex128": 16,
+}
 
 _RUNTIME_DTYPE_TO_TORCH: Dict[str, torch.dtype] = {
     "Bool": torch.bool,

--- a/torch_rbln/memory.py
+++ b/torch_rbln/memory.py
@@ -5,6 +5,7 @@ cache management, memory statistics, and memory monitoring capabilities.
 """
 
 import contextlib
+import math
 import operator
 import sys
 import threading
@@ -296,26 +297,33 @@ def bind_device_memory(tensor: torch.Tensor) -> None:
 
 @dataclass(frozen=True)
 class PhysicalShard:
-    """One device-memory area a tensor occupies: where it sits, how many bytes, and which
-    part of the physical tensor -- its sliced shape when sharded, the whole physical shape
-    when replicated, ``()`` for a flat byte buffer."""
+    """One device-memory area a tensor occupies. ``shape`` is the part of the physical
+    tensor placed there (sliced when sharded, whole when replicated); ``None`` for a
+    flat byte buffer with no tensor transform."""
 
     node_id: int
     chiplet_id: int
     nbytes: int
     device_addr: int
-    shape: tuple[int, ...]
+    shape: Optional[tuple[int, ...]]
 
 
 @dataclass(frozen=True)
 class PhysicalLayout:
-    """Where a tensor's bytes physically sit on the device, per (node, chiplet) area."""
+    """Where a tensor's bytes physically sit on the device, one shard per (node, chiplet) area.
+
+    ``physical_*`` describe the tensor as the device stores it -- after the compiler's
+    pad / cast / reshape transform, before the split into areas. They are ``None`` for a
+    flat binding that has no transform. ``physical_dtype`` is also ``None`` when the
+    on-device dtype has no torch equivalent (DLFloat16, the usual fp16 / bf16 storage);
+    ``physical_itemsize`` is derived from the areas and is always set with a transform.
+    """
 
     logical_shape: tuple[int, ...]
     logical_dtype: torch.dtype
-    physical_shape: tuple[int, ...]
-    physical_dtype: Union[torch.dtype, str]
-    physical_itemsize: int
+    physical_shape: Optional[tuple[int, ...]]
+    physical_dtype: Optional[torch.dtype]
+    physical_itemsize: Optional[int]
     shards: tuple[PhysicalShard, ...]
 
     def nbytes_per_chiplet(self) -> Dict[tuple[int, int], int]:
@@ -331,52 +339,24 @@ def physical_layout(tensor: torch.Tensor) -> PhysicalLayout:
     """
     Report where ``tensor``'s bytes physically sit on the device.
 
-    A device tensor is one virtual allocation whose bytes the runtime places in
-    one device-memory area per (node, chiplet) -- sharded across chiplets,
-    replicated, or a single flat area. This returns those areas as
-    :class:`PhysicalShard` entries. ``nbytes`` is the exact byte count of the
-    area as the runtime sized it; the allocator rounds each area up to its own
-    granularity (2 MiB on REBEL) when it carves device DRAM, so the footprint on
-    the device is at least that.
-
-    The layout exists only once the allocation has been materialized -- after a
-    torch op or compiled graph has bound the tensor, or after
-    :func:`bind_device_memory`. A freshly created tensor has no layout yet.
-
-    The counterpart of ``DTensor.placements``: per-chiplet sizing (e.g. KV cache
-    blocks per chiplet) and placement diagnostics read it instead of inferring
-    the split from the logical shape.
+    Available once the allocation is bound -- after a torch op or compiled graph has
+    touched the tensor, or after :func:`bind_device_memory`. A 4-way head split of a
+    ``(4, 16, 1, 128, 2048)`` KV cache reports one shard per chiplet with shape
+    ``(4, 4, 1, 128, 2048)``; a 4-way replication reports the full shape four times.
+    Each shard's ``nbytes`` is exact; the allocator rounds areas up to 2 MiB on the
+    device. Diagnostic call (full round-trip through the runtime's bookkeeping): read
+    it once after warm-up, not per step.
 
     Args:
-        tensor: An RBLN tensor covering its whole storage: contiguous, with zero
-            storage offset. A slice or an interior view is rejected, since its
-            address is not the allocation's.
-
-    ``physical_shape`` / ``physical_dtype`` describe the tensor as the device
-    stores it -- after the compiler's pad / cast / reshape transform and before
-    it is split into areas -- so they can differ from the logical ones; a flat
-    1:1 binding has no transform and reports the logical values. Each shard's
-    ``shape`` is the part of that physical tensor placed in its area, so a
-    4-way head split of ``(4, 16, 1, 128, 2048)`` reports ``(4, 4, 1, 128, 2048)``
-    per shard while a 4-way replication reports the full shape four times.
-    fp16 / bf16 tensors are usually stored as ``CustomFloat16`` (DLFloat16) on
-    the device, which torch has no dtype for: ``physical_dtype`` is then the
-    runtime name, and ``physical_itemsize`` carries the element size either way.
-
-    Diagnostic call: the runtime answers it through a full serialization of the
-    allocation's bookkeeping. Read it once after warm-up, not per step.
-
-    Returns:
-        PhysicalLayout: logical and physical shape/dtype/itemsize plus one shard per area.
+        tensor: An RBLN tensor covering its whole storage (contiguous, zero storage
+            offset). A slice or interior view is rejected.
 
     Raises:
-        RuntimeError: if ``tensor`` is not an RBLN tensor, does not cover its
-            whole storage, or has no device memory yet.
+        RuntimeError: not an RBLN tensor, not covering its whole storage, or no device
+            memory bound yet.
 
     Example::
 
-        kv = torch.empty(2, num_blocks, heads, block, head_dim, dtype=torch.bfloat16, device="rbln")
-        ...  # run / warm up the compiled graph that binds it
         per_chiplet = torch.rbln.physical_layout(kv).nbytes_per_chiplet()
     """
     info = torch_rbln._C._get_memory_info(tensor)
@@ -385,57 +365,15 @@ def physical_layout(tensor: torch.Tensor) -> PhysicalLayout:
             "physical_layout: tensor has no device memory yet -- run the graph that binds it or "
             "call bind_device_memory() first"
         )
-    shards = tuple(
-        PhysicalShard(node, chiplet, nbytes, addr, tuple(shape))
-        for node, chiplet, nbytes, addr, shape in info["device_areas"]
+    shards = tuple(PhysicalShard(**{**area, "shape": tuple(area["shape"]) or None}) for area in info["device_areas"])
+    physical_shape = tuple(info["physical_shape"]) or None
+    physical_itemsize = None
+    if physical_shape is not None:
+        first = next(s for s in shards if s.shape)
+        physical_itemsize = first.nbytes // math.prod(first.shape)
+    return PhysicalLayout(
+        tuple(tensor.shape), tensor.dtype, physical_shape, info["physical_dtype"], physical_itemsize, shards
     )
-    if info["physical_shape"]:
-        physical_shape = tuple(info["physical_shape"])
-        physical_dtype = _RUNTIME_DTYPE_TO_TORCH.get(info["physical_dtype"], info["physical_dtype"])
-        physical_itemsize = _RUNTIME_DTYPE_ITEMSIZE[info["physical_dtype"]]
-    else:
-        physical_shape, physical_dtype = tuple(tensor.shape), tensor.dtype
-        physical_itemsize = tensor.element_size()
-    return PhysicalLayout(tuple(tensor.shape), tensor.dtype, physical_shape, physical_dtype, physical_itemsize, shards)
-
-
-_RUNTIME_DTYPE_ITEMSIZE: Dict[str, int] = {
-    "Bool": 1,
-    "UInt8": 1,
-    "Int8": 1,
-    "Int16": 2,
-    "Int32": 4,
-    "Int64": 8,
-    "Float16": 2,
-    "Float32": 4,
-    "Float64": 8,
-    "Float8_e4m3": 1,
-    "Float8_e5m2": 1,
-    "BFloat16": 2,
-    "CustomFloat16": 2,
-    "Complex32": 4,
-    "Complex64": 8,
-    "Complex128": 16,
-}
-
-_RUNTIME_DTYPE_TO_TORCH: Dict[str, torch.dtype] = {
-    "Bool": torch.bool,
-    "UInt8": torch.uint8,
-    "Int8": torch.int8,
-    "Int16": torch.int16,
-    "Int32": torch.int32,
-    "Int64": torch.int64,
-    "Float16": torch.float16,
-    "Float32": torch.float32,
-    "Float64": torch.float64,
-    "Float8_e4m3": torch.float8_e4m3fn,
-    "Float8_e5m2": torch.float8_e5m2,
-    "BFloat16": torch.bfloat16,
-    # CustomFloat16 (DLFloat16) has no torch dtype; it falls through as its runtime name
-    "Complex32": torch.complex32,
-    "Complex64": torch.complex64,
-    "Complex128": torch.complex128,
-}
 
 
 def huge_host_empty(nbytes: int) -> torch.Tensor:


### PR DESCRIPTION
## Summary of Changes

### Summary

Adds `torch.rbln.physical_layout(tensor)`: where an RBLN tensor's bytes physically sit on the device, one `PhysicalShard(node_id, chiplet_id, nbytes, device_addr, shape)` per device area, plus the logical shape/dtype and the physical shape/dtype/itemsize of the allocation's transform. It is the input for per-chiplet KV cache sizing (`nbytes_per_chiplet()` divided by the compile-time block hint gives bytes per block per chiplet) and for placement diagnostics (a 4-way head split reports `(4, 4, 1, 128, 2048)` per shard; a 4-way replication reports the full shape four times).

Backed by the librbln C ABI `rbln_get_memory_info()` — `MemoryInfo.device_areas` added in rebellions-sw/rebel_compiler#13405 (ABI 4) — through a new `_C._get_memory_info` binding. No `rebel._C` import on the torch side.

### Details

- **`_C._get_memory_info(tensor)`** (`csrc/rbln/Module.cpp`) — validates the tensor with the same rule as `bind_device_memory` (RBLN tensor covering its whole storage), calls `c10::rbln::get_memory_info(data_ptr())` (`require_runtime` guard), and returns `physical_shape`, `physical_dtype` and `device_areas` as one dict per area keyed like `PhysicalShard`, so Python builds `PhysicalShard(**area)`. `physical_dtype` is a real `torch.dtype` via `getTHPDtype` from the new `c10::rbln::to_scalar_type()` (inverse of `to_rbln_dtype()`), or `None` for a dtype torch lacks — DLFloat16, the usual fp16/bf16 on-device storage.

- **`torch.rbln.physical_layout()`** (`memory.py`) — wraps the dict into `PhysicalLayout(logical_shape, logical_dtype, physical_shape, physical_dtype, physical_itemsize, shards)`. `physical_itemsize` is derived from an area (`nbytes / prod(shape)`), so it is set even when `physical_dtype` is `None`. A tensor whose allocation is not bound yet (no torch op or graph has touched it, no `bind_device_memory`) raises `no device memory yet`. A flat 1:1 binding has no transform: every `physical_*` field and each shard's `shape` is `None`.

- **Timing** — the physical view exists only after the allocation is bound, so the KV sizing flow reads the layout after warm-up and before releasing the tensor. A dynamic (`mark_dynamic`) dim is reported as the concrete value bound at that point, since the runtime regenerates the transform with resolved sizes.

- **Tests** (`test/rbln/test_physical_layout.py`) — API visible and CPU tensor rejected as plain tests; the device tests go through `instantiate_device_type_tests(only_for="privateuse1")`: bound flat buffer is one shard with `physical_* is None`; compiled-op output covers its bytes and every shard satisfies `prod(shape) × physical_itemsize == nbytes`; unbound tensor and interior view raise. `test_cpp_RBLNFunctionsTest.ToScalarTypeInvertsToRblnDtype` pins the dtype inverse.

### Next Steps

- vllm-rbln: replace the per-artifact `kv_cache_memory_profile()` merge with `physical_layout(kv).nbytes_per_chiplet()` after warm-up (dynamic KV proposal).
- Per-shard `slice_axes` (axis/begin/end) is not exposed; the sliced shape covers sizing and placement. Add it next to `shape` if the KV connector needs it.
- `lintrunner` was not run locally (init download timed out); `ruff check`/`ruff format --check` and `clang-format` pass on the changed files.
- `c10::rbln::get_memory_info()` now logs its cost at debug instead of warn, since `physical_layout()` calls it on purpose; the header note still tells hot-path callers to prefer `get_torch_device_id()`.

---

## Related Issues / Tickets

* Related to rebellions-sw/rebel_compiler#13405 (required: `MemoryInfo.device_areas`, `RBLN_ABI_CURRENT` 4)

---

## Type of Change

- [x] `feature` — New capability or functionality
- [x] `core` — Changes to RBLN backend, device layer, C++ extension, op registration, or `torch.compile` integration

---

## Affected Modules

- [x] C++ extension (`torch_rbln/csrc`)
- [x] Memory

---

## How to Test (if applicable)

1. Build against a rebel_compiler that includes rebellions-sw/rebel_compiler#13405.
2. Run `pytest test/rbln/test_physical_layout.py` on an RBLN device.
3. Expected: 6 passed. On REBEL a compiled matmul output reports one shard per chiplet it was placed on, each with `prod(shape) × physical_itemsize == nbytes`.

---

## Checklist

* [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
* [ ] This PR is linked to a corresponding issue — see [Contributing to torch-rbln](https://github.com/RBLN-SW/torch-rbln/blob/main/docs/CONTRIBUTING.md)
* [x] Linting passes — see [Linting](https://github.com/RBLN-SW/torch-rbln/blob/main/docs/LINTING.md)
* [ ] All CI tests pass — see [CI/CD Workflows](https://github.com/RBLN-SW/torch-rbln/blob/main/docs/WORKFLOWS.md)
* [x] The test method is described, and the expected result is clearly stated (if applicable)
* [ ] Relevant documentation has been updated (if applicable)

---

## Notes

CI compiles against the pinned `rebel-compiler` wheel, which does not yet have `MemoryInfo.device_areas`; the C++ build will fail until rebellions-sw/rebel_compiler#13405 lands and the pin moves. Kept as draft until then. All six tests pass on the dev box (REBEL); `test_set_device_layout_like.py` and `test_tensor_memory.py` were run alongside (52 passed in total) to check the neighbouring memory APIs.


