### PR TITLE
fix(test): keep the current stream and the c10d environment inside the test that sets them

### DIFF
--- a/docs/TEST_GUIDE.md
+++ b/docs/TEST_GUIDE.md
@@ -274,6 +274,7 @@ These fixtures are defined in `test/conftest.py` and apply automatically to ever
 | `disable_compile_error_fallback` | function | **Yes** | Appends `compile_error` to `TORCH_RBLN_DISABLE_FALLBACK` env var                                              |
 | `reset_caching_allocator`        | function | **Yes** | Drains in-flight device work then releases the RBLN caching-allocator blocks in teardown; fails loud and skips the flush if the drain faults |
 | `restore_current_device`         | function | **Yes** | Restores the selected RBLN device and lazy-init flag after each test so a `set_device()` can't leak into later tests |
+| `restore_current_stream`         | function | **Yes** | Restores every device's current stream after each test so a `set_stream()` can't leak into later tests               |
 | `enable_deploy_mode`             | function | No      | Sets `TORCH_RBLN_DEPLOY=ON`. Apply with `@pytest.mark.usefixtures("enable_deploy_mode")`                      |
 | `enable_eager_malloc`            | function | No      | Sets `TORCH_RBLN_EAGER_MALLOC=1`. Apply with `@pytest.mark.usefixtures("enable_eager_malloc")`                |
 
@@ -510,8 +511,9 @@ class TestMemoryStats(TestCase):
 >
 > The same applies to any other process-global state a test mutates. Restore it in the
 > test's own teardown (e.g. `TestTorchCompileMonkeyPatch.tearDown` re-installs the original
-> `torch.compile` wrappers it patched), or — for the selected RBLN device — rely on the
-> autouse `restore_current_device` guard in `test/conftest.py` that repairs it after each test.
+> `torch.compile` wrappers it patched), or — for the selected RBLN device and the current
+> stream — rely on the autouse `restore_current_device` / `restore_current_stream` guards in
+> `test/conftest.py` that repair them after each test.
 
 ### Custom Kernel Test Template
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -146,9 +146,11 @@ def restore_current_stream(restore_current_device):
     """Restore every device's current stream after each test, so a test that selected a
     non-default stream cannot leak it into later tests on the same xdist worker.
 
-    Snapshotting is a runtime query per device that claims nothing -- it opens no device
-    context -- so a test that never touches a stream pays only the query. Restore only the
-    devices whose stream moved: ``set_stream`` also selects the stream's device. Depends on
+    Reading a stream claims no device: ``RBLNGuardImpl::getStream`` answers with the default
+    stream for a device whose context is not initialized, so the snapshot reaches the runtime
+    (and with it ``to_device_id``, which commits the device mapping) only for devices already
+    in use -- and initializing a context commits the mapping anyway. Restore only the devices
+    whose stream moved: ``set_stream`` also selects the stream's device. Depends on
     ``restore_current_device`` so this teardown runs first and the device index (and the
     lazy-init flag) are put back after it."""
     count = torch.rbln.device_count()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -139,6 +139,30 @@ def restore_current_device():
 
 
 # =============================================================================
+# Current stream
+# =============================================================================
+@pytest.fixture(scope="function", autouse=True)
+def restore_current_stream(restore_current_device):
+    """Restore every device's current stream after each test, so a test that selected a
+    non-default stream cannot leak it into later tests on the same xdist worker.
+
+    Snapshotting is a runtime query per device that claims nothing -- it opens no device
+    context -- so a test that never touches a stream pays only the query. Restore only the
+    devices whose stream moved: ``set_stream`` also selects the stream's device. Depends on
+    ``restore_current_device`` so this teardown runs first and the device index (and the
+    lazy-init flag) are put back after it."""
+    count = torch.rbln.device_count()
+    if count == 0:
+        yield
+        return
+    saved = [torch.rbln.current_stream(index) for index in range(count)]
+    yield
+    for stream in saved:
+        if torch.rbln.current_stream(stream.device_index) != stream:
+            torch.rbln.set_stream(stream)
+
+
+# =============================================================================
 # Environment variable isolation fixtures
 # =============================================================================
 @pytest.fixture(scope="function", autouse=True)

