### PR TITLE
fix(test): track vllm-rbln ci/torch-rbln-model-tests and keep torch-rbln under test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ uv.lock
 # Virtual environments
 venv/
 .venv/
+.venv-inference/
 
 # Compiled objects & libraries
 *.o

--- a/constraints-build-dev.txt
+++ b/constraints-build-dev.txt
@@ -1,2 +1,2 @@
 # Build/dev dependency constraints (single source of truth).
-rebel-compiler==0.11.3.dev238+g510669fa.prod
+rebel-compiler==0.11.3.dev266+g140f8fa1.prod

--- a/constraints-build-dev.txt
+++ b/constraints-build-dev.txt
@@ -1,2 +1,2 @@
 # Build/dev dependency constraints (single source of truth).
-rebel-compiler==0.11.3.dev218+g8e76c496.prod
+rebel-compiler==0.11.3.dev238+g510669fa.prod

--- a/docs/TEST_GUIDE.md
+++ b/docs/TEST_GUIDE.md
@@ -199,7 +199,9 @@ python -m pytest test/rbln/test_graph_eager_mode.py -s -v -x
 #### Installing Test Dependencies
 
 ```bash
-# Install everything needed to run the full suite
+# Install everything needed to run the full suite. vllm-rbln and optimum-rbln
+# land in .venv-inference (they pin transformers 5; test_transformers.py needs
+# 4), and run_tests.py runs test_optimum_llm.py / test_vllm_llm.py with it.
 ./tools/test/install-test-deps.sh
 
 # Preview what would be installed (dry-run)

--- a/test/models/test_vllm_llm.py
+++ b/test/models/test_vllm_llm.py
@@ -12,7 +12,8 @@ hard-coded expected strings.
 
 Environment requirements
 ------------------------
-* ``vllm-rbln`` installed on ``origin/device_tensor_rebased`` (or descendant).
+* ``vllm-rbln`` installed on ``origin/ci/torch-rbln-model-tests`` (what
+  ``tools/test/install-test-deps.sh`` checks out).
 * ``vllm_rbln`` / ``vllm`` importable.
 
 Matrix
@@ -365,7 +366,11 @@ LLM(
     enforce_eager=False,
     gpu_memory_utilization=0.1,
 )
-arts = glob.glob(os.path.join(os.environ["VLLM_CACHE_ROOT"], "rbln", "**", "*.rbln"), recursive=True)
+root = os.path.join(os.environ["VLLM_CACHE_ROOT"], "rbln")
+# vllm-rbln writes either per-graph .rbln files or a single mega-cache bundle.
+arts = glob.glob(os.path.join(root, "**", "*.rbln"), recursive=True) + glob.glob(
+    os.path.join(root, "**", "mega_cache.bin"), recursive=True
+)
 assert arts, "compile-only produced no .rbln artifacts"
 print(f"OK artifacts={len(arts)}")
 """
@@ -420,8 +425,12 @@ assert torch.rbln.physical_device_count() > 0, "phase 2 needs a real NPU"
 
 from vllm import LLM, SamplingParams
 
-pat = os.path.join(os.environ["VLLM_CACHE_ROOT"], "rbln", "**", "*.rbln")
-before = set(glob.glob(pat, recursive=True))
+root = os.path.join(os.environ["VLLM_CACHE_ROOT"], "rbln")
+# vllm-rbln writes either per-graph .rbln files or a single mega-cache bundle.
+pats = [os.path.join(root, "**", "*.rbln"), os.path.join(root, "**", "mega_cache.bin")]
+def _artifacts():
+    return {f for pat in pats for f in glob.glob(pat, recursive=True)}
+before = _artifacts()
 assert before, "phase 1 wrote no artifacts to load"
 
 llm = LLM(
@@ -442,7 +451,7 @@ try:
 finally:
     llm.llm_engine.engine_core.shutdown()
 
-new = set(glob.glob(pat, recursive=True)) - before
+new = _artifacts() - before
 assert not new, f"recompiled on the real device instead of loading the dummy-built artifacts: {new}"
 assert text == os.environ["RBLN_TEST_EXPECTED"], f"unexpected generation: {text!r}"
 print(f"OK text={text!r}")

--- a/test/models/test_vllm_llm.py
+++ b/test/models/test_vllm_llm.py
@@ -13,8 +13,8 @@ hard-coded expected strings.
 Environment requirements
 ------------------------
 * ``vllm-rbln`` installed on ``origin/ci/torch-rbln-model-tests`` (what
-  ``tools/test/install-test-deps.sh`` checks out).
-* ``vllm_rbln`` / ``vllm`` importable.
+  ``tools/test/install-test-deps.sh`` checks out, into ``.venv-inference``;
+  ``test/run_tests.py`` runs this file with that interpreter).
 
 Matrix
 ------

--- a/test/models/test_vllm_llm.py
+++ b/test/models/test_vllm_llm.py
@@ -429,11 +429,13 @@ def test_vllm_compile_only_no_npu_via_dummy(tmp_path):
 
 
 # Phase 2 of the dummy-compile -> real-run round trip: load the artifacts phase 1
-# built on a dummy device onto a real NPU and generate. Asserts nothing was
-# recompiled (the .rbln set is unchanged) so we know the dummy-built artifact
+# built on a dummy device onto a real NPU and generate. Asserts the artifacts are
+# byte-for-byte the ones phase 1 wrote, so we know the dummy-built artifact
 # actually ran, and that the output matches the CPU-reference expectation.
+# Content, not names: vllm-rbln recompiles into a mega-cache bundle at the path
+# it already used, which a set of names cannot tell apart from a cache hit.
 _REAL_RUN_FROM_CACHE_WORKER = """
-import glob, os
+import glob, hashlib, os
 import torch_rbln  # noqa: F401
 import torch
 
@@ -446,7 +448,12 @@ root = os.path.join(os.environ["VLLM_CACHE_ROOT"], "rbln")
 # vllm-rbln writes either per-graph .rbln files or a single mega-cache bundle.
 pats = [os.path.join(root, "**", "*.rbln"), os.path.join(root, "**", "mega_cache.bin")]
 def _artifacts():
-    return {f for pat in pats for f in glob.glob(pat, recursive=True)}
+    found = {}
+    for pat in pats:
+        for f in glob.glob(pat, recursive=True):
+            st = os.stat(f)
+            found[f] = (st.st_size, st.st_mtime_ns, hashlib.sha256(open(f, "rb").read()).hexdigest())
+    return found
 before = _artifacts()
 assert before, "phase 1 wrote no artifacts to load"
 
@@ -468,8 +475,9 @@ try:
 finally:
     llm.llm_engine.engine_core.shutdown()
 
-new = _artifacts() - before
-assert not new, f"recompiled on the real device instead of loading the dummy-built artifacts: {new}"
+after = _artifacts()
+changed = {f for f in before.keys() | after.keys() if before.get(f) != after.get(f)}
+assert not changed, f"recompiled on the real device instead of loading the dummy-built artifacts: {sorted(changed)}"
 assert text == os.environ["RBLN_TEST_EXPECTED"], f"unexpected generation: {text!r}"
 print(f"OK text={text!r}")
 """

--- a/test/models/test_vllm_llm.py
+++ b/test/models/test_vllm_llm.py
@@ -99,6 +99,23 @@ PROMPT = "The capital of France is"
 MAX_TOKENS = 5
 
 
+def _model_path(model_id: str) -> str:
+    """The cached snapshot directory when the hub is offline, else ``model_id``.
+
+    huggingface_hub validates a cached snapshot against the repo's file tree when it
+    can read its tree cache; shared caches usually hold only the files inference
+    needs, so resolving through the hub fails there. The snapshot directory loads
+    without any hub call.
+    """
+    if not os.environ.get("HF_HUB_OFFLINE"):
+        return model_id
+    from huggingface_hub import try_to_load_from_cache
+
+    config = try_to_load_from_cache(model_id, "config.json")
+    assert isinstance(config, str), f"{model_id} is not in the local HF cache"
+    return os.path.dirname(config)
+
+
 # Greedy-decode (temperature=0) expected outputs. Key: (model, tp, mode, dtype).
 # ``None`` falls back to non-empty + shape checks. Captured on RBLN-CA25 with
 # rebel-compiler dev329 + vllm-rbln device_tensor_rebased; drift = regression.
@@ -149,7 +166,7 @@ def _vllm_generate_worker(
     # model); at that size eager strided KV writes hit deep vmem addresses the v2v
     # engine rejects, then OOM. 0.1 (~10 GiB) is plenty here; ATOM (16 GB) keeps 0.5.
     llm_kwargs: dict = dict(
-        model=cfg.model_id,
+        model=_model_path(cfg.model_id),
         # vLLM expects the dtype as a string name (e.g., "float16", "bfloat16"), not a torch.dtype.
         dtype=str(dtype).removeprefix("torch."),
         max_model_len=cfg.max_model_len,
@@ -398,7 +415,7 @@ def test_vllm_compile_only_no_npu_via_dummy(tmp_path):
         VLLM_RBLN_USE_VLLM_MODEL="1",
         VLLM_RBLN_COMPILE_ONLY="1",
         VLLM_CACHE_ROOT=str(tmp_path / "vllm_cache"),
-        RBLN_TEST_MODEL_ID=MODEL_CONFIGS["qwen3_0_6b"].model_id,
+        RBLN_TEST_MODEL_ID=_model_path(MODEL_CONFIGS["qwen3_0_6b"].model_id),
     )
     proc = subprocess.run(
         [sys.executable, "-c", textwrap.dedent(_COMPILE_ONLY_DUMMY_WORKER)],
@@ -479,7 +496,7 @@ def test_vllm_dummy_compiled_runs_on_real_npu(tmp_path):
         pytest.skip("no NPU available to run the dummy-compiled artifacts")
 
     cache = str(tmp_path / "vllm_cache")
-    model_id = MODEL_CONFIGS["qwen3_0_6b"].model_id
+    model_id = _model_path(MODEL_CONFIGS["qwen3_0_6b"].model_id)
     expected = EXPECTED_TEXT[("qwen3_0_6b", 1, "graph", torch.float16)]
 
     # Phase 1: dummy compile-only -> shared cache (no real device touched). Compile

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -13,6 +13,7 @@ Usage:
 """
 
 import argparse
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -179,7 +180,14 @@ _TRANSFORMERS_TESTS = ["test/models/test_transformers.py"]
 
 
 def _inference_python(project_root: Path) -> str:
-    venv_python = project_root / ".venv-inference" / "bin" / "python"
+    """The inference venv's interpreter, or this one when the split is not installed.
+
+    ``INFERENCE_VENV`` is install-test-deps.sh's override for where that venv
+    lives; both sides have to read it or a custom path installs one environment
+    and tests another.
+    """
+    venv = Path(os.environ.get("INFERENCE_VENV") or project_root / ".venv-inference")
+    venv_python = venv / "bin" / "python"
     return str(venv_python) if venv_python.exists() else sys.executable
 
 

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -41,10 +41,11 @@ def _run_pytest(
     *,
     marker: str,
     workers: int,
+    python: str = sys.executable,
 ) -> int:
     """Run pytest for a single test_dir/marker combo. Returns the exit code."""
     base_cmd = [
-        sys.executable,
+        python,
         "-m",
         "pytest",
         test_dir,
@@ -108,6 +109,7 @@ def _run_with_worker_split(
     workers: int,
     results: _TestResults,
     project_root: Path,
+    python: str = sys.executable,
 ) -> None:
     """Run single_worker (serial) then multi-worker (parallel) for each dir."""
     mode_marker = TEST_MODE_MARKERS[test_mode]
@@ -118,7 +120,7 @@ def _run_with_worker_split(
             marker = f"{mode_marker} and {worker_marker}"
             num_processes = 1 if is_single_worker else workers
             desc = f"{test_dir} [{marker}]"
-            rc = _run_pytest(abs_test_dir, marker=marker, workers=num_processes)
+            rc = _run_pytest(abs_test_dir, marker=marker, workers=num_processes, python=python)
             results.record(rc, desc)
 
 
@@ -168,6 +170,19 @@ def run_distributed_tests(
     )
 
 
+# The inference stack (vllm-rbln, optimum-rbln) pins transformers 5, and
+# test_transformers.py loads a model whose hub code needs transformers 4, so
+# install-test-deps.sh keeps the stack in its own venv and the two groups run
+# under different interpreters.
+_INFERENCE_STACK_TESTS = ["test/models/test_optimum_llm.py", "test/models/test_vllm_llm.py"]
+_TRANSFORMERS_TESTS = ["test/models/test_transformers.py"]
+
+
+def _inference_python(project_root: Path) -> str:
+    venv_python = project_root / ".venv-inference" / "bin" / "python"
+    return str(venv_python) if venv_python.exists() else sys.executable
+
+
 def run_models_tests(
     test_mode: str,
     workers: int,
@@ -176,11 +191,19 @@ def run_models_tests(
 ) -> None:
     _install_model_deps(project_root)
     _run_with_worker_split(
-        ["test/models/"],
+        _TRANSFORMERS_TESTS,
         test_mode=test_mode,
         workers=workers,
         results=results,
         project_root=project_root,
+    )
+    _run_with_worker_split(
+        _INFERENCE_STACK_TESTS,
+        test_mode=test_mode,
+        workers=workers,
+        results=results,
+        project_root=project_root,
+        python=_inference_python(project_root),
     )
 
 

--- a/tools/test/install-test-deps.sh
+++ b/tools/test/install-test-deps.sh
@@ -22,7 +22,9 @@
 #                      test_vllm_llm.py with this venv's interpreter. The venv
 #                      sees the test venv's site-packages (torch, torch-rbln,
 #                      rebel-compiler, pytest) through a .pth file and adds
-#                      only the stack on top.
+#                      only the stack on top. The packages under test must stay
+#                      the test venv's copies, so the install is verified
+#                      against that before the script exits.
 #
 # Usage:
 #   ./tools/test/install-test-deps.sh [--dry-run]
@@ -177,8 +179,13 @@ install_vllm_rbln() {
   if [[ ! -x "${py}" ]]; then
     run python -m venv "${venv}"
   fi
+  # site.addsitedir rather than a bare path: it also processes the .pth files
+  # *inside* the test venv, which is how an editable install (torch-rbln built
+  # from this checkout, an external rebel-compiler) puts its source tree on the
+  # path. It appends, so the inference venv's own packages keep priority and
+  # transformers 5 still wins there.
   if [[ "${DRY_RUN}" -eq 1 ]]; then
-    echo "[dry-run] write ${venv}/<purelib>/torch-rbln-test-venv.pth -> this interpreter's purelib"
+    echo "[dry-run] write ${venv}/<purelib>/torch-rbln-test-venv.pth -> addsitedir(this interpreter's purelib)"
   else
     python - "${py}" <<'PY'
 import pathlib, subprocess, sys, sysconfig
@@ -186,7 +193,9 @@ parent = sysconfig.get_paths()["purelib"]
 child = subprocess.check_output(
     [sys.argv[1], "-c", "import sysconfig; print(sysconfig.get_paths()['purelib'])"], text=True
 ).strip()
-pathlib.Path(child, "torch-rbln-test-venv.pth").write_text(parent + "\n")
+pathlib.Path(child, "torch-rbln-test-venv.pth").write_text(
+    f"import site; site.addsitedir({parent!r})\n"
+)
 PY
   fi
 
@@ -219,11 +228,92 @@ PY
     deps_text="$(vllm_rbln_runtime_deps "${dir}/pyproject.toml")"
     mapfile -t deps <<< "${deps_text}"
   fi
-  pip_install_into "${py}" "${deps[@]}" \
+  # Installed with the inference venv's own pip, never uv, whatever UV is set
+  # to: pip reads the target interpreter's sys.path, so it sees the test venv's
+  # torch and torch-rbln through the .pth above and leaves them alone. uv
+  # resolves against the venv directory only, does not see them, and pulls its
+  # own torch in as a transitive dependency of vllm.
+  run "${py}" -m pip install "${deps[@]}" \
     --extra-index-url "${vllm_index}" \
     --extra-index-url https://pypi.rbln.ai/simple/ \
     --extra-index-url https://download.pytorch.org/whl/cpu
-  pip_install_into "${py}" -e "${dir}" --no-deps
+  run "${py}" -m pip install -e "${dir}" --no-deps
+
+  verify_shared_packages "${py}"
+}
+
+# The inference venv exists to add the vLLM stack, not to re-create the packages
+# under test. A second copy of torch or torch-rbln there would be a different
+# binary from the one the rest of the suite exercises, and the extension built
+# against the test venv's torch would load the inference venv's. Fail here
+# rather than let a run report on packages nobody meant to test.
+verify_shared_packages() {
+  local py="$1"
+
+  if [[ "${DRY_RUN}" -eq 1 ]]; then
+    echo "[dry-run] verify torch / torch_rbln / rebel resolve to this interpreter"
+    return 0
+  fi
+
+  python - "${py}" <<'PY'
+import json
+import os
+import subprocess
+import sys
+import sysconfig
+import tempfile
+
+# -I so the probe measures the interpreter's own environment: no PYTHONPATH, and
+# no working directory on sys.path (a torch-rbln checkout has a ``torch`` symlink
+# at its root, and the installer is normally run from there).
+PROBE = r"""
+import json, os
+out = {}
+for name in ("torch", "torch_rbln", "rebel", "transformers"):
+    try:
+        mod = __import__(name)
+    except Exception as exc:
+        out[name] = [None, repr(exc)]
+    else:
+        path = getattr(mod, "__file__", "") or ""
+        out[name] = [getattr(mod, "__version__", None), os.path.realpath(path) if path else ""]
+print(json.dumps(out))
+"""
+
+
+def probe(interpreter):
+    # Absolute: the probe runs from a directory that is not the caller's.
+    interpreter = os.path.abspath(interpreter)
+    with tempfile.TemporaryDirectory() as neutral:
+        return json.loads(subprocess.check_output([interpreter, "-I", "-c", PROBE], text=True, cwd=neutral))
+
+
+parent = os.path.realpath(sysconfig.get_paths()["purelib"])
+child = probe(sys.argv[1])
+here = probe(sys.executable)
+
+problems = []
+for name in ("torch", "torch_rbln", "rebel"):
+    version, path = child[name]
+    if version is None:
+        problems.append("{}: not importable in the inference venv ({})".format(name, path))
+        continue
+    if path != here[name][1]:
+        problems.append("{}: {} in the inference venv, {} here".format(name, path, here[name][1]))
+    if here[name][0] is not None and version != here[name][0]:
+        problems.append("{}: {} in the inference venv, {} here".format(name, version, here[name][0]))
+
+# The whole point of the split: the inference venv must bring its own transformers.
+if child["transformers"][1] and child["transformers"][1].startswith(parent):
+    problems.append("transformers: inference venv falls back to the test venv's copy ({})".format(child["transformers"][1]))
+
+if problems:
+    sys.exit("inference venv does not share the packages under test:\n  " + "\n  ".join(problems))
+
+shared = ", ".join("{} {}".format(n, child[n][0]) for n in ("torch", "torch_rbln", "rebel"))
+print("Shared with the inference venv: " + shared)
+print("Inference venv transformers: {}".format(child["transformers"][0]))
+PY
 }
 
 # ----- main -----------------------------------------------------------------

--- a/tools/test/install-test-deps.sh
+++ b/tools/test/install-test-deps.sh
@@ -179,6 +179,11 @@ install_vllm_rbln() {
   if [[ ! -x "${py}" ]]; then
     run python -m venv "${venv}"
   fi
+  # A venv this script did not create may have no pip (``uv venv`` makes one
+  # without), and the install below runs the inference venv's own pip.
+  if [[ "${DRY_RUN}" -eq 0 ]] && ! "${py}" -m pip --version >/dev/null 2>&1; then
+    run "${py}" -m ensurepip
+  fi
   # site.addsitedir rather than a bare path: it also processes the .pth files
   # *inside* the test venv, which is how an editable install (torch-rbln built
   # from this checkout, an external rebel-compiler) puts its source tree on the
@@ -304,7 +309,9 @@ for name in ("torch", "torch_rbln", "rebel"):
         problems.append("{}: {} in the inference venv, {} here".format(name, version, here[name][0]))
 
 # The whole point of the split: the inference venv must bring its own transformers.
-if child["transformers"][1] and child["transformers"][1].startswith(parent):
+if child["transformers"][0] is None:
+    problems.append("transformers: not importable in the inference venv ({})".format(child["transformers"][1]))
+elif child["transformers"][1].startswith(parent):
     problems.append("transformers: inference venv falls back to the test venv's copy ({})".format(child["transformers"][1]))
 
 if problems:

--- a/tools/test/install-test-deps.sh
+++ b/tools/test/install-test-deps.sh
@@ -14,10 +14,9 @@
 #   1. Test runner   : pytest, pytest-xdist
 #   2. Test infra    : expecttest (for torch.testing._internal)
 #   3. Model tests   : torchvision (PyTorch CPU index) + pandas
-#   4. vllm-rbln     : git clone + editable install; vllm itself is pulled in
-#                      transitively from vllm-rbln's dependency pin so the
-#                      version stays in lockstep with vllm-rbln upstream
-#                      instead of being re-pinned here.
+#   4. vllm-rbln     : git clone + editable install; its runtime dependencies
+#                      come from its own pyproject, minus torch-rbln and torch
+#                      (the packages under test).
 #
 # Usage:
 #   ./tools/test/install-test-deps.sh [--dry-run]
@@ -25,7 +24,7 @@
 # Optional environment:
 #   UV=1                 Use ``uv pip install`` instead of ``python -m pip``.
 #   VLLM_RBLN_REPO       Override the source repo (default rbln-sw/vllm-rbln).
-#   VLLM_RBLN_REF        Override the ref (default origin/device_tensor_rebased).
+#   VLLM_RBLN_REF        Override the ref (default origin/ci/torch-rbln-model-tests).
 #   VLLM_RBLN_DIR        Override the local checkout path
 #                        (default ``$PROJECT_ROOT/vllm-rbln``).
 # =============================================================================
@@ -108,12 +107,11 @@ install_model_test_deps() {
 
 # ----- step 4: vllm-rbln ----------------------------------------------------
 #
-# vllm-rbln's device-tensor flow is not on PyPI yet, so we source-install the
-# branch directly. We do NOT install ``vllm`` separately: vllm-rbln pins the
-# right vllm version (and the matching vllm-cpu wheel index URL) in its own
-# pyproject.toml, and pip pulls vllm transitively when we install vllm-rbln
-# editable. This keeps the vllm version in lockstep with vllm-rbln's upstream
-# pin instead of duplicating it here.
+# vllm-rbln's runtime dependencies (vllm, optimum-rbln, ...) are read from its
+# pyproject.toml so nothing is re-pinned here. torch-rbln and torch are left
+# out and the editable install is ``--no-deps``: vllm-rbln bounds torch-rbln to
+# a release line that a nightly or editable torch-rbln does not satisfy, and a
+# resolving install would replace the package under test.
 
 vllm_wheel_index_from_pyproject() {
   # Read the vllm-cpu index URL out of vllm-rbln's pyproject.toml so we don't
@@ -130,9 +128,23 @@ sys.exit(f"vllm-cpu index URL not found in {sys.argv[1]}")
 PY
 }
 
+vllm_rbln_runtime_deps() {
+  # One requirement per line, environment markers kept.
+  local pyproject="$1"
+  python - "${pyproject}" <<'PY'
+import re, sys, tomllib, pathlib
+data = tomllib.loads(pathlib.Path(sys.argv[1]).read_text())
+skip = {"torch-rbln", "torch"}
+for req in data["project"]["dependencies"]:
+    name = re.split(r"[\s\[<>=!~;]", req.strip(), maxsplit=1)[0].lower().replace("_", "-")
+    if name not in skip:
+        print(req)
+PY
+}
+
 install_vllm_rbln() {
   local repo="${VLLM_RBLN_REPO:-https://github.com/rbln-sw/vllm-rbln.git}"
-  local ref="${VLLM_RBLN_REF:-origin/chan/remove_cpu_offload}"
+  local ref="${VLLM_RBLN_REF:-origin/ci/torch-rbln-model-tests}"
   local dir="${VLLM_RBLN_DIR:-${PROJECT_ROOT}/vllm-rbln}"
 
   log_step "vllm-rbln (clone + editable install at ${ref})"
@@ -156,13 +168,21 @@ install_vllm_rbln() {
     echo "Resolved vllm wheel index from vllm-rbln pyproject: ${vllm_index}"
   fi
 
-  # The rbln index is needed so pip can resolve vllm-rbln's transitive
-  # ``optimum-rbln`` pin; transformers + other ordinary PyPI packages come
-  # from the default index.
-  pip_install -e "${dir}" \
+  # The rbln index resolves vllm-rbln's ``optimum-rbln`` pin; ordinary PyPI
+  # packages come from the default index.
+  local -a deps
+  if [[ "${DRY_RUN}" -eq 1 ]]; then
+    deps=("<vllm-rbln runtime deps minus torch-rbln/torch, from pyproject at runtime>")
+  else
+    local deps_text
+    deps_text="$(vllm_rbln_runtime_deps "${dir}/pyproject.toml")"
+    mapfile -t deps <<< "${deps_text}"
+  fi
+  pip_install "${deps[@]}" \
     --extra-index-url "${vllm_index}" \
     --extra-index-url https://pypi.rbln.ai/simple/ \
     --extra-index-url https://download.pytorch.org/whl/cpu
+  pip_install -e "${dir}" --no-deps
 }
 
 # ----- main -----------------------------------------------------------------

--- a/tools/test/install-test-deps.sh
+++ b/tools/test/install-test-deps.sh
@@ -13,10 +13,16 @@
 # Steps (each can be skipped via env var if a CI runner already provides it):
 #   1. Test runner   : pytest, pytest-xdist
 #   2. Test infra    : expecttest (for torch.testing._internal)
-#   3. Model tests   : torchvision (PyTorch CPU index) + pandas
-#   4. vllm-rbln     : git clone + editable install; its runtime dependencies
-#                      come from its own pyproject, minus torch-rbln and torch
-#                      (the packages under test).
+#   3. Model tests   : torchvision (PyTorch CPU index), pandas, transformers 4
+#                      (the line test_transformers.py's models load under)
+#   4. inference stack: vllm-rbln (git clone + editable) and, through its
+#                      dependencies, optimum-rbln, in their own venv. That
+#                      stack pins transformers 5, so it cannot share the test
+#                      venv; test/run_tests.py runs test_optimum_llm.py and
+#                      test_vllm_llm.py with this venv's interpreter. The venv
+#                      sees the test venv's site-packages (torch, torch-rbln,
+#                      rebel-compiler, pytest) through a .pth file and adds
+#                      only the stack on top.
 #
 # Usage:
 #   ./tools/test/install-test-deps.sh [--dry-run]
@@ -27,6 +33,9 @@
 #   VLLM_RBLN_REF        Override the ref (default origin/ci/torch-rbln-model-tests).
 #   VLLM_RBLN_DIR        Override the local checkout path
 #                        (default ``$PROJECT_ROOT/vllm-rbln``).
+#   INFERENCE_VENV       Override the inference-stack venv path
+#                        (default ``$PROJECT_ROOT/.venv-inference``, where
+#                        test/run_tests.py looks for it).
 # =============================================================================
 
 set -euo pipefail
@@ -61,10 +70,17 @@ run() {
 }
 
 pip_install() {
+  pip_install_into python "$@"
+}
+
+# pip_install_into <python> <pip args...>: install into the venv of <python>.
+pip_install_into() {
+  local py="$1"
+  shift
   if [[ "${UV:-0}" = "1" ]]; then
-    run uv pip install "$@"
+    run uv pip install --python "${py}" "$@"
   else
-    run python -m pip install "$@"
+    run "${py}" -m pip install "$@"
   fi
 }
 
@@ -93,25 +109,32 @@ install_test_infra() {
 # download.pytorch.org rather than PyPI). pandas is a plain PyPI package used
 # only by test/models/test_optimum_llm.py.
 #
-# transformers and optimum-rbln are NOT installed here — they arrive
-# transitively via vllm-rbln in step 4.
+# transformers stays on the 4 line here: test_transformers.py loads EXAONE-3.5's
+# hub modeling code, which no transformers 5 release runs. optimum-rbln is not
+# installed here; every release that supports this torch pins transformers 5, so
+# it lives in the inference venv (step 4).
 
 install_model_test_deps() {
-  log_step "Model-test deps (torchvision CPU + pandas)"
+  log_step "Model-test deps (torchvision CPU + pandas + transformers 4)"
   pip_install "torchvision==0.25.0+cpu" \
     --index-url https://download.pytorch.org/whl/cpu \
     --force-reinstall \
     --no-deps
   pip_install "pandas==2.2.3"
+  pip_install "transformers<5"
 }
 
-# ----- step 4: vllm-rbln ----------------------------------------------------
+# ----- step 4: inference stack (vllm-rbln + optimum-rbln) --------------------
 #
-# vllm-rbln's runtime dependencies (vllm, optimum-rbln, ...) are read from its
-# pyproject.toml so nothing is re-pinned here. torch-rbln and torch are left
-# out and the editable install is ``--no-deps``: vllm-rbln bounds torch-rbln to
-# a release line that a nightly or editable torch-rbln does not satisfy, and a
-# resolving install would replace the package under test.
+# The stack goes into its own venv because it pins transformers 5 (see step 3).
+# The venv layers on this interpreter's site-packages through a .pth file, so
+# torch, torch-rbln, rebel-compiler and pytest are shared and only vllm-rbln
+# plus its runtime dependencies (optimum-rbln among them) are added. Those
+# dependencies are read from vllm-rbln's pyproject.toml so nothing is re-pinned
+# here. torch-rbln and torch are left out and the editable install is
+# ``--no-deps``: vllm-rbln bounds torch-rbln to a release line that a nightly or
+# editable torch-rbln does not satisfy, and a resolving install would replace
+# the package under test.
 
 vllm_wheel_index_from_pyproject() {
   # Read the vllm-cpu index URL out of vllm-rbln's pyproject.toml so we don't
@@ -146,8 +169,26 @@ install_vllm_rbln() {
   local repo="${VLLM_RBLN_REPO:-https://github.com/rbln-sw/vllm-rbln.git}"
   local ref="${VLLM_RBLN_REF:-origin/ci/torch-rbln-model-tests}"
   local dir="${VLLM_RBLN_DIR:-${PROJECT_ROOT}/vllm-rbln}"
+  local venv="${INFERENCE_VENV:-${PROJECT_ROOT}/.venv-inference}"
+  local py="${venv}/bin/python"
 
-  log_step "vllm-rbln (clone + editable install at ${ref})"
+  log_step "Inference stack: vllm-rbln (clone + editable install at ${ref}) into ${venv}"
+
+  if [[ ! -x "${py}" ]]; then
+    run python -m venv "${venv}"
+  fi
+  if [[ "${DRY_RUN}" -eq 1 ]]; then
+    echo "[dry-run] write ${venv}/<purelib>/torch-rbln-test-venv.pth -> this interpreter's purelib"
+  else
+    python - "${py}" <<'PY'
+import pathlib, subprocess, sys, sysconfig
+parent = sysconfig.get_paths()["purelib"]
+child = subprocess.check_output(
+    [sys.argv[1], "-c", "import sysconfig; print(sysconfig.get_paths()['purelib'])"], text=True
+).strip()
+pathlib.Path(child, "torch-rbln-test-venv.pth").write_text(parent + "\n")
+PY
+  fi
 
   if [[ ! -d "${dir}/.git" ]]; then
     echo "Cloning ${repo} into ${dir}..."
@@ -178,11 +219,11 @@ install_vllm_rbln() {
     deps_text="$(vllm_rbln_runtime_deps "${dir}/pyproject.toml")"
     mapfile -t deps <<< "${deps_text}"
   fi
-  pip_install "${deps[@]}" \
+  pip_install_into "${py}" "${deps[@]}" \
     --extra-index-url "${vllm_index}" \
     --extra-index-url https://pypi.rbln.ai/simple/ \
     --extra-index-url https://download.pytorch.org/whl/cpu
-  pip_install -e "${dir}" --no-deps
+  pip_install_into "${py}" -e "${dir}" --no-deps
 }
 
 # ----- main -----------------------------------------------------------------


### PR DESCRIPTION
## Summary of Changes

The model suite installs vllm-rbln from a branch frozen in June. That branch hands the attention op a per-partition `seq_lens` tensor, which the pinned rebel-compiler rejects on RBLN-CR13 (`Batch decode requires seq shape [1, 1]`), so every graph-mode and dummy-compile case fails on that lineup. Nothing in torch-rbln is at fault; the pin is stale.

Moving the pin to current vllm-rbln changes the dependency set, and the first CI run on this PR showed what that costs. Each of those is addressed here as well.

* `tools/test/install-test-deps.sh`
  * default `VLLM_RBLN_REF` is `origin/ci/torch-rbln-model-tests` (vllm-rbln `dev` plus the fixes the suite needs).
  * vllm-rbln and, through its dependencies, optimum-rbln go into `.venv-inference`, which sees the test venv's site-packages through a `.pth` file (torch, torch-rbln, rebel-compiler, pytest shared). The `.pth` calls `site.addsitedir`, so an editable torch-rbln or an external rebel-compiler reaches it too, and the install is verified afterwards: torch, torch-rbln and rebel must resolve to the test venv's files, transformers must not. Both pin transformers 5; `test_transformers.py` loads EXAONE-3.5's hub code, which no transformers 5 release runs, so the test venv keeps transformers 4. Until now the suite avoided the clash by letting optimum-rbln 0.10 downgrade torch to 2.10 under a torch-rbln built for 2.11.
  * the editable install is `--no-deps` and `torch-rbln`/`torch` are excluded from the dependency list: vllm-rbln bounds `torch-rbln` to a release line the nightly under test does not satisfy, so a resolving install would replace it.
* `test/run_tests.py`: `test_transformers.py` runs with the test interpreter, `test_optimum_llm.py` and `test_vllm_llm.py` with the inference venv, read from the same `INFERENCE_VENV` the installer honours.
* `test/models/test_vllm_llm.py`: models are passed as the cached snapshot directory when the hub is offline (huggingface_hub 1.x validates a cached snapshot against the repo tree and the shared caches hold only the files inference needs); the compile-only checks accept the mega-cache bundle vllm-rbln writes now, and compare artifacts by content, since a recompile lands in the bundle at the path it already used.
* `constraints-build-dev.txt`: rebel-compiler `dev238`. Compile-only writes its artifacts through `rebel.core.mega_cache.write_bundle`, which exists from `dev234`; `#193` targets the same build, `#244` a newer one.

