### PR TITLE
feat(dispatch): extend the eager dtype catalog from the environment, with a strict mode

### DIFF
--- a/c10/rbln/RBLNFunctions.cpp
+++ b/c10/rbln/RBLNFunctions.cpp
@@ -2,16 +2,19 @@
 #include <c10/rbln/DeviceMappingManager.h>
 #include <c10/rbln/RBLNFunctions.h>
 #include <c10/rbln/RBLNLogging.h>
+#include <c10/rbln/RBLNSupportedDtypes.h>
 #include <c10/util/CallOnce.h>
 #include <rebel/runtime/memory_stats.h>
 
 #include <atomic>
+#include <cctype>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <limits>
 #include <map>
 #include <mutex>
+#include <optional>
 #include <vector>
 
 #include <array>
@@ -87,7 +90,152 @@ void rt_timing_get(uint64_t* out) {
   }
 }
 
-// torch.rbln.explain() runtime-counter reads. Thin pass-throughs to librbln's
+// ---------------------------------------------------------------------------
+// Eager-dispatch dtype catalog: runtime extension (see RBLNSupportedDtypes.h)
+// ---------------------------------------------------------------------------
+namespace {
+
+std::optional<c10::ScalarType> parse_dtype_name(std::string name) {
+  for (auto& ch : name) {
+    ch = static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
+  }
+  struct Entry {
+    const char* name;
+    c10::ScalarType type;
+  };
+  static constexpr std::array<Entry, 26> kNames = {{
+      {"float32", c10::kFloat},  {"float", c10::kFloat},   {"fp32", c10::kFloat},        {"f32", c10::kFloat},
+      {"float64", c10::kDouble}, {"double", c10::kDouble}, {"fp64", c10::kDouble},       {"float16", c10::kHalf},
+      {"half", c10::kHalf},      {"fp16", c10::kHalf},     {"bfloat16", c10::kBFloat16}, {"bf16", c10::kBFloat16},
+      {"int32", c10::kInt},      {"int", c10::kInt},       {"i32", c10::kInt},           {"int64", c10::kLong},
+      {"long", c10::kLong},      {"i64", c10::kLong},      {"int16", c10::kShort},       {"short", c10::kShort},
+      {"i16", c10::kShort},      {"int8", c10::kChar},     {"i8", c10::kChar},           {"uint8", c10::kByte},
+      {"u8", c10::kByte},        {"bool", c10::kBool},
+  }};
+  for (const auto& e : kNames) {
+    if (name == e.name) {
+      return e.type;
+    }
+  }
+  return std::nullopt;
+}
+
+// Parse a comma-separated dtype list from `env_name` into a bitmask over c10::ScalarType.
+// "all" sets `all_out`. The env string is compared on every call (a short strcmp) and
+// re-parsed only when it changed, so a per-test env toggle takes effect without latching a
+// value into the process.
+struct DtypeMaskCache {
+  std::mutex mu;
+  std::string last_env;
+  bool have_last = false;
+  uint64_t mask = 0;
+  bool all = false;
+};
+
+uint64_t dtype_mask_from_env(const char* env_name, DtypeMaskCache& c, bool* all_out) {
+  const char* env = std::getenv(env_name);
+  std::lock_guard<std::mutex> lock(c.mu);
+  const std::string current = env == nullptr ? "" : env;
+  if (!c.have_last || c.last_env != current) {
+    // Parse into locals and commit only a complete result: a rejected value must
+    // not leave a partial mask behind for the next call to return silently.
+    uint64_t mask = 0;
+    bool all = false;
+    size_t start = 0;
+    while (start <= current.size()) {
+      size_t end = current.find(',', start);
+      if (end == std::string::npos) {
+        end = current.size();
+      }
+      std::string tok = current.substr(start, end - start);
+      const auto b = tok.find_first_not_of(" \t");
+      const auto e = tok.find_last_not_of(" \t");
+      if (b != std::string::npos) {
+        tok = tok.substr(b, e - b + 1);
+        if (tok == "all") {
+          all = true;
+        } else if (auto st = parse_dtype_name(tok)) {
+          mask |= uint64_t{1} << static_cast<unsigned>(*st);
+        } else {
+          TORCH_CHECK(false, env_name, ": unknown dtype name '", tok, "'");
+        }
+      }
+      start = end + 1;
+    }
+    c.have_last = true;
+    c.last_env = current;
+    c.mask = mask;
+    c.all = all;
+  }
+  if (all_out != nullptr) {
+    *all_out = c.all;
+  }
+  return c.mask;
+}
+
+// Bitmask of the extra dtypes named by TORCH_RBLN_DISPATCH_DTYPES.
+uint64_t dispatch_dtype_ext_mask() {
+  static DtypeMaskCache cache;
+  return dtype_mask_from_env("TORCH_RBLN_DISPATCH_DTYPES", cache, nullptr);
+}
+
+// Bitmask of the dtypes named by TORCH_RBLN_DISPATCH_STRICT ("all" = catalog + extension).
+uint64_t dispatch_dtype_strict_mask() {
+  static DtypeMaskCache cache;
+  bool all = false;
+  uint64_t mask = dtype_mask_from_env("TORCH_RBLN_DISPATCH_STRICT", cache, &all);
+  if (all) {
+    for (const auto d : kDispatchDtypes) {
+      mask |= uint64_t{1} << static_cast<unsigned>(d);
+    }
+    mask |= dispatch_dtype_ext_mask();
+  }
+  return mask;
+}
+
+} // namespace
+
+bool is_dispatch_dtype_rt(c10::ScalarType s) {
+  if (is_dispatch_dtype(s)) {
+    return true;
+  }
+  const auto idx = static_cast<unsigned>(s);
+  if (idx >= 64) {
+    return false;
+  }
+  return (dispatch_dtype_ext_mask() >> idx) & uint64_t{1};
+}
+
+bool is_strict_dispatch_dtype_rt(c10::ScalarType s) {
+  const auto idx = static_cast<unsigned>(s);
+  if (idx >= 64) {
+    return false;
+  }
+  return (dispatch_dtype_strict_mask() >> idx) & uint64_t{1};
+}
+
+std::vector<c10::ScalarType> strict_dispatch_dtypes_rt() {
+  std::vector<c10::ScalarType> out;
+  const uint64_t mask = dispatch_dtype_strict_mask();
+  for (unsigned i = 0; i < 64; ++i) {
+    if ((mask >> i) & uint64_t{1}) {
+      out.push_back(static_cast<c10::ScalarType>(i));
+    }
+  }
+  return out;
+}
+
+std::vector<c10::ScalarType> dispatch_dtypes_rt() {
+  std::vector<c10::ScalarType> out(kDispatchDtypes.begin(), kDispatchDtypes.end());
+  const uint64_t mask = dispatch_dtype_ext_mask();
+  for (unsigned i = 0; i < 64; ++i) {
+    if (((mask >> i) & uint64_t{1}) && !is_dispatch_dtype(static_cast<c10::ScalarType>(i))) {
+      out.push_back(static_cast<c10::ScalarType>(i));
+    }
+  }
+  return out;
+}
+
 // public C-API (rbln_prof_*, declared in rbln_runtime_api.h via RBLNFunctions.h).
 uint32_t rt_prof_hidden_num() {
   return rbln_prof_v2v_hidden_num_reasons();

--- a/c10/rbln/RBLNSupportedDtypes.h
+++ b/c10/rbln/RBLNSupportedDtypes.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <c10/core/ScalarType.h>
+#include <c10/rbln/RBLNMacros.h>
 
 #include <array>
+#include <vector>
 
 namespace c10::rbln {
 
@@ -32,5 +34,37 @@ constexpr bool is_dispatch_dtype(c10::ScalarType s) noexcept {
   }
   return false;
 }
+
+// Runtime extension of the eager-dispatch catalog.
+//
+// `TORCH_RBLN_DISPATCH_DTYPES` is a comma-separated list of extra dtypes (torch
+// names or the usual aliases: float32|fp32, float64, int32, int64, int16, int8,
+// uint8, bool) whose tensors the eager shim dispatches to the RBLN compile path
+// instead of the CPU fallback. Unset (default) leaves the catalog as is.
+//
+// This is opt-in on purpose: the device holds every float as DLFloat16
+// (1-6-9), so a float32 op dispatched to the device computes in reduced
+// precision. It is worth it when the surrounding graph already produces its
+// float32 tensors on the device (a device function returns float32 as dlf16
+// physical bytes) and the alternative is a host round trip per op; it is not
+// worth it when the caller relies on float32 precision. The value is read live
+// from the environment (re-parsed only when the string changes), like the other
+// TORCH_RBLN_* runtime gates in DispatchShim.cpp. An unknown dtype name throws, so
+// these are not noexcept: the error has to reach the caller as a Python exception.
+C10_RBLN_API bool is_dispatch_dtype_rt(c10::ScalarType s);
+// Catalog + environment extension, in catalog order then env order (deduplicated).
+C10_RBLN_API std::vector<c10::ScalarType> dispatch_dtypes_rt();
+
+// Strict dispatch: for the dtypes named in `TORCH_RBLN_DISPATCH_STRICT` (comma-separated
+// dtype names, or "all" = every dtype in the catalog + extension) the eager shim does NOT
+// take the *performance* fallbacks — the align-penalty routing of unaligned last dims to
+// the CPU fallback here, and the 64-alignment fallback in the Python compile path. The op
+// goes through the compile path as a first-class device op even when the compiler has to
+// wrap it in host pad/depad, so the true device-path cost of that dtype/shape is what the
+// caller measures. Safety fallbacks (tracer, dispatch mode, mixed devices, dtype mismatch,
+// NaN/Inf scan, reentrancy) are unaffected. Ops without a Python wrapper (the explicit
+// CPU-fallback registrations) are unaffected too; they show up in the fallback log.
+C10_RBLN_API bool is_strict_dispatch_dtype_rt(c10::ScalarType s);
+C10_RBLN_API std::vector<c10::ScalarType> strict_dispatch_dtypes_rt();
 
 } // namespace c10::rbln

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -326,3 +326,13 @@ This is an escape hatch for unblocking a machine while a matching wheel is built
 suppresses the diagnosis, not the incompatibility: the mismatch it hides is what would
 otherwise surface as an `undefined symbol` import crash or as corruption inside the
 runtime.
