### PR TITLE
feat(vmem): keep device-resident storages on the device through the in-place host paths

### DIFF
--- a/aten/src/ATen/native/rbln/RBLNCPUFallback.cpp
+++ b/aten/src/ATen/native/rbln/RBLNCPUFallback.cpp
@@ -204,6 +204,15 @@ at::Tensor borrow_rbln_as_cpu(const at::Tensor& t, uint64_t& borrow_id_out) {
     // host region and corrupt reads. Caller falls back to the copy path.
     return {};
   }
+  // A borrow syncs the whole vmem entry, so borrowing a small view of a device-latest
+  // storage reads back every byte of it and leaves the storage host-latest. The copy path
+  // moves only the view: a D2H when the data is on the device, a host memcpy when it is
+  // not. Without asking where the data is, views under half the storage take the copy
+  // path: the worst case costs a memcpy of a small view, the best case saves the
+  // whole-storage round trip. Larger views keep the zero-copy borrow.
+  if (static_cast<size_t>(t.numel()) * t.element_size() * 2 < t.storage().nbytes()) {
+    return {};
+  }
   if (t.storage_offset() != 0) {
     // Contiguous offset view (e.g. `x[1:]`): interior borrows ARE offset-correct.
     // The runtime's BorrowVirtualAtHost bounds-checks [vaddr, vaddr+size) against

--- a/aten/src/ATen/native/rbln/RBLNCopy.cpp
+++ b/aten/src/ATen/native/rbln/RBLNCopy.cpp
@@ -87,6 +87,29 @@ struct IndirectD2DGuard {
 // the errors are asymmetric: staging a slab descriptors would have won costs ~1.3x,
 // descriptors on element-sized slabs 130x.
 constexpr size_t kMinStridedHostCopyBytes = 16 * 1024;
+// Below the crossover the plan declines and copy_ stages through the host. For a
+// device-latest dst that staging is a read-back and rewrite of the whole span, so a lower
+// crossover would pay off there; choosing it needs the residency, which this path does not
+// query, so the constant stays at the host-latest crossover.
+
+// Whether make_strided_host_plan would accept `dst` paired with a contiguous source of the
+// same shape and dtype: the inner block is then dst's own contiguous suffix and the overlap
+// rule is dst's, so the answer does not need the source to exist yet.
+bool strided_plan_possible_for_contiguous_src(const at::Tensor& dst) {
+  if (dst.numel() == 0 || dst.is_contiguous()) {
+    return false;
+  }
+  if (at::has_internal_overlap(dst) != at::MemOverlap::No && view_may_self_overlap(dst.sizes(), dst.strides())) {
+    return false;
+  }
+  const auto sizes = dst.sizes();
+  const int64_t inner_start = contig_suffix_start(sizes, dst.strides());
+  int64_t inner_block_elems = 1;
+  for (int64_t i = inner_start; i < dst.dim(); ++i) {
+    inner_block_elems *= sizes[i];
+  }
+  return static_cast<size_t>(inner_block_elems) * static_cast<size_t>(dst.element_size()) >= kMinStridedHostCopyBytes;
+}
 
 // Byte-level description of one strided pair. `inner_block_bytes` is the largest
 // run contiguous in both tensors; the outer vectors describe the iteration above
@@ -284,7 +307,39 @@ void tensor_copy_from_cpu_to_rbln(const at::Tensor& cpu_src, const at::Tensor& r
           prepared_cpu_src.sizes(), prepared_cpu_src.strides(), prepared_cpu_src.element_size());
       c10::rbln::memcpy_h2v(dst_data, src_data, nbytes);
     } else {
-      // PROFILER (cold branch): a non-contiguous rbln dst is pulled to host
+      // A shape / dtype / layout mismatch on the cpu src is what kept the strided plan
+      // above from applying. A contiguous src in the dst's shape and dtype lets the plan
+      // write the runs in place instead of staging the whole dst. The dst alone decides
+      // whether the plan can take such a src, so that is checked before converting; the
+      // converted src is reused by the staged path if the plan still declines.
+      std::optional<at::Tensor> prepared_cpu_src;
+      if ((cpu_src.sizes() != rbln_dst.sizes() || cpu_src.scalar_type() != rbln_dst.scalar_type() ||
+           !cpu_src.is_contiguous()) &&
+          strided_plan_possible_for_contiguous_src(rbln_dst)) {
+        // PROFILER (cold branch): hidden staging alloc + CPU copy of the src before h2v.
+        // Suppressed when nested inside an rbln->rbln indirect copy (counted once there).
+        if (g_indirect_d2d_depth == 0) {
+          c10::rbln::prof::record_bounce(
+              c10::rbln::prof::BounceSite::kCpu2RblnStaging,
+              static_cast<uint64_t>(rbln_dst.numel()) * rbln_dst.element_size());
+        }
+        prepared_cpu_src = at::empty(
+            rbln_dst.sizes(),
+            rbln_dst.scalar_type(),
+            std::nullopt,
+            c10::Device(c10::kCPU),
+            false,
+            c10::MemoryFormat::Contiguous);
+        prepared_cpu_src->copy_(cpu_src);
+        if (const auto plan = make_strided_host_plan(rbln_dst, *prepared_cpu_src)) {
+          RBLN_LOG_DEBUG("Strided h2v copy of a prepared src (no staging of the dst)");
+          c10::rbln::H2VBatch batch;
+          strided_host_copy<HostDir::kH2V>(rbln_dst, *prepared_cpu_src, *plan, batch, "copy_");
+          batch.submit();
+          return;
+        }
+      }
+      // PROFILER (cold branch): the non-contiguous rbln dst is pulled to the host
       // (hidden v2h), written on CPU, then copied back (h2v). Suppressed when
       // nested inside an rbln->rbln indirect copy (counted once there).
       if (g_indirect_d2d_depth == 0) {
@@ -297,7 +352,7 @@ void tensor_copy_from_cpu_to_rbln(const at::Tensor& cpu_src, const at::Tensor& r
 
       RBLN_LOG_DEBUG("Copying CPU src to CPU copy");
       // Upstream at::native::copy_() handles broadcasting, dtype conversion, and non-contiguous tensors.
-      cpu_dst.copy_(cpu_src);
+      cpu_dst.copy_(prepared_cpu_src ? *prepared_cpu_src : cpu_src);
 
       RBLN_LOG_DEBUG("Copying CPU copy back to RBLN dst");
       auto* dst_data = rbln_dst.data_ptr();

--- a/aten/src/ATen/native/rbln/RBLNTensorFactories.cpp
+++ b/aten/src/ATen/native/rbln/RBLNTensorFactories.cpp
@@ -1,13 +1,17 @@
+#include <ATen/MemoryOverlap.h>
 #include <ATen/native/rbln/RBLNCopy.h>
+#include <ATen/native/rbln/RBLNStrideUtils.h>
 #include <ATen/native/rbln/RBLNTensorFactories.h>
 #include <ATen/native/rbln/RBLNTensorUtils.h>
 #include <c10/rbln/RBLNFunctions.h>
+#include <c10/rbln/RBLNHostBatch.h>
 #include <c10/rbln/RBLNLogging.h>
 
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <cstring>
+#include <vector>
 
 namespace at::native::rbln {
 
@@ -228,6 +232,67 @@ at::Tensor& fill_scalar_via_cpu(at::Tensor& self, const at::Scalar& value) {
   return self;
 }
 
+// Region fill through the runtime's host->virtual copy.
+//
+// The borrow path below materialises the whole storage on the host: a device-latest
+// tensor is read back in full, the view is filled, and the storage is left host-latest,
+// so the next device consumer uploads all of it again. Writing the view's runs through
+// the h2v copy instead lets the runtime route by the entry's own sync state, as it does
+// for every cpu->rbln copy_: a device-resident entry is written in place and stays
+// device-latest; a host-latest or empty entry is written in its user view with no
+// transfer.
+//
+// The contiguous suffix of the view's dims is one run; the dims above it are the outer
+// iteration, enqueued with a source stride of 0 so one pattern buffer feeds every run,
+// and H2VBatch splits the submit to the runtime's bulk caps. Declined, and left to the
+// paths below: a view whose runs could alias (bulk destinations must be disjoint), more
+// runs than kMaxFillRuns, or a run larger than the pattern buffer cap.
+namespace {
+constexpr int64_t kMaxFillRuns = 4096;
+constexpr size_t kMaxPatternBytes = size_t{16} << 20; // one pattern buffer per fill
+
+bool fill_region_device(at::Tensor& self, const at::Scalar& value) {
+  const auto sizes = self.sizes();
+  const auto strides = self.strides();
+  if (at::has_internal_overlap(self) != at::MemOverlap::No && view_may_self_overlap(sizes, strides)) {
+    return false;
+  }
+  const int64_t rank = self.dim();
+  const int64_t elm = self.element_size();
+  const int64_t inner_start = contig_suffix_start(sizes, strides);
+  int64_t inner_elems = 1;
+  for (int64_t i = inner_start; i < rank; ++i) {
+    inner_elems *= sizes[i];
+  }
+  int64_t outer_count = 1;
+  for (int64_t i = 0; i < inner_start; ++i) {
+    outer_count *= sizes[i];
+  }
+  if (outer_count > kMaxFillRuns) {
+    return false;
+  }
+  const size_t run_bytes = static_cast<size_t>(inner_elems) * static_cast<size_t>(elm);
+  if (run_bytes == 0 || run_bytes > kMaxPatternBytes) {
+    return false;
+  }
+  std::vector<uint8_t> pattern(run_bytes);
+  if (!fill_host_typed(pattern.data(), inner_elems, self.scalar_type(), value)) {
+    return false;
+  }
+  c10::SmallVector<int64_t, 8> outer_sizes(sizes.begin(), sizes.begin() + inner_start);
+  c10::SmallVector<int64_t, 8> src_byte_strides(static_cast<size_t>(inner_start), 0);
+  c10::SmallVector<int64_t, 8> dst_byte_strides;
+  for (int64_t i = 0; i < inner_start; ++i) {
+    dst_byte_strides.push_back(strides[i] * elm);
+  }
+  c10::rbln::H2VBatch batch;
+  batch.enqueue_strided(self.data_ptr(), pattern.data(), run_bytes, outer_sizes, src_byte_strides, dst_byte_strides);
+  batch.submit();
+  RBLN_LOG_DEBUG("fill_: region fill through h2v, runs={} run_bytes={}", outer_count, run_bytes);
+  return true;
+}
+} // namespace
+
 // RAII for a host borrow: if the scope exits via a throw (e.g. Scalar::to<T>()'s checked
 // cast overflowing), return the borrow (updated=false) so it isn't leaked. The happy path
 // returns explicitly then disarms.
@@ -271,6 +336,10 @@ at::Tensor& fill_scalar_rbln_(at::Tensor& self, const at::Scalar& value) {
       }
     }
     fill_scalar_rbln_(collapsed, value);
+    return self;
+  }
+
+  if (fill_host_typed_supports(self.scalar_type()) && fill_region_device(self, value)) {
     return self;
   }
 

--- a/test/rbln/test_fallback_region_io.py
+++ b/test/rbln/test_fallback_region_io.py
@@ -1,0 +1,138 @@
+# Owner(s): ["module: PrivateUse1"]
+"""In-place / fallback paths touch only the view's bytes of a device-resident storage.
+
+Two paths used to move whole storages:
+  - the boxed CPU fallback's input borrow syncs the whole vmem entry, so an op reading a
+    prefix view of a device-latest tensor read back every byte of it;
+  - a cpu->rbln copy_ into a non-contiguous view with a dtype/shape-mismatched cpu src
+    staged the whole dst span through the host (read-modify-write).
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import torch
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+import torch_rbln  # noqa: F401
+from torch_rbln import _C
+
+
+DEVICE = torch.device("rbln:0")
+_have_device = torch_rbln.device.device_count() > 0 and os.environ.get("RBLN_DUMMY_DEVICE") != "1"
+needs_device = pytest.mark.skipif(not _have_device, reason="needs an RBLN device")
+_identity = torch.compile(lambda t: torch.maximum(t, t), backend="rbln", dynamic=False)
+
+
+def _host_sync():
+    (dc, db), (hc, hb) = _C._rt_prof_host_sync()
+    return dc, db, hc, hb
+
+
+def _delta(a, b):
+    return tuple(y - x for x, y in zip(a, b))
+
+
+def _d2h_bytes_of(fn):
+    """D2H bytes the runtime moved while running fn()."""
+    before = _host_sync()
+    out = fn()
+    torch.rbln.synchronize()
+    return _delta(before, _host_sync())[1], out
+
+
+def _assert_data_on_device(tc, x, msg=""):
+    """Reading x back must move every byte from the device: the data still lives there."""
+    moved, _ = _d2h_bytes_of(x.cpu)
+    tc.assertEqual(moved, x.numel() * x.element_size(), f"{msg}: storage is not device-latest ({moved} B moved)")
+
+
+def _device_latest(shape, dtype=torch.bfloat16):
+    y = _identity(torch.randn(shape).to(dtype).to(DEVICE))  # compiled output: device-latest
+    torch.rbln.synchronize()
+    return y
+
+
+@pytest.mark.test_set_ci
+@needs_device
+class TestFallbackRegionIO(TestCase):
+    def test_boxed_fallback_reads_only_the_view(self):
+        # argmax is an explicit CPU fallback; its input is a 4-row prefix of a 512-row storage
+        x = _device_latest((512, 3072))
+        ref = x.cpu()[:4].argmax(-1)
+        before = _host_sync()
+        got = x[:4].argmax(-1)
+        torch.rbln.synchronize()
+        d = _delta(before, _host_sync())
+        self.assertLessEqual(d[1], 4 * 3072 * 2 + 4096, f"read back more than the 4-row view: {d}")
+        _assert_data_on_device(self, x, "storage should stay device-latest")
+        torch.testing.assert_close(got.cpu(), ref)
+
+    def test_small_view_of_host_latest_storage_costs_only_the_view(self):
+        # the size heuristic's worst case: the data is on the host, so the copy path is a host
+        # memcpy of the view (no transfer) instead of a free borrow
+        x = torch.randn(512, 3072).to(torch.bfloat16).to(DEVICE)
+        ref = x.cpu()[:4].argmax(-1)
+        before = _host_sync()
+        got = x[:4].argmax(-1)
+        torch.rbln.synchronize()
+        d = _delta(before, _host_sync())
+        self.assertEqual((d[0], d[2]), (0, 0), f"host-latest view read moved data: {d}")
+        torch.testing.assert_close(got.cpu(), ref)
+
+    def test_full_view_keeps_borrow(self):
+        # a view covering at least half the storage keeps the borrow fast path (one D2H, then synced)
+        x = _device_latest((64, 1024))
+        ref = x.cpu().argmax(-1)
+        before = _host_sync()
+        got = x.argmax(-1)
+        torch.rbln.synchronize()
+        d = _delta(before, _host_sync())
+        self.assertEqual(d[0], 1)
+        torch.testing.assert_close(got.cpu(), ref)
+
+    def test_strided_copy_from_mismatched_cpu_src_writes_only_runs(self):
+        # every 4th row of a device-latest [256, 8192] bf16 tensor <- fp32 rows: the src is
+        # converted on the CPU and the rows (above the strided run threshold) are written in place; the dst span is
+        # neither read back nor rewritten as a whole
+        x = _device_latest((256, 8192))
+        ref = x.cpu()
+        rows = torch.randn(64, 8192)  # fp32 -> bf16 conversion + strided dst
+        ref[::4].copy_(rows)
+        before = _host_sync()
+        x[::4].copy_(rows)
+        torch.rbln.synchronize()
+        d = _delta(before, _host_sync())
+        self.assertEqual(d[0], 0, f"strided dst copy read the dst back: {d}")
+        self.assertLessEqual(d[3], 64 * 8192 * 2 + 65536, f"wrote more than the strided rows: {d}")
+        _assert_data_on_device(self, x, "strided copy_ pulled the storage to the host")
+        torch.testing.assert_close(x.cpu(), ref, rtol=0, atol=0)
+
+    def test_strided_copy_profiler_attribution(self):
+        # the src conversion counts as staging; the dst is not pulled to the host, so the
+        # "non-contiguous rbln dst pulled to host" site must not move (BounceSite order:
+        # 1 = cpu src staged, 2 = non-contiguous dst pulled)
+        x = _device_latest((256, 8192))
+        rows = torch.randn(64, 8192)
+        before = _C._profiler_dump_bounces()
+        x[::4].copy_(rows)
+        torch.rbln.synchronize()
+        after = _C._profiler_dump_bounces()
+        self.assertEqual(after[1][0] - before[1][0], 1, "src conversion not attributed to staging")
+        self.assertEqual(after[2][0] - before[2][0], 0, "dst reported as pulled to the host")
+
+    def test_small_runs_still_correct(self):
+        # below the strided run threshold the staged path remains; correctness only
+        x = _device_latest((256, 4096))
+        ref = x.cpu()
+        rows = torch.randn(64, 4096)
+        ref[::4].copy_(rows)
+        x[::4].copy_(rows)
+        torch.rbln.synchronize()
+        torch.testing.assert_close(x.cpu(), ref, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/rbln/test_fill_region_device.py
+++ b/test/rbln/test_fill_region_device.py
@@ -1,0 +1,176 @@
+# Owner(s): ["module: PrivateUse1"]
+"""fill_ on a view of a device-resident storage writes only that region, on the device.
+
+The borrow path read the whole storage back, filled on the host, and left the storage
+host-latest for the next device consumer to re-upload. The region path writes the view's
+runs through the runtime's h2v copy and the storage stays device-latest.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import torch
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+import torch_rbln  # noqa: F401
+from torch_rbln import _C
+
+
+DEVICE = torch.device("rbln:0")
+_have_device = torch_rbln.device.device_count() > 0 and os.environ.get("RBLN_DUMMY_DEVICE") != "1"
+needs_device = pytest.mark.skipif(not _have_device, reason="needs an RBLN device")
+_identity = torch.compile(lambda t: torch.maximum(t, t), backend="rbln", dynamic=False)
+
+
+def _host_sync():
+    (dc, db), (hc, hb) = _C._rt_prof_host_sync()
+    return dc, db, hc, hb
+
+
+def _delta(a, b):
+    return tuple(y - x for x, y in zip(a, b))
+
+
+def _d2h_bytes_of(fn):
+    """D2H bytes the runtime moved while running fn()."""
+    before = _host_sync()
+    out = fn()
+    torch.rbln.synchronize()
+    return _delta(before, _host_sync())[1], out
+
+
+def _assert_data_on_device(tc, x, msg=""):
+    """Reading x back must move every byte from the device: the data still lives there."""
+    moved, _ = _d2h_bytes_of(x.cpu)
+    tc.assertEqual(moved, x.numel() * x.element_size(), f"{msg}: storage is not device-latest ({moved} B moved)")
+
+
+def _device_latest(shape, dtype=torch.bfloat16):
+    x = (
+        torch.randn(shape).to(dtype).to(DEVICE)
+        if dtype.is_floating_point
+        else torch.randint(-50, 50, shape, dtype=dtype).to(DEVICE)
+    )
+    y = _identity(x)  # a compiled graph's output lives on the device (device-latest)
+    torch.rbln.synchronize()
+    return y
+
+
+@pytest.mark.test_set_ci
+@needs_device
+class TestFillRegionDevice(TestCase):
+    def _check(self, make_view, value, shape=(1, 474, 3072), dtype=torch.bfloat16, resident=True):
+        x = _device_latest(shape, dtype)
+        ref = x.cpu()
+        make_view(ref).fill_(value)
+        before = _host_sync()
+        make_view(x).fill_(value)
+        torch.rbln.synchronize()
+        d = _delta(before, _host_sync())
+        if resident:
+            self.assertEqual(d[0], 0, f"{dtype}: region fill read the storage back: {d}")
+            self.assertLessEqual(
+                d[3], make_view(x).numel() * x.element_size(), f"{dtype}: uploaded more than the region: {d}"
+            )
+            _assert_data_on_device(self, x, f"{dtype}: storage left the device")
+        torch.testing.assert_close(x.cpu(), ref, rtol=0, atol=0)
+
+    def test_tail_slice_single_run(self):
+        # rows [38:) of a 3-D buffer: one contiguous run
+        self._check(lambda t: t[:, 38:, :], 0.0)
+
+    def test_strided_column_region(self):
+        # many runs: a column slice through a 2-D tensor
+        self._check(lambda t: t[:, 1000:1500], 1.5, shape=(512, 3072))
+
+    def test_full_contiguous_device_latest_tensor(self):
+        # a full fill of a device-latest tensor no longer round-trips either
+        self._check(lambda t: t, -2.0, shape=(64, 4096))
+
+    def test_dtypes_native_physical(self):
+        # dtypes the device stores as-is: region fill stays on the device
+        for dtype, value in ((torch.int32, -7), (torch.int16, 3), (torch.bfloat16, 0.5)):
+            with self.subTest(dtype=dtype):
+                self._check(lambda t: t[:, 8:], value, shape=(16, 1024), dtype=dtype)
+
+    def test_dtypes_converted_physical_stay_correct(self):
+        # float16/float32 are held as dlf16 on the device (user dtype != physical dtype). The
+        # runtime routes a converting host write to the user view (exact bytes for host readers),
+        # so these take the same whole-entry host path as before; only correctness is asserted.
+        # A device-side fill for converting views needs the runtime to accept a pattern in the
+        # physical dtype.
+        for dtype, value in ((torch.float32, 3.25), (torch.float16, 0.5)):
+            with self.subTest(dtype=dtype):
+                self._check(lambda t: t[:, 8:], value, shape=(16, 1024), dtype=dtype, resident=False)
+
+    def test_host_latest_storage_moves_nothing(self):
+        # host-latest: the runtime lands the region in the user view; nothing may move, and the
+        # data stays on the host (reading it back is a host copy, not a D2H)
+        x = torch.randn(64, 1024).to(torch.bfloat16).to(DEVICE)
+        before = _host_sync()
+        x[:, 10:].fill_(4.0)
+        torch.rbln.synchronize()
+        d = _delta(before, _host_sync())
+        self.assertEqual((d[0], d[2]), (0, 0), f"host-latest fill moved data: {d}")
+        moved, host = _d2h_bytes_of(x.cpu)
+        self.assertEqual(moved, 0, "host-latest storage was pushed to the device by fill_")
+        self.assertTrue(torch.all(host[:, 10:] == 4.0))
+
+    def test_fresh_empty_storage(self):
+        # an entry that was never materialised anywhere: fill_ is the first write
+        x = torch.empty(32, 1024, dtype=torch.bfloat16, device=DEVICE)
+        before = _host_sync()
+        x.fill_(2.5)
+        x[:, :100].fill_(-1.0)
+        torch.rbln.synchronize()
+        d = _delta(before, _host_sync())
+        self.assertEqual(d[0], 0, f"fill of a fresh storage read something back: {d}")
+        host = x.cpu()
+        self.assertTrue(torch.all(host[:, :100] == -1.0) and torch.all(host[:, 100:] == 2.5))
+
+    def test_region_above_bulk_caps_is_split_and_correct(self):
+        # more entries and more bytes than one bulk call may carry (RBLNHostBatch.cpp caps):
+        # H2VBatch must split the submit
+        x = _device_latest((32, 524288))
+        ref = x.cpu()
+        ref[:, :262144].fill_(1.0)
+        before = _host_sync()
+        x[:, :262144].fill_(1.0)
+        torch.rbln.synchronize()
+        d = _delta(before, _host_sync())
+        self.assertEqual(d[0], 0, f"large region fill read the storage back: {d}")
+        torch.testing.assert_close(x.cpu(), ref, rtol=0, atol=0)
+
+    def test_overlapping_unfold_view_stays_correct(self):
+        # unfold windows overlap with positive strides; bulk destinations must be disjoint,
+        # so this view takes the previous path
+        x = _device_latest((64,))
+        ref = x.cpu()
+        ref.unfold(0, 4, 1).fill_(1.0)
+        x.unfold(0, 4, 1).fill_(1.0)
+        torch.rbln.synchronize()
+        torch.testing.assert_close(x.cpu(), ref, rtol=0, atol=0)
+
+    def test_too_many_runs_falls_back_correctly(self):
+        # one-element runs above kMaxFillRuns: previous path
+        x = _device_latest((8192, 64))
+        ref = x.cpu()
+        ref[:, 3].fill_(1.0)
+        x[:, 3].fill_(1.0)
+        torch.rbln.synchronize()
+        torch.testing.assert_close(x.cpu(), ref, rtol=0, atol=0)
+
+    def test_zero_full_allocation_still_marks_zeros(self):
+        x = _device_latest((64, 1024))
+        before = _host_sync()
+        x.zero_()
+        torch.rbln.synchronize()
+        d = _delta(before, _host_sync())
+        self.assertEqual((d[0], d[2]), (0, 0))
+        self.assertTrue(torch.all(x.cpu() == 0))
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
## Summary of Changes

The runtime tracks sync state per vmem entry. A host borrow of a *view* therefore syncs the **whole storage** to the host and leaves it host-latest, and the next device consumer uploads all of it again. Three eager paths in torch-rbln paid that whole-storage round trip for a few bytes of work on a device-resident storage:

| path | before | after |
|---|---|---|
| `fill_` on a view of a device-resident storage (`fill_scalar_rbln_`) | borrow the host view: D2H of every byte, fill, storage becomes host-latest, next graph re-uploads it | enqueue one host pattern buffer against the view's contiguous runs on an `H2VBatch` (`enqueue_strided` with a zero source stride; the batch splits the submit to the runtime's bulk caps); the runtime routes by the entry's own state, so a device-resident storage is written in place and stays device-latest, a host-latest one is written in its user view with no transfer |
| boxed CPU fallback reading a small prefix view of a device-resident storage (`borrow_rbln_as_cpu`) | borrow reads back the whole storage to hand the kernel a few rows | views smaller than half the storage take the region copy path (v2h of the view when the data is on the device, a host memcpy of the view when it is not); the storage stays where it was |
| `copy_` into a non-contiguous device view from a shape/dtype-mismatched CPU source (`tensor_copy_from_cpu_to_rbln`) | stage the whole dst span through the host (read-modify-write) | convert the source on the CPU, then write the runs in place through the existing strided h2v plan |

**No runtime or compiler change is needed, and none of the paths asks the runtime where the data is.** Every call is one the cpu→rbln `copy_` path already makes, and the pinned runtime already routes an h2v copy by the entry's sync state (`PlanFastHostToVirtualCopy`, in `rebel-compiler` since 0.10.x): device-resident entry → written on the device in place, marked device-latest; host-latest / empty entry → written in the user view, no transfer. torch-rbln only stops borrowing (and thereby syncing) the whole entry.

Also worth knowing:

* The strided h2v plan keeps its existing minimum run size. A lower crossover would pay for device-latest destinations, but picking it needs the residency, which this PR deliberately does not query. No new configuration is introduced.
* Storages the device holds in a converted dtype (fp16/fp32 as dlf16) go through the runtime's converting user-view path for `fill_`, the same whole-entry cost as before; a device-side fill for them needs the runtime to accept a pattern in the physical dtype.

What this is not: it does not change the compiled path, dispatch, or the cost of any host-latest storage beyond a memcpy of a small view in the fallback case. Layer 3 keeps its entry-granular sync model; torch-rbln stops asking for the whole entry when it needs a region.

**Effect, measured on one RBLN-CR03 against the published rebel-compiler wheel (relative; the harness is `fill_micro.py`, attached in the PR discussion):**

* A CPU-fallback op reading a small prefix of a device-latest tensor: roughly one tenth of the previous cost, and the tensor stays on the device.
* An in-place `fill_` of a region of a device-latest buffer: about a fifth faster per call, and the storage is no longer pulled to the host and re-uploaded by the next graph.
* A region `fill_` of a host-latest tensor: several times faster than the borrow path.
* The size heuristic's worst case (a small view of a host-latest storage read by a fallback): a few percent slower, the memcpy of that view.
* Tiny fills and device-latest small fills: unchanged within noise.

End-to-end on the EAGLE3 spec-decode serve that motivated this (fsw-inference#548), step time is neutral at the median: these round trips are a small fraction of a step, and the remaining levers are in the model code (fsw-inference#1048, #1042). This PR is the structural fix for the eager side, not a step-time win by itself.

---

## Related Issues / Tickets

* Resolves rebellions-sw/torch-rbln-internal#40
* Related to rebellions-sw/fsw-inference#548 (EAGLE3 spec-decode device-tensor overhead: where the whole-storage round trips were found)

---

## Type of Change

- [x] `perf` — Performance improvement
- [x] `core` — Changes to RBLN backend, device layer, C++ extension, op registration, or `torch.compile` integration

---

## Affected Modules

- [x] Ops/Kernels (`fill_`, `copy_`, boxed CPU fallback)
- [x] Memory (`c10/rbln`)

---

## How to Test

Base for every number above: torch-rbln at this branch head; rebel-compiler `0.11.3.dev237+g687d3f76` (the newest published; the pinned dev185 has the same h2v routing); one RBLN-CR03. No runtime dependency beyond the pin.

1. **Against the published runtime (what CI sees).** Rebuild, then:
   ```bash
   RBLN_DEVICES=7 uv run --no-sync pytest test/rbln/test_fill_region_device.py test/rbln/test_fallback_region_io.py -v
   # -> 17 passed
   RBLN_DEVICES=7 uv run --no-sync pytest test/rbln/test_tensor_copy.py test/rbln/test_view_copy.py test/rbln/test_cpu_fast_paths.py test/rbln/test_strided_host_copy.py test/rbln/test_non_zero_storage_offset.py test/rbln/test_native_fill_scalar.py
   # -> 832 passed, 3 skipped (same as origin/dev)
   ```
   Both files carry `@pytest.mark.test_set_ci`, so they run on this PR. Against an `origin/dev` build (same wheel, same device) the six tests that cover the change fail — `test_tail_slice_single_run`, `test_strided_column_region`, `test_full_contiguous_device_latest_tensor`, `test_dtypes_native_physical`, `test_boxed_fallback_reads_only_the_view`, `test_strided_copy_from_mismatched_cpu_src_writes_only_runs` (e.g. `read back more than the 4-row view`) — and the eight edge-case guards pass on both, as they should.
2. **What the tests assert.** Each test builds a device-latest storage (`torch.compile(..., backend="rbln")` identity output), runs the in-place op on a view, and checks with `_C._rt_prof_host_sync()` deltas that (a) the result equals the CPU reference, (b) no D2H happened during the op and the H2D moved at most the region's bytes, and (c) reading the tensor back afterwards moves every byte from the device, i.e. the storage is still device-latest. Host-latest and fresh (never materialised) storages are covered too: nothing may move, and reading them back is a host copy.
3. **Edge cases covered by the tests:** fill on a converted-dtype storage (fp16/fp32: correctness only, whole-entry path as before); fill on a host-latest storage (nothing moves, stays host-latest); fill on a fresh `torch.empty` storage; a region larger than one bulk call may carry (split by the batch); an overlapping `unfold` view (declined: bulk destinations must be disjoint); a run count above 4096 (declines, borrow path); the fallback heuristic's worst case (a small view of a host-latest storage: no transfer, host memcpy only) and its boundary (a full view keeps the borrow); cpu src with a different dtype and shape into `x[::4]`; runs below the 16 KiB threshold (staged path, correctness only).
4. **Reproducer without the suite** (any host with an RBLN device):
   ```python
   import torch, torch_rbln
   from torch_rbln import _C
   f = torch.compile(lambda t: torch.maximum(t, t), backend="rbln", dynamic=False)
   x = f(torch.randn(4, 512, 768).to(torch.bfloat16).to("rbln"))     # device-latest
   torch.rbln.synchronize()
   (d0, b0), _ = _C._rt_prof_host_sync()
   x[:, 300:, :].fill_(0.0); torch.rbln.synchronize()
   (d1, b1), _ = _C._rt_prof_host_sync()
   x.cpu(); torch.rbln.synchronize()
   (d2, b2), _ = _C._rt_prof_host_sync()
   print("D2H bytes during fill_:", b1 - b0, "| D2H bytes reading back:", b2 - b1)
   # before this PR: the whole storage, then 0 (it was already on the host)
   # after:          0, then the whole storage (the data stayed on the device)
   ```

---

## Checklist

* [x] PR title follows Conventional Commits
* [x] Linked to a corresponding issue (fsw-inference#548)
* [x] Linting passes — `uv run --no-sync lintrunner -m origin/dev -a` in a fresh worktree venv (ruff, clang-format, clang-tidy against a real `compile_commands.json`)
* [ ] All CI tests pass
* [x] Test method and expected results described above
* [x] No documentation change needed: no new configuration or public API; the behaviour is described in the code comments at the three sites

---

## Notes

* **Why no residency query.** An earlier draft asked the runtime for the entry's sync state through a new C API. That API is not in any published rebel-compiler, and it turned out to be unnecessary for the main path: the runtime's h2v copy already routes by that state. So `fill_` never asks, the fallback uses a size heuristic (below half the storage → copy path; worst case a host memcpy of a small view), and the strided threshold keeps its existing constant. The exact residency-aware variants of the last two are a possible follow-up once such a query exists; the gain on the motivating workload came from `fill_`.
* **Review focus:** (1) `fill_region_device` in `RBLNTensorFactories.cpp`: the overlap guard (same rule as `make_strided_host_plan`), the run enumeration (`contig_suffix_start`) and the caps (≤4096 runs, ≤16 MB pattern); anything else falls to the previous path. The submit goes through `H2VBatch`, which enforces the runtime's 16-entry / 8 MiB bulk caps. (2) `borrow_rbln_as_cpu`: the new early-return sits before the storage_offset guard and routes to the existing region copy path. (3) `RBLNCopy.cpp`: `strided_plan_possible_for_contiguous_src` decides from the dst alone whether preparing a contiguous source can pay off, so the conversion happens at most once, and the staged path reuses it when the plan still declines. The profiler attribution follows the work actually done: the src conversion is recorded as `copy_h2d_staging`, and `copy_h2d_noncontig_dst` is recorded only when the dst really is pulled to the host (`test_strided_copy_profiler_attribution`).
* The relative figures above come from `fill_micro.py` (best of several batches per case, both builds against the same wheel on the same device); the raw numbers stay internal per the repository's publication rule.
* Debug-level log strings (`RBLN_LOG_DEBUG`) are compiled out in Release, so grepping the built `.so` for them says nothing; `nm -C libtorch_rbln.so | grep strided_host_copy` / the new test results are the evidence the rebuild took.