Layer: test tooling and the compiler pin. The seq-shape assertion is settled on the vllm-rbln side.

---

## Related Issues / Tickets

* Resolves https://github.com/rebellions-sw/torch-rbln-internal/issues/59
* Failing runs: rebellions-sw/fsw-integration 34174280892 (CR13, stale pin) and 34199534687 (first run of this PR).
* Related to rbln-sw/vllm-rbln `ci/torch-rbln-model-tests` (`db9f0025`), and to #193 / #244 for the compiler pin.

---

## Type of Change

- [x] `other` — test tooling / CI pin

---

## Affected Modules

- [x] Build/Tools

---

## How to Test

1. `bash tools/test/install-test-deps.sh` in a venv holding the torch-rbln nightly: `torch` and `torch-rbln` unchanged, transformers 4 in the venv, `.venv-inference` with vllm-rbln and optimum-rbln importable.
2. `python test/run_tests.py --suite=models`: `test_transformers.py` (EXAONE included), `test_optimum_llm.py` and `test_vllm_llm.py` pass; TP>1 cases skip on the REBEL lineup.

Done on an RBLN-CR03 host. CR13 and CA25 were not available locally; the CI run on this PR covers them. pypi.rbln.ai needs credentials this host does not have, so the local run used a mirror; CI reaches it directly.

---

## Checklist

* [x] PR title follows Conventional Commits
* [x] Linked to a corresponding issue
* [x] Linting passes (shellcheck with the repo's `enable=all`, flake8 rules on the Python files)
* [ ] All CI tests pass
* [x] Test method and expected result described
* [x] Relevant documentation updated (`docs/TEST_GUIDE.md`, script header)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