--- a/test/distributed/test_no_device.py
+++ b/test/distributed/test_no_device.py
@@ -14,6 +14,7 @@ regression and runs only when a device is present.
 
 import os
 import unittest
+from unittest import mock
 
 import pytest
 import torch
@@ -81,7 +82,11 @@ class TestNoDeviceDistributed(TestCase):
     """Process group / DeviceMesh / DTensor with ``device_count() == 0``."""
 
     def setUp(self) -> None:
-        os.environ["MASTER_ADDR"] = "127.0.0.1"
+        # Scoped to the test: these are process-global, and patch.dict restores the whole
+        # environment -- including the MASTER_PORT the helper below adds.
+        env = mock.patch.dict(os.environ, {"MASTER_ADDR": "127.0.0.1"})
+        env.start()
+        self.addCleanup(env.stop)
         configure_master_port_for_rccl_tests()
 
     @unittest.skipIf(_HAS_NPU, _NEEDS_NO_NPU)

--- a/test/distributed/test_process_group.py
+++ b/test/distributed/test_process_group.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: PrivateUse1"]
 
 import os
+from unittest import mock
 
 import pytest
 import torch
@@ -510,10 +511,19 @@ class TestProcessGroupRBLNBase(TestCase):
     ]
 
     def setUp(self):
-        os.environ["RCCL_FORCE_EXPORT_MEM"] = "1"
-        os.environ["RBLN_ROOT_IP"] = "127.0.0.1"
-        os.environ["RBLN_LOCAL_IP"] = "127.0.0.1"
-        os.environ["MASTER_ADDR"] = "127.0.0.1"
+        # Scoped to the test: these are process-global, and patch.dict restores the whole
+        # environment -- including the MASTER_PORT the helper below adds.
+        env = mock.patch.dict(
+            os.environ,
+            {
+                "RCCL_FORCE_EXPORT_MEM": "1",
+                "RBLN_ROOT_IP": "127.0.0.1",
+                "RBLN_LOCAL_IP": "127.0.0.1",
+                "MASTER_ADDR": "127.0.0.1",
+            },
+        )
+        env.start()
+        self.addCleanup(env.stop)
         configure_master_port_for_rccl_tests()
         self.backend = "rbln-ccl"
         self.world_size = min(torch.rbln.device_count(), 2)

--- a/test/distributed/test_tp_pp.py
+++ b/test/distributed/test_tp_pp.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: PrivateUse1"]
 
 import os
+from unittest import mock
 
 import pytest
 import torch
@@ -1399,10 +1400,19 @@ class TestTPPPRBLNBase(TestCase):
     ]
 
     def setUp(self):
-        os.environ["RCCL_FORCE_EXPORT_MEM"] = "1"
-        os.environ["RBLN_ROOT_IP"] = "127.0.0.1"
-        os.environ["RBLN_LOCAL_IP"] = "127.0.0.1"
-        os.environ["MASTER_ADDR"] = "127.0.0.1"
+        # Scoped to the test: these are process-global, and patch.dict restores the whole
+        # environment -- including the MASTER_PORT the helper below adds.
+        env = mock.patch.dict(
+            os.environ,
+            {
+                "RCCL_FORCE_EXPORT_MEM": "1",
+                "RBLN_ROOT_IP": "127.0.0.1",
+                "RBLN_LOCAL_IP": "127.0.0.1",
+                "MASTER_ADDR": "127.0.0.1",
+            },
+        )
+        env.start()
+        self.addCleanup(env.stop)
         configure_master_port_for_rccl_tests()
         self.backend = "rbln-ccl"
         self.device_count = torch.rbln.device_count()

--- a/test/rbln/test_custom_kernel.py
+++ b/test/rbln/test_custom_kernel.py
@@ -11,6 +11,7 @@ and a finite/non-degenerate result — not numerical correctness.
 import math
 
 import pytest
+import rebel  # noqa: F401  -- defines the rbln_custom_ops schemas these tests call
 import torch
 from torch.testing._internal.common_device_type import dtypes, instantiate_device_type_tests
 from torch.testing._internal.common_utils import run_tests, TestCase