+
+## Eager-dispatch dtype catalog (measurement knobs)
+
+Both unset by default; set before `import torch_rbln`. `docs/DTYPE_DISPATCH.md` has the
+contract and the boundaries to know before enabling a dtype.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `TORCH_RBLN_DISPATCH_DTYPES` | Extra dtypes admitted to the eager dispatch catalog (torch dtype names or aliases; an unknown name is an error) | unset |
+| `TORCH_RBLN_DISPATCH_STRICT` | Dtypes (or `all`) whose ops skip the alignment performance fallbacks and always reach the compiler | unset |

--- a/docs/DTYPE_DISPATCH.md
+++ b/docs/DTYPE_DISPATCH.md
@@ -1,0 +1,54 @@
+# Extending the eager dispatch catalog
+
+torch-rbln's eager path decides per op whether to compile it for the device or run it on the
+host (CPU fallback). The dtype catalog is the first gate: fp16 and bf16. Two variables widen it
+for one process, for measurement. Both are unset by default, and a default build behaves
+exactly as before.
+
+```
+TORCH_RBLN_DISPATCH_DTYPES=<names>       admit these dtypes into the eager dispatch catalog
+TORCH_RBLN_DISPATCH_STRICT=<names|all>   never take the performance fallbacks for these dtypes
+```
+
+Names are torch dtype names or the usual aliases (`float32`/`fp32`/`f32`, `float64`, `float16`,
+`bfloat16`, `int32`, `int64`, `int16`, `int8`, `uint8`, `bool`), comma-separated. An unknown name
+is an error that names the variable and the token. Set them before `import torch_rbln`: the C++
+shim reads them live, the Python gate snapshots them at import.
+
+## What admitting a dtype does
+
+An op whose operands are all of an admitted dtype passes the shim precheck and the Python gate
+and reaches the compile path, where it is compiled per (op, shape, dtype) and run with `out=`
+bound to the caller's tensor. Every other reason to stay on the host still applies: a tracer or
+dispatch mode, mixed dtypes, all-scalar inputs, a storage offset, NaN/Inf in a floating input,
+re-entrancy. The NaN/Inf scan covers every floating dtype that can be admitted.
+
+**Mixed devices.** Before the extension, a call with an operand outside the catalog went to the
+C++ boxed fallback, which tolerates a CPU operand next to an rbln one and places the result on
+the first tensor argument's device. Extended, such a call would reach the compile path and fail.
+So when any non-bool operand is of an extension dtype (a bool tensor is a condition or mask) and
+the operands span more than one device, the Python gate sends the op to the host and keeps the
+first-argument rule. Stock dtypes keep their existing behaviour.
+
+**Strict.** Two fallbacks are performance choices, not safety: the 64-alignment fallback in the
+compile path (host pad/depad orchestration dwarfs the compute on small tensors) and the
+align-penalty routing in the shim. `TORCH_RBLN_DISPATCH_STRICT` skips both for the listed
+dtypes, so the op reaches the compiler whatever its shape. What the compiler does with it is its
+decision; it may place a small or unaligned op on the host inside the compiled program.
+`SCHEDULE_HOST_OPS_STAT` in the compile log says how an op was split; `torch.rbln.explain()` and
+`ops_utils.cpu_fallback_counts()` list what left the device through torch-rbln's own fallbacks.
+
+## Boundaries to know before enabling a dtype
+
+- Integer arithmetic saturates on the device; the CPU wraps. `INT32_MAX + 1`, `INT32_MIN - 1`,
+  `65536 * 65536` and `-INT32_MIN` give different answers on the two paths. Code that relies on
+  wrap-around (hashes, counters, bit tricks) must not run under an extended integer catalog.
+- Floats other than bf16 compute in the device's reduced precision; int64 is narrowed to 32 bits
+  on the device, so values outside the int32 range are wrong.
+- Every new (op, shape, dtype) costs a compile in every process; eager programs are not cached
+  on disk.
+- A device launch costs far more than the host op on small tensors; admitting a dtype for
+  glue-sized tensors makes them slower even when the result is right.
+
+The default catalog stays fp16/bf16 because of these. The variables exist so the trade-off can
+be measured on a workload instead of argued.

