### PR TITLE
fix(c10d): keep a byte-identical device view for byte-copy collectives

### DIFF
--- a/c10/rbln/RBLNFunctions.h
+++ b/c10/rbln/RBLNFunctions.h
@@ -133,8 +133,10 @@ C10_RBLN_API bool is_eager_malloc();
  * shape a consumer that treats the region as bytes expects. Use set_device_layout_like()
  * instead when the region has to match another tensor's layout.
  *
- * Re-binding an already-bound region is allowed and is what the collective path does
- * before every operation.
+ * Re-binding an already-bound region is allowed. A region whose device view is already
+ * flat is left as it is; one that carries a different layout is re-materialized through the
+ * host, so callers that only need the bytes should check the view first (see
+ * ensureRcclRawMemory in the collective path).
  *
  * @param rbln_data Base pointer of an RBLN allocation (not an interior address).
  * @param nbytes Size of the allocation in bytes. Must be positive.

--- a/test/distributed/test_process_group.py
+++ b/test/distributed/test_process_group.py
@@ -256,6 +256,57 @@ def run_send_recv_test(rank: int, world_size: int, backend: str, src: int, dst: 
         dist.destroy_process_group()
 
 
+def run_send_recv_compiled_output_test(rank: int, world_size: int, backend: str) -> None:
+    """Send a compiled graph's static output and check the receiver gets the same bytes.
+
+    A compiled graph keeps its outputs in the layout the compiler chose, not as a flat
+    allocation, and re-applies that layout on every run. The byte-copy collective path must
+    hand such a view to RCCL as it is: re-binding it flat would re-materialize the buffer
+    through the host before every send. This test pins the correctness side of that
+    contract by comparing the received bytes with the sender's host copy across several
+    runs of the graph, so a layout the collective path must not treat as raw bytes shows up
+    as a mismatch here.
+    """
+    setup_environment(rank, world_size)
+    dist.init_process_group(backend=backend, rank=rank, world_size=world_size)
+    device = torch.device("rbln", rank)
+    src, dst = 0, 1
+    shape = (64, 256)
+    dtype = torch.bfloat16
+    num_rounds = 3
+
+    try:
+        if world_size < 2:
+            return
+
+        if rank == src:
+            net = torch.nn.Linear(shape[1], shape[1], bias=False).to(dtype).to(device)
+            compiled = torch.compile(net, backend="rbln", dynamic=False, options={"use_static_output": True})
+            for _ in range(num_rounds):
+                x = torch.randn(shape, dtype=dtype, device=device)
+                y = compiled(x)
+                torch.rbln.synchronize()
+                reference = y.cpu()
+                dist.send(y, dst=dst)
+                # The host copy travels over the CPU path of the same group.
+                dist.send(reference, dst=dst)
+        elif rank == dst:
+            received = torch.empty(shape, dtype=dtype, device=device)
+            for round_idx in range(num_rounds):
+                dist.recv(received, src=src)
+                reference = torch.empty(shape, dtype=dtype)
+                dist.recv(reference, src=src)
+                torch.testing.assert_close(
+                    received.cpu(),
+                    reference,
+                    rtol=0,
+                    atol=0,
+                    msg=f"compiled-output send/recv round {round_idx}: received bytes differ from the sender's copy",
+                )
+    finally:
+        dist.destroy_process_group()
+
+
 def run_allgather_test(rank: int, world_size: int, backend: str, dtype: torch.dtype, size: int) -> None:
     """Test allgather operation."""
     setup_environment(rank, world_size)
@@ -848,6 +899,15 @@ class TestSendRecvRBLN(TestProcessGroupRBLNBase):
             self.skipTest("Requires world_size > 1")
         self.run_c10d_test(
             c10d_async_env, self.world_size, run_send_recv_test, (self.world_size, self.backend, 0, 1, dtype)
+        )
+
+    @parametrize("c10d_async_env", TestProcessGroupRBLNBase.c10d_async_envs)
+    def test_send_recv_compiled_output(self, c10d_async_env):
+        """Send a compiled graph's static output from rank 0 to rank 1 and compare bytes."""
+        if self.should_skip_multi_rank_tests():
+            self.skipTest("Requires world_size > 1")
+        self.run_c10d_test(
+            c10d_async_env, self.world_size, run_send_recv_compiled_output_test, (self.world_size, self.backend)
         )
 
 

--- a/torch_rbln/csrc/distributed/c10d/rbln/ProcessGroupRBLN.cpp
+++ b/torch_rbln/csrc/distributed/c10d/rbln/ProcessGroupRBLN.cpp
@@ -17,6 +17,7 @@
 #include <unordered_map>
 
 // C10 includes
+#include <c10/rbln/DeviceMappingManager.h>
 #include <c10/rbln/RBLNFunctions.h>
 #include <c10/rbln/RBLNLogging.h>
 #include <c10/util/error.h>
@@ -263,10 +264,63 @@ std::optional<rbln::MemoryInfo> getRcclMemoryInfo(const at::Tensor& tensor) {
   return mem_info;
 }
 
+namespace {
+
+// True when the tensor's current device view already holds the user's bytes 1:1: a
+// with-transform view whose physical dtype is the tensor's dtype and whose element count covers
+// the whole storage. Such a view can be handed to a byte-copy collective as-is.
+//
+// Re-binding it flat is not a no-op: the runtime treats a flat allocation and a with-transform
+// view as different layouts, so the request re-materializes the view through the host
+// (device-to-host, reallocate, host-to-device). When the buffer is a compiled graph's static
+// output, the graph re-applies its own layout on the next run and the round trip repeats on
+// every collective. Pipeline-parallel handoffs send exactly such outputs.
+//
+// The runtime does not expose the element order (op_replay) here, so a view that permutes
+// elements while keeping dtype and count would pass this check. No such view has been observed
+// for byte-copy operands; dtype conversion and padding, the layouts that do differ in bytes, are
+// rejected below.
+bool deviceViewIsRawUserBytes(const at::Tensor& tensor, const rbln::MemoryInfo& mem_info) {
+  if (mem_info.physical_dtype == rbln::DataType::Undefined) {
+    return false; // no device view, or a flat one: bind_device_memory allocates or is a no-op
+  }
+  if (mem_info.physical_dtype != mem_info.user_dtype ||
+      mem_info.user_dtype != c10::rbln::to_rbln_dtype(tensor.scalar_type())) {
+    return false;
+  }
+  // A logical device made of several NPUs may spread one view over several device areas; the
+  // collective path reads a single area, so only a single-NPU device keeps its view.
+  if (c10::rbln::DeviceMappingManager::getInstance().getPhysicalDeviceIds(tensor.device().index()).size() != 1) {
+    return false;
+  }
+  // The device view may split a dimension into aligned tiles (e.g. [N, 3072] kept as
+  // [N, 48, 64]); that is a reshape, so compare element counts rather than shapes.
+  auto count = [](const std::vector<int64_t>& shape, size_t& out) {
+    out = 1;
+    for (auto d : shape) {
+      if (d < 0) {
+        return false;
+      }
+      out *= static_cast<size_t>(d);
+    }
+    return true;
+  };
+  size_t user_numel = 0;
+  size_t physical_numel = 0;
+  if (!count(mem_info.user_shape, user_numel) || !count(mem_info.physical_shape, physical_numel)) {
+    return false;
+  }
+  return user_numel == physical_numel && user_numel * tensor.element_size() == tensor.storage().nbytes();
+}
+
+} // namespace
+
 /**
- * @brief Prepare tensor for RCCL byte-copy operations (no dtype transform)
+ * @brief Make sure the tensor's bytes are device-resident for an RCCL byte-copy operation.
  *
- * Uses SINGLE_DEVICE_NO_TRANSFORM mode for raw byte transfers.
+ * A device view that already holds the user's bytes 1:1 is used as-is. Otherwise the
+ * enclosing allocation is bound flat (SINGLE_DEVICE_NO_TRANSFORM), which materializes it
+ * or re-lays it out as raw bytes.
  * Suitable for: AllGather, Broadcast, Send, Recv, Scatter.
  *
  * @param tensor The tensor to prepare
@@ -274,6 +328,9 @@ std::optional<rbln::MemoryInfo> getRcclMemoryInfo(const at::Tensor& tensor) {
 void ensureRcclRawMemory(const at::Tensor& tensor) {
   auto mem_info = getRcclMemoryInfo(tensor);
   if (!mem_info) {
+    return;
+  }
+  if (deviceViewIsRawUserBytes(tensor, *mem_info)) {
     return;
   }
   // key_vaddr rather than data_ptr(): a view's data_ptr() is an interior address, and the


### PR DESCRIPTION
## Summary of Changes

`ensureRcclRawMemory` re-binds every byte-copy operand flat through `bind_device_memory` before each collective. The runtime treats a flat allocation and a with-transform view as different layouts, so for an operand that is already device-resident in the layout the compiler chose, the re-binding is not a no-op: the buffer is re-materialized through the host (device-to-host, reallocate, host-to-device) before RCCL touches it.

A compiled graph's static output is such an operand, and it is what a vLLM pipeline-parallel stage sends to the next stage. The graph re-applies its own layout on the next run, so the host round trip repeats on every step: once inside the send, once inside the graph's output preparation. In a pipeline-parallel profile both show up as the dominant host cost of the handoff, several times what the same bytes cost from a persistent flat buffer.

This change keeps a device view that already holds the user's bytes 1:1 and hands it to RCCL as it is. The check reads the runtime's `MemoryInfo` (already fetched here): the view must have a physical dtype equal to the tensor's dtype, an element count that covers the whole storage, and the tensor's logical device must be a single NPU (a multi-NPU logical device may spread one view over several device areas, and the collective path reads one). Views without a device view, flat views, dtype-converting views, padded views and multi-NPU devices still take the existing `bind_device_memory` path. `bind_device_memory` keeps its flat contract; only its doc comment is updated to say what re-binding a differently laid-out region costs.

Limits: `MemoryInfo` does not expose the element order, so a view that permutes elements while keeping dtype and count would pass the check. No such view has been observed for byte-copy operands; the new test compares received bytes against the sender's host copy across several graph runs so that one would fail loudly rather than silently.

Layer: torch-rbln C++ extension (`ProcessGroupRBLN.cpp`), a doc comment in `c10/rbln/RBLNFunctions.h`, one new test. No runtime or Python change.

---

## Related Issues / Tickets

* Related to `rebellions-sw/torch-rbln-internal#61` — the analysis of the pipeline-parallel handoff cost that led to this change (internal). The public issue #246 was folded into it and closed.

---

## Type of Change

- [x] `core` — Changes to RBLN backend, device layer, C++ extension, op registration, or `torch.compile` integration
- [x] `perf` — Performance improvement

---

## Affected Modules

- [x] C++ extension (`torch_rbln/csrc`)
- [x] Memory

---

## How to Test

1. `pytest test/distributed/test_process_group.py -k compiled_output` — rank 0 compiles a small `Linear` with `use_static_output`, runs it three times and sends each output; rank 1 receives into one buffer and compares the bytes with the sender's host copy (sent over the CPU path of the same group). Passes with this change.
2. The existing `test_send_recv` matrix still passes: operands allocated with `torch.full`/`torch.zeros` have no with-transform view and keep the flat re-binding path.
3. In a two-rank micro-benchmark that sends a compiled graph's static output, `strace` shows one device job per send (the DMA) instead of three (device-to-host, host-to-device, DMA), and the send's host time comes down to what a send of a persistent flat buffer costs.
4. A MiniMax-M2.7 PP=4 vLLM prefill shows the same change on the per-handoff `rbln::send`/`rbln::recv` and on the runtime's output preparation, and the time-to-first-token improves accordingly. The first tensor's send now mostly reflects the sender's outstanding compute, which the DMA legitimately waits for.

---

## Checklist

* [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
* [x] This PR is linked to a corresponding issue
* [x] Linting passes (`lintrunner -m origin/main`)
* [ ] All CI tests pass
* [x] The test method is described, and the expected result is clearly stated
* [x] Relevant documentation has been updated (doc comments)

---

## Notes

The root cause sits in the runtime's layout rule (a flat request is never considered compatible with a with-transform view, even a byte-identical one). Teaching the runtime that equivalence would let this check go away; until then the collective path is the right place for it, since it is the one caller that only needs the bytes.