--- a/test/rbln/test_isolation_guards.py
+++ b/test/rbln/test_isolation_guards.py
@@ -7,6 +7,7 @@ later tests on the same pytest-xdist worker (the class of bug behind the intermi
 profiler / pinned-copy CI failures)."""
 
 import importlib.util
+import inspect
 import os
 import sys
 from collections import namedtuple
@@ -211,32 +212,52 @@ def test_clean_teardown_order_sync_then_sdpa_clear_then_flush(monkeypatch):
 
 
 @pytest.mark.test_set_ci
-def test_restore_current_stream_restores_only_the_streams_a_test_moved(monkeypatch):
-    """A test that selects another stream must not leave it current. Devices whose stream did
-    not move are skipped: set_stream also selects the stream's device, so re-issuing it for
-    every device would move the current device instead of restoring it."""
+def test_stream_guard_restores_the_stream_a_test_moved_and_the_device_guard_the_index(monkeypatch):
+    """Driven through both guards, from an entry state that is not the default stream, with
+    set_stream's device selection modelled: the stream guard restores what the test found (not
+    a default) and only for the devices that moved, and restore_current_device -- which the
+    fixture argument orders after it -- puts the index back that set_stream moved."""
     conftest = _load_root_conftest()
     stream = namedtuple("stream", "device_index stream_id")  # the fixture reads device_index and ==
-    current = {0: 0, 1: 0}
+    # The fixture argument is what orders the two teardowns; pin it rather than assume it.
+    assert "restore_current_device" in inspect.signature(conftest.restore_current_stream.__wrapped__).parameters
+
+    # rbln:0 enters on a non-default stream, so restoring the snapshot and resetting to the
+    # default are different outcomes; rbln:2 never moves.
+    state = {"device": 0, "streams": {0: 4, 1: 0, 2: 2}}
     set_calls = []
 
     def _set_stream(target):
         set_calls.append(target)
-        current[target.device_index] = target.stream_id
+        state["streams"][target.device_index] = target.stream_id
+        state["device"] = target.device_index  # set_stream selects the stream's device
 
     with monkeypatch.context() as m:
-        m.setattr(torch.rbln, "device_count", lambda: 2)
-        m.setattr(torch.rbln, "current_stream", lambda index: stream(index, current[index]))
+        m.setattr(torch.rbln, "device_count", lambda: 3)
+        m.setattr(torch.rbln, "current_stream", lambda index: stream(index, state["streams"][index]))
         m.setattr(torch.rbln, "set_stream", _set_stream)
+        m.setattr(_dev, "device_count", lambda: 3)
+        m.setattr(_dev, "current_device", lambda: state["device"])
+        m.setattr(_dev, "set_device", lambda index: state.__setitem__("device", index))
+        m.setattr(_dev, "_initialized", _dev._initialized)  # the device guard writes it back
 
-        gen = conftest.restore_current_stream.__wrapped__(None)
-        next(gen)  # setup: snapshots the default stream on both devices
-        current[1] = 7  # a "test" selected another stream on rbln:1
+        device_guard = conftest.restore_current_device.__wrapped__()
+        stream_guard = conftest.restore_current_stream.__wrapped__(None)
+        next(device_guard)
+        next(stream_guard)
+
+        state["streams"][0] = 9  # a "test" selected other streams...
+        state["streams"][1] = 7
+        state["device"] = 1  # ...and the last one selected its device with it
+
         with pytest.raises(StopIteration):
-            next(gen)  # teardown restores it
+            next(stream_guard)  # streams first; restoring rbln:1 leaves it the current device
+        with pytest.raises(StopIteration):
+            next(device_guard)  # then the index goes back
 
-    assert set_calls == [stream(1, 0)]
-    assert current == {0: 0, 1: 0}
+    assert set_calls == [stream(0, 4), stream(1, 0)]  # rbln:2 did not move, so it is left alone
+    assert state["streams"] == {0: 4, 1: 0, 2: 2}  # restored to what the test found, not to default
+    assert state["device"] == 0
 
 
 def _with_env(var, value, fn):

--- a/test/rbln/test_isolation_guards.py
+++ b/test/rbln/test_isolation_guards.py
@@ -9,6 +9,7 @@ profiler / pinned-copy CI failures)."""
 import importlib.util
 import os
 import sys