--- a/test/rbln/test_dispatch_mixed_device.py
+++ b/test/rbln/test_dispatch_mixed_device.py
@@ -1,0 +1,73 @@
+# Owner(s): ["module: PrivateUse1"]
+"""Mixed CPU/rbln operands with an extended dispatch catalog (TORCH_RBLN_DISPATCH_DTYPES).
+
+Before the catalog could be extended, int operands never reached the compile path: the C++
+boxed CPU fallback took them and placed the result on the first tensor argument's device.
+vllm-rbln's speculative-decoding glue relies on that (a CPU cumsum minus an rbln count).
+With int32 in the catalog the same expression must neither raise nor change device, and
+stock dtypes must keep the result device they had.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import subprocess
+import sys
+
+import pytest
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+import torch_rbln  # noqa: F401
+
+
+_have_device = torch_rbln.device.device_count() > 0 and os.environ.get("RBLN_DUMMY_DEVICE") != "1"
+needs_device = pytest.mark.skipif(not _have_device, reason="needs an RBLN device")
+
+_SCENARIO = r"""
+import torch, torch_rbln
+mask_cpu = torch.tensor([False], dtype=torch.bool)
+backup_cpu = torch.tensor([5], dtype=torch.int32)
+valid = torch.tensor([2], dtype=torch.int32, device="rbln")
+ids = torch.tensor([[7, -1, 9]], dtype=torch.int32, device="rbln")
+mask64_cpu = torch.zeros(64, dtype=torch.bool)
+a = torch.ones(64, dtype=torch.bfloat16, device="rbln")
+outs = [
+    torch.where(mask_cpu, torch.zeros_like(valid), valid),  # int32, cpu first
+    torch.where(valid > 0, valid, backup_cpu),  # int32, rbln first
+    torch.where(mask_cpu, backup_cpu, valid),  # int32, cpu first
+    (ids != -1).sum(dim=1).to(torch.int32),  # int32, all rbln
+    torch.where(mask64_cpu, a, a * 2),  # bf16 (stock) with a cpu condition
+    torch.where(mask_cpu, backup_cpu.to(torch.bfloat16), valid),  # extension dtype only in the last operand
+]
+torch.rbln.synchronize()
+print("RESULT", [(o.device.type, o.cpu().flatten().tolist()) for o in outs])
+"""
+
+
+def _run(**env):
+    """Run the scenario in a fresh interpreter: the Python dtype policy is an import-time snapshot."""
+    full_env = dict(os.environ)
+    full_env.pop("TORCH_RBLN_DISPATCH_DTYPES", None)
+    full_env.pop("TORCH_RBLN_DISPATCH_STRICT", None)
+    full_env.update(env)
+    proc = subprocess.run([sys.executable, "-c", _SCENARIO], env=full_env, capture_output=True, text=True, timeout=600)
+    lines = [ln for ln in proc.stdout.splitlines() if ln.startswith("RESULT ")]
+    assert proc.returncode == 0 and lines, proc.stderr[-2000:]
+    return ast.literal_eval(lines[-1][len("RESULT ") :])
+
+
+@pytest.mark.test_set_ci
+@needs_device
+class TestMixedDeviceOperands(TestCase):
+    def test_extended_catalog_keeps_stock_device_semantics(self):
+        stock = _run()
+        self.assertEqual([d for d, _ in stock], ["cpu", "rbln", "cpu", "rbln", "rbln", "cpu"])
+        self.assertEqual([v for _, v in stock[:4]], [[2], [2], [2], [2]])
+        for dtypes in ("int32,int16", "bool", "int32,bool"):
+            with self.subTest(dtypes=dtypes):
+                self.assertEqual(_run(TORCH_RBLN_DISPATCH_DTYPES=dtypes), stock)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/rbln/test_dispatch_strict.py
+++ b/test/rbln/test_dispatch_strict.py
@@ -1,0 +1,204 @@
+# Owner(s): ["module: PrivateUse1"]
+"""TORCH_RBLN_DISPATCH_STRICT: listed dtypes skip the alignment performance fallbacks and take the
+device path as first-class ops; results must match the CPU and the op must not be counted as a
+CPU fallback."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import torch
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+import torch_rbln  # noqa: F401
+from torch_rbln import _C
+
+
+DEVICE = torch.device("rbln:0")
+_have_device = torch_rbln.device.device_count() > 0 and os.environ.get("RBLN_DUMMY_DEVICE") != "1"
+needs_device = pytest.mark.skipif(not _have_device, reason="needs an RBLN device")
+
+
+_SCENARIO = r"""
+import os, sys, torch, torch_rbln
+from torch_rbln import _C
+from torch_rbln._internal import compile_cache
+from torch_rbln._internal.ops_utils import cpu_fallback_counts
+dtype = getattr(torch, sys.argv[1])
+a = (torch.arange(12).reshape(4, 3) * 3).to(dtype).to("rbln")
+b = torch.ones(4, 3).to(dtype).to("rbln")
+want = a.cpu() + b.cpu()
+cpu_fallback_counts(reset=True)
+_C._dispatch_fallback_by_op_reset()
+compiled_before = len(compile_cache._compiled_op_cache)
+got = a + b
+torch.rbln.synchronize()
+assert torch.equal(got.cpu(), want), (got.cpu(), want)
+extra = {}
+if dtype == torch.int32:
+    x = torch.randint(0, 9, (4, 3), dtype=torch.int32, device="rbln")
+    xc = x.cpu()
+    checks = {
+        "mul": (x * x, xc * xc),
+        "eq": (x == 3, xc == 3),
+        "where": (torch.where(x > 4, x, x - 1), torch.where(xc > 4, xc, xc - 1)),
+    }
+    torch.rbln.synchronize()
+    extra = {k: bool(torch.equal(r.cpu(), ref)) for k, (r, ref) in checks.items()}
+# Device-path evidence beyond the Python counter: the C++ boxed fallback (which also
+# returns rbln results without touching the Python counter) recorded nothing, and the
+# compile cache gained the op.
+evidence = {
+    "cxx_fallbacks": _C._dispatch_fallback_by_op(),
+    "compiled": len(compile_cache._compiled_op_cache) - compiled_before,
+}
+print("RESULT", cpu_fallback_counts().get("aten::add", 0), got.device.type, (extra, evidence))
+"""
+
+_BAD_ENV_SCENARIO = r"""
+import os, torch, torch_rbln
+a = torch.arange(64, dtype=torch.int32).reshape(1, 64).to("rbln")
+b = a + 1  # int32 admitted: compiles
+torch.rbln.synchronize()
+os.environ["TORCH_RBLN_DISPATCH_DTYPES"] = "int32,bad_dtype"  # the shim re-reads it on the next op
+try:
+    c = a + 1
+    torch.rbln.synchronize()
+    print("RESULT no_error")
+except RuntimeError as e:
+    print("RESULT", "bad_dtype" in str(e))
+"""
+
+_NAN_SCENARIO = r"""
+import torch, torch_rbln
+from torch_rbln import _C
+x = torch.arange(64, dtype=torch.float32).reshape(1, 64).to("rbln")
+for _ in range(3):  # finite inputs: compile, then warm-cache hits
+    y = x + 1
+torch.rbln.synchronize()
+bad = x.cpu()
+bad[0, 5] = float("nan")
+bad[0, 7] = float("inf")
+bad = bad.to("rbln")
+before = _C._dispatch_fallback_reasons()
+z = bad + 1
+torch.rbln.synchronize()
+after = _C._dispatch_fallback_reasons()
+zc = z.cpu()
+print("RESULT", after[1] - before[1], bool(torch.isnan(zc[0, 5])), bool(torch.isinf(zc[0, 7])))
+"""
+
+
+def _run_scenario(dtype_name: str, **env) -> tuple[int, str, dict]:
+    """Run the unaligned-add scenario in a fresh interpreter with the env set before import.
+
+    The Python compile path snapshots the dtype policy at import (SupportedDtypes), which
+    is also how the knob is meant to be used; a subprocess keeps this test independent of
+    what earlier tests imported or patched in this process."""
+    import ast
+    import subprocess
+    import sys
+
+    full_env = dict(os.environ)
+    full_env.pop("TORCH_RBLN_DISPATCH_STRICT", None)
+    full_env.pop("TORCH_RBLN_DISPATCH_DTYPES", None)
+    full_env.update(env)
+    proc = subprocess.run(
+        [sys.executable, "-c", _SCENARIO, dtype_name], env=full_env, capture_output=True, text=True, timeout=600
+    )
+    lines = [ln for ln in proc.stdout.splitlines() if ln.startswith("RESULT ")]
+    assert proc.returncode == 0 and lines, proc.stderr[-2000:]
+    _, count, device, extra = lines[-1].split(" ", 3)
+    extra, evidence = ast.literal_eval(extra)
+    return int(count), device, extra, evidence
+
+
+def _run_nan_scenario(**env) -> tuple[int, bool, bool]:
+    import ast
+    import subprocess
+    import sys
+
+    full_env = dict(os.environ)
+    full_env.pop("TORCH_RBLN_DISPATCH_STRICT", None)
+    full_env.pop("TORCH_RBLN_DISPATCH_DTYPES", None)
+    full_env.update(env)
+    proc = subprocess.run(
+        [sys.executable, "-c", _NAN_SCENARIO], env=full_env, capture_output=True, text=True, timeout=600
+    )
+    lines = [ln for ln in proc.stdout.splitlines() if ln.startswith("RESULT ")]
+    assert proc.returncode == 0 and lines, proc.stderr[-2000:]
+    _, hits, is_nan, is_inf = lines[-1].split(" ")
+    return int(hits), ast.literal_eval(is_nan), ast.literal_eval(is_inf)
+
+
+@pytest.mark.test_set_ci
+class TestStrictCatalog(TestCase):
+    def test_env_parsing(self):
+        with pytest.MonkeyPatch.context() as mp:
+            mp.delenv("TORCH_RBLN_DISPATCH_STRICT", raising=False)
+            self.assertEqual(_C._dispatch_strict_dtypes(), ())
+            mp.setenv("TORCH_RBLN_DISPATCH_STRICT", "int32, float32")
+            self.assertEqual(set(_C._dispatch_strict_dtypes()), {torch.int32, torch.float32})
+            mp.setenv("TORCH_RBLN_DISPATCH_DTYPES", "int16")
+            mp.setenv("TORCH_RBLN_DISPATCH_STRICT", "all")
+            self.assertEqual(set(_C._dispatch_strict_dtypes()), {torch.float16, torch.bfloat16, torch.int16})
+            mp.setenv("TORCH_RBLN_DISPATCH_STRICT", "int32, float3")
+            with self.assertRaisesRegex(RuntimeError, "unknown dtype name 'float3'"):
+                _C._dispatch_strict_dtypes()
+            mp.setenv("TORCH_RBLN_DISPATCH_STRICT", "int32")
+            self.assertEqual(_C._dispatch_strict_dtypes(), (torch.int32,))  # the bad value left no partial state
+
+
+@pytest.mark.test_set_ci
+@needs_device
+class TestStrictDispatch(TestCase):
+    def test_default_policy_keeps_unaligned_bf16_on_host(self):
+        count, _, _, _ = _run_scenario("bfloat16")
+        self.assertGreater(count, 0)
+
+    def test_strict_bf16_takes_device_path(self):
+        count, device, _, evidence = _run_scenario("bfloat16", TORCH_RBLN_DISPATCH_STRICT="bfloat16")
+        self.assertEqual(count, 0)
+        self.assertEqual(device, "rbln")
+        self.assertEqual(evidence["cxx_fallbacks"], [])
+        self.assertGreater(evidence["compiled"], 0)
+
+    def test_strict_int32_with_extended_catalog(self):
+        # int32 is outside the default catalog: DISPATCH_DTYPES admits it, STRICT keeps it on the
+        # device even at [4, 3]; a few more glue-shaped int32 ops must stay correct too.
+        count, device, extra, evidence = _run_scenario(
+            "int32", TORCH_RBLN_DISPATCH_DTYPES="int32", TORCH_RBLN_DISPATCH_STRICT="int32"
+        )
+        self.assertEqual(count, 0)
+        self.assertEqual(device, "rbln")
+        self.assertEqual(evidence["cxx_fallbacks"], [], "the C++ boxed fallback ran an int32 op")
+        self.assertGreater(evidence["compiled"], 0, "no int32 op was compiled for the device")
+        self.assertEqual(extra, {"mul": True, "eq": True, "where": True})
+
+    def test_bad_dtype_name_after_import_raises_instead_of_terminating(self):
+        # the live parser throws on an unknown name; the getters it runs under must not be
+        # noexcept, or the throw terminates the process instead of reaching Python
+        import subprocess
+        import sys
+
+        env = dict(os.environ, TORCH_RBLN_DISPATCH_DTYPES="int32")
+        env.pop("TORCH_RBLN_DISPATCH_STRICT", None)
+        proc = subprocess.run(
+            [sys.executable, "-c", _BAD_ENV_SCENARIO], env=env, capture_output=True, text=True, timeout=600
+        )
+        self.assertEqual(proc.returncode, 0, f"process died instead of raising: {proc.stderr[-1500:]}")
+        lines = [ln for ln in proc.stdout.splitlines() if ln.startswith("RESULT ")]
+        self.assertEqual(lines[-1], "RESULT True", proc.stdout[-500:])
+
+    def test_extended_float32_nan_inf_is_still_caught_on_warm_cache(self):
+        # float32 admitted by DISPATCH_DTYPES: after finite calls warmed the cache, a NaN/Inf
+        # input must still be caught by the C++ scan (reason 1) and land on the host path,
+        # where NaN/Inf propagate as on the CPU.
+        hits, is_nan, is_inf = _run_nan_scenario(TORCH_RBLN_DISPATCH_DTYPES="float32")
+        self.assertGreaterEqual(hits, 1, "float32 NaN/Inf input was not caught by the shim scan")
+        self.assertTrue(is_nan and is_inf)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch_rbln/_internal/ops_utils.py
+++ b/torch_rbln/_internal/ops_utils.py
@@ -16,6 +16,13 @@ class SupportedDtypes:
     """Per-path supported dtype tuples for RBLN device dispatch."""
 
     dispatch: tuple[torch.dtype, ...] = _C._dispatch_dtypes()