+from collections import namedtuple
 from pathlib import Path
 
 import pytest
@@ -207,6 +208,35 @@ def test_clean_teardown_order_sync_then_sdpa_clear_then_flush(monkeypatch):
         with pytest.raises(StopIteration):
             next(gen)  # teardown runs to completion
     assert calls == ["sync", "sdpa_clear", "flush"]
+
+
+@pytest.mark.test_set_ci
+def test_restore_current_stream_restores_only_the_streams_a_test_moved(monkeypatch):
+    """A test that selects another stream must not leave it current. Devices whose stream did
+    not move are skipped: set_stream also selects the stream's device, so re-issuing it for
+    every device would move the current device instead of restoring it."""
+    conftest = _load_root_conftest()
+    stream = namedtuple("stream", "device_index stream_id")  # the fixture reads device_index and ==
+    current = {0: 0, 1: 0}
+    set_calls = []
+
+    def _set_stream(target):
+        set_calls.append(target)
+        current[target.device_index] = target.stream_id
+
+    with monkeypatch.context() as m:
+        m.setattr(torch.rbln, "device_count", lambda: 2)
+        m.setattr(torch.rbln, "current_stream", lambda index: stream(index, current[index]))
+        m.setattr(torch.rbln, "set_stream", _set_stream)
+
+        gen = conftest.restore_current_stream.__wrapped__(None)
+        next(gen)  # setup: snapshots the default stream on both devices
+        current[1] = 7  # a "test" selected another stream on rbln:1
+        with pytest.raises(StopIteration):
+            next(gen)  # teardown restores it
+
+    assert set_calls == [stream(1, 0)]
+    assert current == {0: 0, 1: 0}
 
 
 def _with_env(var, value, fn):