+    # Dtypes admitted only by TORCH_RBLN_DISPATCH_DTYPES. Empty unless the catalog is extended.
+    dispatch_extension: tuple[torch.dtype, ...] = tuple(
+        d for d in _C._dispatch_dtypes() if d not in _C._dispatch_catalog_dtypes()
+    )
+    # Strict dispatch (TORCH_RBLN_DISPATCH_STRICT): tensors of these dtypes skip the
+    # performance fallbacks (64-alignment) and always take the compile path.
+    strict: tuple[torch.dtype, ...] = _C._dispatch_strict_dtypes()
     sdpa: tuple[torch.dtype, ...] = _C._sdpa_dtypes()
     amp: tuple[torch.dtype, ...] = _C._amp_dtypes()
 
@@ -1760,7 +1767,13 @@ def compile_and_run_view_aware(op_callable, op_name, args, kwargs_filtered, out_
     def _last_dim_unaligned(t):
         return isinstance(t, torch.Tensor) and t.dim() > 0 and t.shape[-1] % 64 != 0
 
-    if any(_last_dim_unaligned(a) for a in args) or any(_last_dim_unaligned(v) for v in kwargs_filtered.values()):
+    def _strict(t):
+        # TORCH_RBLN_DISPATCH_STRICT: this dtype takes the device path even when unaligned
+        return isinstance(t, torch.Tensor) and t.dtype in SupportedDtypes.strict
+
+    if (
+        any(_last_dim_unaligned(a) for a in args) or any(_last_dim_unaligned(v) for v in kwargs_filtered.values())
+    ) and not (any(_strict(a) for a in args) or any(_strict(v) for v in kwargs_filtered.values())):
         return cpu_fallback_path(
             op_callable,
             args,
@@ -1946,6 +1959,13 @@ def is_cpu_fallback_cases(args):
             if tensor_args[i].dtype != first_dtype:
                 return True
 
+    # 2b: an operand of an extension dtype (TORCH_RBLN_DISPATCH_DTYPES) on a different device
+    #     than the others. Before the extension such a call went to the C++ boxed fallback,
+    #     which tolerates mixed devices; the compile path does not. Stock dtypes are not
+    #     affected: an empty extension keeps this branch closed.
+    if "device" not in disabled_cases and _has_mixed_device_extension_operand(tensor_args):
+        return True
+
     # 3: fall back to the CPU if all input tensors are scalar tensors
     if "scalar" not in disabled_cases:
         if all(a.ndim == 0 for a in tensor_args):
@@ -1978,6 +1998,39 @@ def is_cpu_fallback_cases(args):
     return False
 
 
+def _has_mixed_device_extension_operand(tensor_args) -> bool:
+    """The op's working dtype is an extension dtype and its operands span more than one device.
+
+    Any non-bool operand of an extension dtype counts: a bool tensor is a condition or mask
+    (where's cond), which the shim's dtype check skips as well, so admitting bool must not
+    re-route an op whose data operands are stock dtypes. Devices are taken over every operand,
+    condition included, because that is what the boxed fallback's first-argument rule sees.
+    """
+    extension = SupportedDtypes.dispatch_extension
+    if not extension:
+        return False
+    non_scalar = [a for a in tensor_args if a.ndim > 0]
+    data = [a for a in non_scalar if a.dtype != torch.bool] or non_scalar
+    if not any(a.dtype in extension for a in data):
+        return False
+    return len({a.device for a in non_scalar}) > 1
+
+
+# Per-op count of Python-path CPU fallbacks (the C++ shim keeps its own counters for the
+# boxed/precheck fallbacks, see torch.rbln.explain). Together they list every op that still
+# leaves the device for a given dtype policy — the input the SW team needs to decide what the
+# compiler/runtime should make cheap next.
+_cpu_fallback_counts: dict[str, int] = {}
+
+
+def cpu_fallback_counts(reset: bool = False) -> dict[str, int]:
+    """Snapshot of Python-path CPU fallbacks per op name (optionally clearing it)."""
+    snap = dict(_cpu_fallback_counts)
+    if reset:
+        _cpu_fallback_counts.clear()
+    return snap
+
+
 def cpu_fallback_path(
     target_ops, args, *, result: Optional[torch.Tensor] = None, op_name: Optional[str] = None, **op_kwargs
 ):
@@ -2001,12 +2054,21 @@ def cpu_fallback_path(
     """
     if op_name is not None:
         rbln_log_cpu_fallback(op_name)
+        _cpu_fallback_counts[op_name] = _cpu_fallback_counts.get(op_name, 0) + 1
     cpu_args = to_cpu(args)
     cpu_op_kwargs = to_cpu(op_kwargs)
     result_cpu = target_ops(*cpu_args, **cpu_op_kwargs)
     if result is not None and result_cpu.size() == result.size():
         result.copy_(result_cpu)
         return result
+
+    # Mixed-device extension-dtype operands (see is_cpu_fallback_cases 2b): mirror the C++
+    # boxed fallback's convention, which handled these calls before the extension, and put
+    # the result on the first tensor argument's device. Stock dtypes keep the rule below.
+    tensor_args = extract_tensors(args)
+    if result is None and _has_mixed_device_extension_operand(tensor_args):
+        first_device = tensor_args[0].device
+        return result_cpu if first_device.type == "cpu" else result_cpu.to(first_device)
 
     # Get device_index from result tensor or from input args/op_kwargs
     # In this context, rbln tensors always have a device_index

--- a/torch_rbln/csrc/rbln/DispatchShim.cpp
+++ b/torch_rbln/csrc/rbln/DispatchShim.cpp
@@ -468,6 +468,14 @@ bool align_penalty_fast_path_check(torch::jit::Stack* stack, const SchemaCache& 
     return false;
   }
   auto args = torch::jit::last(stack, cache.num_args);
+  // Strict dispatch (TORCH_RBLN_DISPATCH_STRICT): the op must take the device path even
+  // when it pays the pad/depad penalty, so this performance routing is skipped.
+  auto unaligned_unless_strict = [](const at::Tensor& t) {
+    if (c10::rbln::is_strict_dispatch_dtype_rt(t.scalar_type())) {
+      return false;
+    }
+    return (t.size(t.dim() - 1) % 64) != 0;
+  };
   // Prefer checking the OUT tensor's last-dim — it reflects the broadcast
   // result shape, which is what the device graph would produce.
   if (cache.out_positional_idx >= 0) {
@@ -475,7 +483,7 @@ bool align_penalty_fast_path_check(torch::jit::Stack* stack, const SchemaCache& 
     if (iv.isTensor()) {
       const auto& t = iv.toTensor();
       if (t.defined() && t.dim() > 0) {
-        return (t.size(t.dim() - 1) % 64) != 0;
+        return unaligned_unless_strict(t);
       }
     }
   }
@@ -488,7 +496,7 @@ bool align_penalty_fast_path_check(torch::jit::Stack* stack, const SchemaCache& 
     const auto& t = iv.toTensor();
     if (!t.defined() || cache.is_write_alias[i] || t.dim() == 0)
       continue;
-    return (t.size(t.dim() - 1) % 64) != 0;
+    return unaligned_unless_strict(t);
   }
   return false;
 }
@@ -531,40 +539,36 @@ bool is_nan_inf_check_disabled() {
   return false;
 }
 
-// fp16/bf16 NaN/Inf bit-pattern check.
-//
-// Both formats encode NaN/Inf as "exponent field all-ones"; only the field
-// width differs (fp16: 5 bits at offset 10, mask ``0x7C00``; bf16: 8 bits
-// at offset 7, mask ``0x7F80``). NaN distinguishes itself by a non-zero
-// mantissa, Inf has mantissa==0 — we don't care about the distinction for
-// fallback routing, either value means "rbln runtime cannot handle this".
-inline bool fp16_has_nan_or_inf(const uint16_t* data, size_t n) noexcept {
+// NaN/Inf bit-pattern check. Every IEEE format encodes NaN/Inf as "exponent field
+// all-ones"; only the mask differs (fp16 ``0x7C00``, bf16 ``0x7F80``, fp32
+// ``0x7F800000``, fp64 ``0x7FF0000000000000``). NaN and Inf are not distinguished:
+// either value means "rbln runtime cannot handle this".
+template <typename Word, Word kExpMask>
+bool words_have_nan_or_inf(const void* data, size_t n) noexcept {
+  const auto* words = static_cast<const Word*>(data);
   for (size_t i = 0; i < n; ++i) {
-    if ((data[i] & 0x7C00) == 0x7C00) {
+    if ((words[i] & kExpMask) == kExpMask) {
       return true;
     }
   }
   return false;
 }
 
-inline bool bf16_has_nan_or_inf(const uint16_t* data, size_t n) noexcept {
-  for (size_t i = 0; i < n; ++i) {
-    if ((data[i] & 0x7F80) == 0x7F80) {
-      return true;
-    }
-  }
-  return false;
-}
-
-using ScannerFn = bool (*)(const uint16_t*, size_t);
+using ScannerFn = bool (*)(const void*, size_t);
+// One scanner per floating dtype the catalog or TORCH_RBLN_DISPATCH_DTYPES can admit
+// (parse_dtype_name in RBLNFunctions.cpp accepts no other floating names).
 inline ScannerFn scanner_for(c10::ScalarType scalar_type) {
   switch (scalar_type) {
     case c10::kHalf:
-      return fp16_has_nan_or_inf;
+      return words_have_nan_or_inf<uint16_t, uint16_t{0x7C00}>;
     case c10::kBFloat16:
-      return bf16_has_nan_or_inf;
+      return words_have_nan_or_inf<uint16_t, uint16_t{0x7F80}>;
+    case c10::kFloat:
+      return words_have_nan_or_inf<uint32_t, uint32_t{0x7F800000}>;
+    case c10::kDouble:
+      return words_have_nan_or_inf<uint64_t, uint64_t{0x7FF0000000000000}>;
     default:
-      TORCH_INTERNAL_ASSERT(false, "missing scanner for ScalarType");
+      TORCH_INTERNAL_ASSERT(false, "missing NaN/Inf scanner for ScalarType");
   }
 }
 
@@ -573,10 +577,12 @@ inline ScannerFn scanner_for(c10::ScalarType scalar_type) {
 // will trigger a D2H sync (this is the price of catching NaN/Inf in
 // just-computed device data — matches AS-IS Python ``to_cpu(args)`` cost).
 //
-// Returns false for: undefined / empty / dtype outside the dispatch
-// catalog / non-contiguous tensors. Non-catalog dtypes are short-circuited
-// earlier in ``quick_fallback_check``; ``skip_dtype_args`` slots are
-// typically bool/int (eq/ne ``cond`` etc.) which cannot carry NaN/Inf.
+// Returns false for: undefined / empty / dtype outside the dispatch policy or
+// not floating / non-contiguous tensors. Non-admitted dtypes are short-circuited
+// earlier in ``quick_fallback_check``; ``skip_dtype_args`` slots are typically
+// bool/int (eq/ne ``cond`` etc.) which cannot carry NaN/Inf. An admitted floating
+// dtype without a scanner is a bug, not a skip: a warm-cache hit would then run
+// the device kernel on NaN/Inf without the Python scan ever seeing the input.
 // Non-contiguous tensors are skipped here because the warm-cache key
 // requires contig + offset=0 anyway — the non-contig case will miss and
 // fall through to the Python wrapper which performs the full
@@ -587,7 +593,7 @@ bool tensor_has_nan_or_inf(const at::Tensor& t) {
   const auto numel = t.numel();
   if (numel == 0)
     return false;
-  if (!c10::rbln::is_dispatch_dtype(t.scalar_type())) {
+  if (!c10::rbln::is_dispatch_dtype_rt(t.scalar_type()) || !c10::isFloatingType(t.scalar_type())) {
     return false;
   }
   const auto scanner = scanner_for(t.scalar_type());
@@ -599,7 +605,7 @@ bool tensor_has_nan_or_inf(const at::Tensor& t) {
   if (dev_type != c10::DeviceType::PrivateUse1) {
     // CPU tensor (e.g. wrapped 0-dim scalar that didn't get unwrapped):
     // scan in place.
-    const uint16_t* data = static_cast<const uint16_t*>(t.data_ptr());
+    const void* data = t.data_ptr();
     if (data == nullptr)
       return false;
     return scanner(data, n);
@@ -618,13 +624,13 @@ bool tensor_has_nan_or_inf(const at::Tensor& t) {
   auto borrowed = c10::rbln::try_borrow_host_ptr(ptr, nbytes);
   if (!borrowed) {
     const at::Tensor cpu_copy = t.cpu();
-    const uint16_t* host_data = static_cast<const uint16_t*>(cpu_copy.data_ptr());
+    const void* host_data = cpu_copy.data_ptr();
     if (host_data == nullptr)
       return false;
     return scanner(host_data, n);
   }
   void* host_raw = reinterpret_cast<void*>(borrowed->host_ptr); // NOLINT(performance-no-int-to-ptr)
-  const bool found = scanner(static_cast<const uint16_t*>(host_raw), n);
+  const bool found = scanner(host_raw, n);
   c10::rbln::return_borrowed(borrowed->borrow_id, /*updated=*/false);
   return found;
 }
@@ -681,9 +687,7 @@ int quick_fallback_check(
     // gates that skip args from the shortcut counter. We want to catch
     // NaN/Inf in any defined non-write-alias input — including wrapped
     // 0-dim values such as ``tensor + math.nan``. tensor_has_nan_or_inf
-    // internally filters out dtypes outside the dispatch catalog (catalog
-    // dtypes — fp16/bf16 — are the ones that can encode NaN/Inf on the
-    // shim path).
+    // scans every floating dtype the dispatch policy admits and skips the rest.
     if (nan_inf_scan_enabled && !nan_inf_found && tensor_has_nan_or_inf(t)) {
       nan_inf_found = true;
     }
@@ -705,7 +709,8 @@ int quick_fallback_check(
       continue;
     }
     has_input_tensor = true;
-    if (!c10::rbln::is_dispatch_dtype(t.scalar_type())) {
+    // Catalog plus the TORCH_RBLN_DISPATCH_DTYPES extension (RBLNSupportedDtypes.h).
+    if (!c10::rbln::is_dispatch_dtype_rt(t.scalar_type())) {
       return 1; // dtype-not-fp16 (dtype outside the dispatch policy)
     }
     if (t.dim() != 0) {

--- a/torch_rbln/csrc/rbln/Module.cpp
+++ b/torch_rbln/csrc/rbln/Module.cpp
@@ -527,8 +527,25 @@ py::tuple supported_dtypes_to_tuple(c10::ArrayRef<c10::ScalarType> scalar_types)
 void register_supported_dtypes_api(py::module_& module) {
   module.def(
       "_dispatch_dtypes",
+      [] {
+        // Catalog plus the TORCH_RBLN_DISPATCH_DTYPES extension, evaluated now: the
+        // Python SupportedDtypes snapshot is taken at import, so the env var must be
+        // set before `import torch_rbln`.
+        const auto v = c10::rbln::dispatch_dtypes_rt();
+        return supported_dtypes_to_tuple(c10::ArrayRef<c10::ScalarType>(v));
+      },
+      "Internal: eager-dispatch supported dtypes (catalog + TORCH_RBLN_DISPATCH_DTYPES)");
+  module.def(
+      "_dispatch_catalog_dtypes",
       [] { return supported_dtypes_to_tuple(c10::rbln::kDispatchDtypes); },
-      "Internal: eager-dispatch supported dtypes");
+      "Internal: the built-in eager-dispatch catalog, without the TORCH_RBLN_DISPATCH_DTYPES extension");
+  module.def(
+      "_dispatch_strict_dtypes",
+      [] {
+        const auto v = c10::rbln::strict_dispatch_dtypes_rt();
+        return supported_dtypes_to_tuple(c10::ArrayRef<c10::ScalarType>(v));
+      },
+      "Internal: dtypes under strict dispatch (TORCH_RBLN_DISPATCH_STRICT), evaluated now");
   module.def(
       "_sdpa_dtypes",
       [] { return supported_dtypes_to_tuple(c10::rbln::kSdpaDtypes); },


### PR DESCRIPTION
## Summary of Changes

Extends the eager shim's dtype catalog (`kDispatchDtypes = {fp16, bf16}`) from the environment, and adds a strict mode in which an extended dtype runs as a first-class device op rather than a fallback. Every knob is unset by default, so **default behaviour does not change.** This is measurement infrastructure, not a speed-up: it turns "what does running dtype X on the device cost today" from an inference into a number, so the compiler/runtime side can see what has to become cheap.

| change | what |
|---|---|
| `TORCH_RBLN_DISPATCH_DTYPES` | Comma-separated dtypes (`int32`, `float32`, `int16`, ... aliases accepted) added to the catalog. The C++ shim's `quick_fallback_check` and the Python gate's `SupportedDtypes.dispatch` see the same union (`is_dispatch_dtype_rt`, `_C._dispatch_dtypes()`). The env string is compared with a short strcmp per call and re-parsed only when it changes (no latching). |
| `TORCH_RBLN_DISPATCH_STRICT` | Ops on the listed dtypes (or `all`) skip the two *performance* fallbacks — the 64-alignment fallback in the Python compile path and the align-penalty routing in the C++ shim — and go through the compile path as first-class device ops, pad penalty and per-shape compile included. *Safety* fallbacks (tracer, dispatch mode, mixed devices, dtype mismatch, NaN/Inf, reentrancy) are unchanged. |
| mixed-device fallback convention | With a wider catalog, `cpu_tensor op rbln_tensor` combinations that only the C++ boxed fallback used to see reach the Python compile path and fail with "Expected all tensors to be on the same device" (hit in vllm-rbln's `eagle_prepare_inputs_padded`). The Python gate gets case 2b: any non-bool operand (a bool tensor is a condition or mask, which the shim's dtype check skips too) is of an **extension** dtype (`SupportedDtypes.dispatch_extension`, admitted only by the env) and the operands span more than one device → fallback, and `cpu_fallback_path` places that result on the first tensor argument's device, the boxed fallback's convention. Stock dtypes keep their existing rules: `where(cpu_bool, rbln_bf16, rbln_bf16)` lands on rbln with the env unset, with `int32`, and with `bool`; with the env unset the extension is empty and the branch is closed. |
| NaN/Inf scan for admitted floats | The shim's NaN/Inf scan only knew fp16/bf16; a float32/float64 admitted by the env would pass the precheck unscanned, and a warm-cache hit would bypass the Python scan too. The scanner now covers every floating dtype the policy can admit (fp16, bf16, float32, float64) through one bit-pattern template. |
| `ops_utils.cpu_fallback_counts()` | Per-op counter of Python-path CPU fallbacks. Together with the C++ counters in `torch.rbln.explain()` it lists every op that still leaves the device under a given dtype policy. |
| `docs/DTYPE_DISPATCH.md` | torch-rbln's contract for the two variables: what admitting a dtype does, the mixed-device rule, what strict skips, and the boundaries to know before enabling a dtype (integer arithmetic saturates on the device where the CPU wraps; int64 is narrowed; per-process compiles; launch cost on small tensors). It does not describe compiler or runtime internals; how the compiler split an op is read from its own log. |

**What the compiler does with an admitted int32 today (observed on one NPU with this branch):** an aligned `a + 1` becomes one device op with no host ops; an unaligned `[4, 3]` `a + 1` under strict is compiled with the whole op placed on the host by the compiler (no pad/depad); a large aligned tensor runs on the device with no transfers. Integer overflow **saturates** on the device where the CPU wraps (`INT32_MAX + 1`, `INT32_MIN - 1`, `65536 * 65536`, `-INT32_MIN` all differ); `div(rounding_mode="trunc")` and `sum` match the CPU. The design note lists these as boundaries.

Enabling int32 pays off for large aligned tensors that already live on the device and costs for small glue (`[B, 3]`-shaped spec-decode tensors). The EAGLE3 workload is dominated by the latter, so the default catalog stays fp16/bf16. What this PR adds is the switch that lets that judgement be re-measured per workload.

---

## Related Issues / Tickets

* Resolves rebellions-sw/torch-rbln-internal#41
* Resolves RBLN-SW/torch-rbln#234 (per-op int16/int32 device dispatch policy instead of the fp16/bf16-only guard)
* Related to rebellions-sw/fsw-inference#548 (EAGLE3 spec-decode: the workload on which the int extension was measured)

---

## Type of Change

- [x] `feature` — New capability or functionality (opt-in, default off)
- [x] `core` — Changes to RBLN backend, device layer, C++ extension, op registration, or `torch.compile` integration

---

## Affected Modules

- [x] Backend (dispatch policy)
- [x] Ops/Kernels (`ops_utils.py` gate / fallback path)
- [x] C++ extension (`torch_rbln/csrc`) — `DispatchShim.cpp`, `Module.cpp`
- [x] Docs (`docs/CONFIGURATION.md`, `docs/DTYPE_DISPATCH.md`)

---

## How to Test

Base: torch-rbln at this branch head, rebel-compiler `0.11.3.dev237+g687d3f76` (newest published), one RBLN-CR03. No runtime API dependency.

1. **Defaults unchanged** (env unset):
   ```bash
   RBLN_DEVICES=7 uv run --no-sync pytest test/rbln/test_dispatch_strict.py test/rbln/test_dispatch_mixed_device.py -rs
   # -> 7 passed
   RBLN_DEVICES=7 uv run --no-sync pytest test/rbln/test_cpu_fast_paths.py test/rbln/test_tensor_copy.py
   # -> 708 passed (same as origin/dev)
   ```
   `test_dispatch_strict.py` runs **subprocess scenarios** with the env set before import, because `SupportedDtypes` is a snapshot taken at import: env parsing (union, dedup, aliases via `_C._dispatch_dtypes()` / `_dispatch_strict_dtypes()`); unaligned bf16 stays on the host under the default policy; under `STRICT=bfloat16` and under `DTYPES=int32 STRICT=int32` the op takes the compile path, with three pieces of evidence: the Python fallback counter is zero, the C++ per-op fallback counter (`_dispatch_fallback_by_op`, which the boxed fallback would have incremented) is empty, and the compile cache gained the op (whether the compiler then placed the op on the device or on the host is its decision, see the design note); under `DTYPES=float32` a NaN/Inf input after warm-cache hits is still caught by the shim scan (fallback reason counter) and propagates as on the CPU; and an unknown dtype name set after import surfaces as a Python `RuntimeError` on the next op instead of terminating the process (the live getters are not `noexcept`).
   All classes carry `@pytest.mark.test_set_ci`. Against an `origin/dev` build the strict, extended-catalog, and NaN scenarios fail (the getters are missing; int32 / float32 are not in the catalog); the mixed-device test passes on both: it pins result devices the extension must not change.
   `test_dispatch_mixed_device.py` runs the vllm-rbln glue patterns, a stock-dtype `where` with a CPU condition, and a `where` whose only extension-dtype operand is the last one, with the env unset and with `DTYPES=int32,int16`, `bool`, and `int32,bool`, and requires identical result devices and values in every case.
2. **By hand:**
   ```bash
   TORCH_RBLN_DISPATCH_DTYPES=int32 TORCH_RBLN_DISPATCH_STRICT=int32 RBLN_DEVICES=7 uv run --no-sync python - <<'PY'
   import torch, torch_rbln
   from torch_rbln._internal import ops_utils
   a = torch.arange(3*200064, dtype=torch.int32).reshape(3, 200064).to("rbln")
   b = a + 1                                                      # device op (first call compiles)
   g = torch.zeros(4, 3, dtype=torch.int32, device="rbln") + 1    # unaligned [4,3]: device because strict
   print(b.dtype, b.device, (b.cpu() == a.cpu() + 1).all().item(), g.cpu().tolist()[0])
   print("python fallbacks:", ops_utils.cpu_fallback_counts())     # {} = both took the device path
   PY
   ```
   The same script without the env puts both ops on the CPU fallback and the counter shows `add.Tensor`.
3. **Edges:** `TORCH_RBLN_DISPATCH_STRICT=all`; an unknown dtype name is an error naming the variable and the token, and leaves no partial state; changing the env mid-process is picked up by the C++ shim immediately and by the Python snapshot on the next import (documented).

---

## Checklist

* [x] PR title follows Conventional Commits
* [x] Linked to a corresponding issue (#234)
* [x] Linting passes — `uv run --no-sync lintrunner -m origin/dev` in a fresh worktree venv
* [ ] All CI tests pass
* [x] Test method and expected results described
* [x] Docs updated (`docs/CONFIGURATION.md`: one section with the two variables; `docs/DTYPE_DISPATCH.md`: the contract and boundaries, new)

---

## Notes

* **Review focus.** (1) `is_cpu_fallback_cases` case 2b and the result-device convention in `cpu_fallback_path`: both are gated on an extension-dtype operand, so with the env unset the branch is closed and stock behaviour is untouched (the mixed-device test pins the stock result devices). (2) The mutex in `dtype_mask_from_env`: one lock on the hot path; `getenv` + strcmp then a cache hit is the common case and it did not show in measurements, but it can become an atomic snapshot if preferred. (3) The strict bypass in `DispatchShim.cpp::align_penalty_fast_path_check`: this function is dead code on `dev` too (referenced as `(void)` only), so the strict mode's live effect is the Python 64-alignment bypass alone. The dead path was updated so the policy does not diverge if it is revived; drop that hunk if you would rather delete the function.
* **Non-goals, on purpose.** No change to the default catalog. `int64` computes as int32 in the compiler, so enabling it strictly can be wrong; the note says so and the tests only enable int32 / bf16.
* Independent of rebellions-sw/fsw-inference#239 (`chan/vmem-region-io`). The only overlap is adjacent hunks in `c10/rbln/RBLNFunctions.cpp`, `docs/CONFIGURATION.md`, and `torch_rbln/csrc/rbln/Module.cpp`; both apply cleanly to `origin/dev` and whichever merges second rebases.