--- a/test/rbln/walkthrough/test_08_c10d_rbln_ccl.py
+++ b/test/rbln/walkthrough/test_08_c10d_rbln_ccl.py
@@ -18,6 +18,7 @@ Multi-process launch uses `torch.multiprocessing.spawn`; each rank runs on
 """
 
 import os
+from unittest import mock
 
 import pytest
 import torch
@@ -105,10 +106,19 @@ class TestC10dRBLNCCL(TestCase):
 
     def setUp(self):
         # Match the env setup used by test/distributed/test_process_group.py.
-        os.environ["RCCL_FORCE_EXPORT_MEM"] = "1"
-        os.environ["RBLN_ROOT_IP"] = "127.0.0.1"
-        os.environ["RBLN_LOCAL_IP"] = "127.0.0.1"
-        os.environ["MASTER_ADDR"] = "127.0.0.1"
+        # Scoped to the test: these are process-global, and patch.dict restores the whole
+        # environment -- including the MASTER_PORT the helper below adds.
+        env = mock.patch.dict(
+            os.environ,
+            {
+                "RCCL_FORCE_EXPORT_MEM": "1",
+                "RBLN_ROOT_IP": "127.0.0.1",
+                "RBLN_LOCAL_IP": "127.0.0.1",
+                "MASTER_ADDR": "127.0.0.1",
+            },
+        )
+        env.start()
+        self.addCleanup(env.stop)
         configure_master_port_for_rccl_tests()
 
         self.backend = "rbln-ccl"


### PR DESCRIPTION
## Summary of Changes

A test that selects a non-default stream was leaving it selected for every later test on the
same pytest-xdist worker. `test/rbln/test_stream.py::TestStream::test_current_defaults_to_default`
then read stream id 1 where it expects the default, and failed — in the fsw-integration release
lane, not in the PR lane, because `--numprocesses` without `--dist` promotes to `--dist load`
(`xdist/plugin.py:318`) and each run decides anew whether the two tests share a worker.

`restore_current_stream` joins the autouse guards in `test/conftest.py`: it snapshots each
device's current stream and restores the ones a test moved. Only the ones that moved —
`set_stream` also selects the stream's device, so re-issuing it everywhere would move the
current device instead of restoring it. It depends on `restore_current_device` so its own
teardown runs first and the device index and lazy-init flag are put back after it.

Diffing process state around every test in the core suite turned up two more of the same shape:

- `TestC10dRBLNCCL.setUp`, `TestProcessGroupRBLNBase.setUp`, `TestTPPPRBLNBase.setUp` and
  `TestNoDeviceDistributed.setUp` wrote `RCCL_FORCE_EXPORT_MEM`, `RBLN_ROOT_IP`, `RBLN_LOCAL_IP`
  and `MASTER_ADDR` straight into `os.environ` and never removed them. They are scoped to the test now; `patch.dict` restores the whole environment, so the
  `MASTER_PORT` the helper adds is reverted with them. Nothing in the suite depends on those
  being unset today, so this is latent rather than an active failure.
- `test/rbln/test_custom_kernel.py` called `rbln_custom_ops` without owning the import that
  defines those schemas. They come from the `rebel` package, which torch-rbln imports on first
  device use, so the file passed only when a neighbour had already touched the device; run alone
  it fails with `AttributeError: ... has no attribute 'paged_attn_decode'`. If those tests are
  the first on a worker, the same failure can reach CI.

Test-layer change only — no `torch_rbln/` or C++ change, so eager and `torch.compile` behaviour
is untouched. The guard adds a stream read per device per test, and that read claims no device:
`torch.rbln.current_stream()` goes through `RBLNGuardImpl::getStream`, which answers with the
default stream for a device whose context is not initialized and never reaches `to_device_id`,
where the device mapping commits. On a four-device host, running the fixture body in a fresh
process leaves the mapping open — a later `RBLN_DEVICES` change still re-plans — while an
allocation freezes it; and a device that has a context went through `to_device_id` to get one,
so the mapping was already committed before the fixture could read it. Core-suite wall time did
not move measurably.

---

## Related Issues / Tickets

* Resolves https://github.com/rebellions-sw/torch-rbln-internal/issues/1

---

## Type of Change

- [x] `fix` — Bug fix

---

## Affected Modules

- [x] Build/Tools (test infrastructure)
- [x] Docs

---

## How to Test

1. Reproduce the original failure on `dev`:
   `uv run --no-sync pytest test/rbln/test_accelerator_stream.py::TestAcceleratorStream::test_generic_stream_behavior test/rbln/test_stream.py::TestStream::test_current_defaults_to_default`
   → the second test fails with `stream_id=1 != stream_id=0`. With this branch both pass.
2. `uv run --no-sync pytest test/rbln/test_isolation_guards.py` → the new guard regression test
   passes; it fails if the fixture restores every device unconditionally or restores none.
3. `uv run --no-sync pytest test/rbln/test_custom_kernel.py` on its own → passes on this branch,
   fails on `dev`.
4. `uv run --no-sync pytest test/rbln/walkthrough/test_08_c10d_rbln_ccl.py` (needs 2 logical
   devices) → passes, and leaves `RBLN_ROOT_IP` / `RCCL_FORCE_EXPORT_MEM` unset afterwards.
   `test/distributed/test_tp_pp.py` and `test/distributed/test_no_device.py` under
   `-m test_set_ci`: 19 passed / 4 skipped, and running each `setUp` plus its cleanups leaves
   none of the five variables set (all five survive on `dev`).
5. Core suite: `test/internal` + `test/rbln`, `test_set_ci`, parallel leg 4273 passed / 28
   skipped / 3 xfailed, single-worker leg 60 passed / 4 skipped.

---

## Notes

Ran with a per-test state diff (env, current device, per-device current stream, default dtype,
autocast, warnings filters) over the core suite; after this change the only remaining difference
is `test_amp_autocast` growing the global `warnings` filter list, which comes from torch or
transformers rather than from this repository and breaks nothing today.

Shuffling the whole core suite into a random order also surfaces `code=501 SYS_ERROR ([context]
submission failed)` from `create_sync_runtime` in the compile-heavy `test_custom_kernel` tests.
It is not a state leak — the same shuffle seed produced a different set of failures on a re-run —
and the cause is not identified. Worth knowing before enabling random test order in CI.

Verification ran on a four-device host against this branch's tree; the suite numbers above come
from that machine, not from CI.
