### PR TITLE
perf(index_copy): keep an in-place view's indexed runs on the device

### DIFF
--- a/aten/src/ATen/native/rbln/RBLNCopy.cpp
+++ b/aten/src/ATen/native/rbln/RBLNCopy.cpp
@@ -362,9 +362,11 @@ void tensor_copy_from_rbln_to_rbln(const at::Tensor& rbln_src, const at::Tensor&
   }
 
   // Strided copy: route to the on-device v2v engine while the outer iteration
-  // count stays within the runtime per-dst v2v cap (::rbln::kMaxV2VMultiCopies,
-  // the single source shared with the runtime); above it the engine fans out to
-  // a host fallback anyway, so bounce via host here.
+  // count stays within ::rbln::kMaxV2VMultiCopies. A larger fan-out would still
+  // reach the device — V2VBatch::submit splits a batch at that cap — but it
+  // pays one descriptor per contiguous run, and where that stops beating the
+  // host bounce below is unmeasured, so a fan-out past the cap takes the
+  // bounce.
   if (rbln_src.sizes() == rbln_dst.sizes() && rbln_src.scalar_type() == rbln_dst.scalar_type() &&
       rbln_src.device() == rbln_dst.device()) {
     const auto inner_start = common_inner_start(rbln_src.sizes(), rbln_src.strides(), rbln_dst.strides());

--- a/aten/src/ATen/native/rbln/RBLNTensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/rbln/RBLNTensorAdvancedIndexing.cpp
@@ -376,11 +376,13 @@ at::Tensor& index_copy_out_rbln(
   // already shaped correctly, or when out.sizes() == self.sizes()).
   at::native::resize_output(out, self.sizes());
 
-  // Non-contig `out`: stage through a contig buffer and copy_ back at the end.
-  // The engine assumes a contig output for the "out aliasing self" detection
-  // to be unambiguous, and most upstream callers pass a contig (or freshly
-  // empty) `out` anyway.
-  if (!out.is_contiguous()) {
+  // Non-contig `out` that is not `self` itself: stage through a contig buffer
+  // and copy_ back at the end, so the positions the index does not name get
+  // self's values through one copy_ rather than a strided v2v of the whole
+  // view. The in-place form on a view (`out` is `self`) needs no initialisation:
+  // Phase 2 writes the indexed runs into the view and the rest stays as it is,
+  // so it takes the direct path below however the view is laid out.
+  if (!out.is_contiguous() && !is_same_view(out, self)) {
     auto staging = at::empty(self.sizes(), out.options().memory_format(c10::MemoryFormat::Contiguous));
     index_copy_out_rbln(self, dim, index, source, staging);
     out.copy_(staging);

--- a/c10/rbln/RBLNV2VBatch.cpp
+++ b/c10/rbln/RBLNV2VBatch.cpp
@@ -5,6 +5,8 @@
 #include <c10/rbln/RBLNV2VBatch.h>
 #include <c10/rbln/detail/RBLNCopyBatchImpl.h>
 
+#include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <vector>
 
@@ -56,41 +58,73 @@ void V2VBatch::submit() {
     }
   } guard{&impl_->st};
 
-  bool drained = false;
-  if (impl_->st.homogeneous) {
-    // Try the batched fast path first. The runtime's
-    // ``CopyVirtualToVirtualMulti`` enforces stricter no-overlap invariants
-    // between concurrent sub-copies than the per-entry path needs (writes
-    // can be observed out-of-order across the batch), and some strided
-    // patterns we emit from ``strided_v2v_copy`` — e.g. multi-slab ``cat``
-    // into a non-contig output where each slab fans out to thousands of
-    // narrow sub-copies — hit that check even though no two sub-copies
-    // actually alias each other. Catch the runtime rejection and fall back
-    // to the per-entry path, which has no such inter-copy ordering
-    // constraint. Correctness-equivalent to the dev path; loses the batch
-    // throughput win only for the offending submit().
-    RBLN_LOG_DEBUG("V2VBatch::submit draining {} entries (batched)", impl_->st.pending.size());
+  const auto& all = impl_->st.pending;
+
+  if (!impl_->st.homogeneous) {
+    // Heterogeneous — per-entry memcpy_v2v handles host-bounce internally and
+    // tolerates any ordering between entries.
+    RBLN_LOG_DEBUG("V2VBatch::submit draining {} entries (per-entry, cross-device)", all.size());
+    for (const auto& e : all) {
+      memcpy_v2v(e.dst, e.src, e.nbytes);
+    }
+    return;
+  }
+
+  // Submit `all[begin, end)` as one bulk call, per-entry on rejection.
+  //
+  // The runtime's ``CopyVirtualToVirtualMulti`` enforces stricter no-overlap
+  // invariants between concurrent sub-copies than the per-entry path needs
+  // (writes can be observed out-of-order across the batch), and some strided
+  // patterns we emit from ``strided_v2v_copy`` — e.g. multi-slab ``cat`` into a
+  // non-contig output where each slab fans out to thousands of narrow
+  // sub-copies — hit that check even though no two sub-copies actually alias
+  // each other. Catch the rejection and fall back to the per-entry path, which
+  // has no such inter-copy ordering constraint. Replay is sound under an API
+  // documenting no rollback because a copy is idempotent: a plain write, never
+  // a read-modify-write, so a re-applied entry writes the same bytes. Retrying
+  // one call's range rather than the whole batch keeps a rejection local to the
+  // group that caused it.
+  const auto submit_one_call = [&all](size_t begin, size_t end) {
     try {
-      memcpy_v2v_multi(impl_->st.pending);
-      drained = true;
+      if (begin == 0 && end == all.size()) {
+        memcpy_v2v_multi(all); // whole batch fits one call — submit it as is, no copy
+      } else {
+        memcpy_v2v_multi(std::vector<V2VCopyOp>(
+            all.begin() + static_cast<std::ptrdiff_t>(begin), all.begin() + static_cast<std::ptrdiff_t>(end)));
+      }
+      return;
     } catch (const c10::Error& e) {
       // PROFILER (cold branch): batched v2v rejected by the runtime's no-overlap
-      // check; we fall to the per-entry loop (host-bounces cross-device entries).
+      // check; the per-entry loop below has no inter-copy constraint.
       c10::rbln::prof::record_bounce(c10::rbln::prof::BounceSite::kV2VBatchToPerEntry, 0);
       RBLN_LOG_WARN(
           "V2VBatch::submit batched path rejected ({} entries) — falling back to per-entry: {}",
-          impl_->st.pending.size(),
+          end - begin,
           e.what_without_backtrace());
     }
-  }
-  if (!drained) {
-    // Heterogeneous (or batched path was rejected) — per-entry memcpy_v2v
-    // handles host-bounce internally and tolerates any ordering between
-    // entries.
-    RBLN_LOG_DEBUG("V2VBatch::submit draining {} entries (per-entry fallback)", impl_->st.pending.size());
-    for (const auto& e : impl_->st.pending) {
-      memcpy_v2v(e.dst, e.src, e.nbytes);
+    for (size_t i = begin; i < end; ++i) {
+      memcpy_v2v(all[i].dst, all[i].src, all[i].nbytes);
     }
+  };
+
+  // Work one bulk call may carry. The runtime dispatches at most
+  // ::rbln::kMaxV2VMultiCopies sub-copies per call through the device command
+  // buffer; past that it completes the call by syncing the entries to the host
+  // instead, which leaves the destination storage host-latest and makes the
+  // next device consumer re-upload all of it. Splitting keeps every call on the
+  // device: entries of one batch are disjoint by contract, so the split result
+  // is the same. Unlike RBLNHostBatch's caps this one is the runtime's own
+  // published constant, not a measured one.
+  constexpr size_t kMaxBulkEntries = ::rbln::kMaxV2VMultiCopies;
+  if (all.size() <= kMaxBulkEntries) {
+    RBLN_LOG_DEBUG("V2VBatch::submit draining {} entries (batched)", all.size());
+    submit_one_call(0, all.size());
+    return;
+  }
+  RBLN_LOG_DEBUG(
+      "V2VBatch::submit splitting {} entries to stay under the cap ({} entries)", all.size(), kMaxBulkEntries);
+  for (size_t begin = 0; begin < all.size(); begin += kMaxBulkEntries) {
+    submit_one_call(begin, std::min(begin + kMaxBulkEntries, all.size()));
   }
 }
 

--- a/c10/rbln/RBLNV2VBatch.h
+++ b/c10/rbln/RBLNV2VBatch.h
@@ -13,9 +13,11 @@ namespace c10::rbln {
  *
  * Isolates callers from the rebel runtime's v2v API. enqueue() / enqueue_strided()
  * record copy requests; submit() flushes them through rbln_memcpy_v2v_multi when
- * every entry shares one device, or falls back to per-entry memcpy_v2v (which
- * host-bounces cross-device entries). The path is decided from bookkeeping kept
- * at enqueue time, so submit() is O(N) with no extra lookups.
+ * every entry shares one device — in calls of at most
+ * ::rbln::kMaxV2VMultiCopies entries, the most one call dispatches on the
+ * device — or falls back to per-entry memcpy_v2v (which host-bounces
+ * cross-device entries). The path is decided from bookkeeping kept at enqueue
+ * time, so submit() is O(N) with no extra lookups.
  *
  * When the runtime exposes a strided v2v API, enqueue_strided will forward the
  * description directly instead of expanding internally — engine/kernel code that

--- a/test/cpp/core/RBLNV2VBatchTest.cpp
+++ b/test/cpp/core/RBLNV2VBatchTest.cpp
@@ -390,6 +390,49 @@ TEST_F(RBLNV2VBatchTest, LargeBatchedSubmit) {
   c10::rbln::free(dst);
 }
 
+// More entries than one rbln_memcpy_v2v_multi call dispatches on the device
+// (::rbln::kMaxV2VMultiCopies): submit() must issue runtime-sized calls — one
+// oversized call makes the runtime host-sync the whole entry — and the data
+// must still arrive in full.
+TEST_F(RBLNV2VBatchTest, AboveRuntimeCapSubmitsInRuntimeSizedCalls) {
+  constexpr size_t blk = 16;
+  constexpr size_t nblk = ::rbln::kMaxV2VMultiCopies + 1;
+  constexpr size_t total = blk * nblk;
+
+  std::vector<int8_t> src_host(total);
+  for (size_t i = 0; i < total; ++i) {
+    src_host[i] = static_cast<int8_t>((i * 17) % 127);
+  }
+  std::vector<int8_t> dst_initial(total, -1);
+
+  auto* src = static_cast<int8_t*>(AllocAndCopyFromHost(src_host.data(), total));
+  auto* dst = static_cast<int8_t*>(AllocAndCopyFromHost(dst_initial.data(), total));
+
+  {
+    c10::rbln::V2VBatch batch;
+    for (size_t i = 0; i < nblk; ++i) {
+      batch.enqueue(dst + i * blk, src + i * blk, blk);
+    }
+    EXPECT_EQ(batch.pending_count(), nblk);
+
+    // rt_timing_get fills [ns, calls] per primitive in RtIdx order
+    // (v2v, v2v_multi, ...), so v2v_multi's call count is slot 1's second word.
+    constexpr size_t kV2VMultiSlot = 1;
+    c10::rbln::rt_timing_reset();
+    c10::rbln::rt_timing_enable(true);
+    batch.submit();
+    c10::rbln::rt_timing_enable(false);
+    std::vector<uint64_t> timing(2 * c10::rbln::kRtTimingN);
+    c10::rbln::rt_timing_get(timing.data());
+    EXPECT_EQ(timing[2 * kV2VMultiSlot + 1], 2u) << "cap + 1 entries must go out as two runtime-sized calls";
+    EXPECT_EQ(batch.pending_count(), 0u);
+  }
+
+  EXPECT_EQ(CopyToHost(dst, total), src_host);
+  c10::rbln::free(src);
+  c10::rbln::free(dst);
+}
+
 // Multiple flat enqueues into adjacent dst slots — verifies submit doesn't
 // reorder or merge entries incorrectly.
 TEST_F(RBLNV2VBatchTest, MultipleFlatEnqueues) {

--- a/test/rbln/test_index_copy_v2v.py
+++ b/test/rbln/test_index_copy_v2v.py
@@ -28,6 +28,38 @@ from torch.testing._internal.common_utils import parametrize, run_tests, TestCas
 from test.utils_v2v import arange as _arange, DEVICE, ENGINE_DTYPES, eq as _eq, to_dev as _to_dev
 
 
+def _device_latest(shape, dtype=torch.bfloat16):
+    """A tensor whose data lives on the device: a compiled graph's output.
+    ``torch.empty(...).copy_(cpu)`` would leave it host-latest, which is the
+    state these tests must not be measured in."""
+    f = torch.compile(lambda t: torch.maximum(t, t), backend="rbln", dynamic=False)
+    y = f(torch.randn(shape).to(dtype).to(DEVICE))
+    torch.rbln.synchronize()
+    return y
+
+
+def _run_and_count(fn):
+    """Run ``fn`` and report what crossed the host boundary: bytes the runtime
+    moved device->host, and how many ``rbln_memcpy_v2v_multi`` calls it made."""
+    from torch_rbln import _C
+    from torch_rbln.profiler import _read_rt_timing, _RT_PRIMS, _rt_timing_enable, _rt_timing_reset
+
+    slot = _RT_PRIMS.index("v2v_multi")
+    torch.rbln.synchronize()
+    (_, d2h_before), _ = _C._rt_prof_host_sync()
+    _rt_timing_reset()
+    _rt_timing_enable(True)
+    try:
+        fn()
+        torch.rbln.synchronize()
+    finally:
+        _rt_timing_enable(False)
+    (_, d2h_after), _ = _C._rt_prof_host_sync()
+    timing = _read_rt_timing()
+    assert timing is not None, "this build has no _rt_timing_get binding; rebuild before trusting the result"
+    return d2h_after - d2h_before, timing[slot][1]
+
+
 @pytest.mark.test_set_ci
 @pytest.mark.usefixtures("enable_deploy_mode")
 class TestIndexCopyV2V(TestCase):
@@ -148,6 +180,52 @@ class TestIndexCopyV2V(TestCase):
         expected = self_cpu.clone()
         expected.index_copy_(0, idx_cpu, src_cpu)
         _eq(self_dev, expected)
+
+    def test_in_place_on_non_contig_view_writes_only_the_indexed_rows(self):
+        """``cache = storage[:, :128]`` updated in place: only the two indexed
+        rows may be written and nothing may reach the host. The kernel used to
+        stage a non-contig ``out`` through a contig buffer and copy it back,
+        which for a storage this size meant pulling every byte to the host and
+        re-uploading it — for two rows of work."""
+        n_slots = 2048
+        storage = _device_latest((n_slots, 256))
+        expected = storage.cpu()
+        cache = storage[:, :128]
+        self.assertFalse(cache.is_contiguous())
+        idx_cpu = torch.tensor([3, n_slots - 2], dtype=torch.int64)
+        idx = _to_dev(idx_cpu)  # moved before the measurement so its h2v is not counted
+        src = _device_latest((2, 128))
+
+        moved, _ = _run_and_count(lambda: cache.index_copy_(0, idx, src))
+        self.assertEqual(moved, 0, "index_copy_ on the view pulled the storage to the host")
+
+        expected[:, :128].index_copy_(0, idx_cpu, src.cpu())
+        # Reading the storage back must move every byte: the data is still on the device.
+        read_back, _ = _run_and_count(storage.cpu)
+        self.assertEqual(read_back, storage.numel() * storage.element_size())
+        _eq(storage, expected)
+
+    def test_unique_indices_above_the_v2v_multi_cap_stay_on_device(self):
+        """Every other row of a 4096-row storage: 2048 single-row runs, twice
+        what one ``rbln_memcpy_v2v_multi`` call dispatches on the device
+        (``kMaxV2VMultiCopies`` = 1024). The batch has to split the submit —
+        one oversized call makes the runtime host-sync the whole storage and
+        leave it host-latest, so the next graph re-uploads all of it."""
+        n_rows = 2048
+        storage = _device_latest((2 * n_rows, 256))
+        expected = storage.cpu()
+        idx_cpu = torch.arange(0, 2 * n_rows, 2, dtype=torch.int64)
+        idx = _to_dev(idx_cpu)  # moved before the measurement so its h2v is not counted
+        src = _device_latest((n_rows, 256))
+
+        moved, calls = _run_and_count(lambda: storage.index_copy_(0, idx, src))
+        self.assertEqual(moved, 0, "index_copy_ above the cap pulled the storage to the host")
+        self.assertEqual(calls, 2, "2048 entries must go out as two runtime-sized calls, not one oversized one")
+
+        expected.index_copy_(0, idx_cpu, src.cpu())
+        read_back, _ = _run_and_count(storage.cpu)
+        self.assertEqual(read_back, storage.numel() * storage.element_size())
+        _eq(storage, expected)
 
     def test_in_place_returns_same_tensor(self):
         """The in-place form must return self (same Python object semantics)."""


### PR DESCRIPTION
## Summary of Changes

`index_copy_` on a **non-contiguous view** of a device-resident storage paid for the whole storage twice, for a few rows of work.

A non-contiguous `out` was staged through a contiguous buffer. The recursive call copied all of `self` into the staging tensor, and the closing `out.copy_(staging)` fanned out to one descriptor per row; past the runtime's per-call v2v cap that leaves the strided path and bounces the whole storage through the host. So updating two slots of a KV cache shaped `storage[:, :128]` moved every byte of the storage down and back up, and left it host-latest for the next graph to re-upload.

Two changes, both in layer 2:

| site | before | after |
|---|---|---|
| `index_copy_out_rbln` (`RBLNTensorAdvancedIndexing.cpp`) | any non-contiguous `out` stages through a contiguous buffer and copies back | `out` that **is** `self` (`is_same_view`: storage, offset, strides) writes the indexed runs straight into the view; a separate non-contiguous `out` still stages |
| `V2VBatch::submit` (`RBLNV2VBatch.cpp`) | one `rbln_memcpy_v2v_multi` for the whole batch, however many entries | calls of at most `::rbln::kMaxV2VMultiCopies` entries; a rejected call degrades only its own range to per-entry instead of the whole batch |

**Why the staging was there, and why the in-place form does not need it.** The staging exists so the positions the index does not name still get `self`'s values. The in-place form already has them: `out` is `self`, so those positions hold what they should, and Phase 2 writes only the indexed runs. The strided v2v engine documents arbitrary dst strides, and `is_same_view` decides the aliasing question that the contiguity check was standing in for. The old comment claimed contiguity was needed for the "out aliasing self" detection to be unambiguous; that reason does not hold, since `is_same_view` never consults contiguity.

**Why splitting the submit is not a workaround for the runtime.** `rbln_runtime_api.h` publishes `kMaxV2VMultiCopies` and invites callers to gate on it: at or below that count the copies go through the device command buffer, above it the runtime completes the call by syncing to the host. `RBLNCopy.cpp` already gates on the same constant and `RBLNHostBatch.cpp` already splits at its own (measured) caps, so this is the documented contract, not a guard over a defect, and no new tuning constant is introduced. Entries of one batch are disjoint by the batch's own caller contract, so the split result is identical.

**Effect, measured on one RBLN-CR03 against this branch's parent** (same wheel, same device; number of updated slots held fixed, only the cache capacity growing):

* The view form moved the whole storage host-ward and back on the parent, growing with capacity. It now moves only the region's bytes, in one direction, at every capacity, and the storage is still device-latest afterwards.
* Its per-call cost stops growing with capacity.
* A fan-out past the per-call cap did the same whole-storage round trip on the parent and additionally left the storage host-latest for the next graph. It now moves nothing.
* Above the cap the wall time per call is in the same range as the parent's, and run-to-run noise covers the difference. The win there is the transfer and the residency, not the call itself.

---

## Related Issues / Tickets

* Related to #239 — same subject (an eager in-place path syncing a whole vmem entry for a region of work); this is a fourth site, found in review of that PR. The two PRs touch disjoint files and neither depends on the other.
* Related to RBLN-SW/torch-rbln-internal#40 and rebellions-sw/fsw-inference#548 — where the whole-storage round trips were first found.

No issue is filed for this path yet, by the author's decision.

---

## Type of Change

- [x] `perf` — Performance improvement
- [x] `core` — Changes to RBLN backend, device layer, C++ extension, op registration, or `torch.compile` integration

---

## Affected Modules

- [x] Ops/Kernels (`index_copy.out`)
- [x] Memory (`c10/rbln` — the v2v batch)

---

## How to Test

Base for every statement below: this branch's head, `rebel-compiler 0.11.3.dev237+g687d3f76` (the pinned dev185 has the same v2v-multi cap), one RBLN-CR03, `TORCH_RBLN_LOG_LEVEL=WARNING`.

1. **The two new tests** (`test_set_ci`, so they run on this PR):
   ```bash
   RBLN_DEVICES=<free> uv run --no-sync pytest test/rbln/test_index_copy_v2v.py -q
   # -> 66 passed
   RBLN_DEVICES=<free> ./build/bin/test_cpp_RBLNV2VBatchTest
   # -> 15 passed, 4 skipped (the skipped ones need more than one device)
   ```
2. **What they assert.** Each builds a device-latest storage (a compiled graph's output), runs `index_copy_` on it, and reads `_C._rt_prof_host_sync()` deltas to check that (a) the result equals the CPU reference, (b) no D2H happened during the op, and (c) reading the storage back afterwards moves every byte from the device, i.e. it is still device-latest. `test_unique_indices_above_the_v2v_multi_cap_stay_on_device` additionally pins the mechanism through the `v2v_multi` boundary-call count: 2048 entries must go out as two runtime-sized calls, not one oversized one. The C++ test does the same at `kMaxV2VMultiCopies + 1` entries, directly on the batch.
3. **Both tests fail on the parent commit**, for the right reason. Reverting only `aten/` and `c10/` to the parent commit and rebuilding turns both red on the moved-bytes assertion; restoring and rebuilding turns them green again.
4. **Regression sweep**, on this branch rebased onto `main` (`32e0a4f`), same device:
   ```bash
   pytest test/rbln/test_index_copy_v2v.py test/rbln/test_cat_index_select_v2v.py \
          test/rbln/test_foreach_copy_v2v.py test/rbln/test_view_copy.py \
          test/rbln/test_tensor_copy.py test/rbln/test_profiler.py -q
   # -> 974 passed, 2 skipped
   ```
   The same change was also swept before the rebase (base `66d1e87`, identical diff): the files above minus
   `test_profiler.py` gave 937 passed / 2 skipped; `test_copy_v2v.py`, `test_repeat_interleave_v2v.py`,
   `test_strided_host_copy.py`, `test_foreach_copy_host.py`, `test_v2v_cross_chiplet.py` and `test_profiler.py`
   gave 353 passed / 5 skipped; and `python test/run_tests.py --suite=core --test_mode=ci --workers=4` gave
   3895 passed / 307 skipped / 3 xfailed on its parallel pass. `main` touched none of the six files in this diff.

---

## Checklist

* [x] PR title follows Conventional Commits
* [ ] This PR is linked to a corresponding issue — not filed for this path yet (see above)
* [x] Linting passes — `uv run --no-sync lintrunner -m origin/main -a`, no issues, nothing auto-fixed
* [ ] All CI tests pass — not known yet; see the local results above and the one environment-blocked test below
* [x] The test method is described, and the expected result is clearly stated
* [x] No documentation change needed: no new configuration, no public API change, no new tuning constant

---

## Notes

**Review focus.**
1. `index_copy_out_rbln`: the added `!is_same_view(out, self)` clause. The claim is that the in-place form needs no initialisation of the un-indexed positions. Note that `assert_no_internal_overlap(out)` and `assert_no_overlap(out, source)` still run ahead of it, so a self-overlapping view (`unfold`) is still rejected, and a *different* view of the same storage has different strides and therefore still stages.
2. `V2VBatch::submit`: the restructure. The rejection retry is now per call range rather than per batch, which is the shape `RBLNHostBatch.cpp` already uses; the comment there says it mirrors this function, and now it does in both directions. The `begin == 0 && end == all.size()` branch keeps the common case free of the vector copy.

**Behaviour change worth knowing.** Because a rejection is now handled per call range, a large batch that the runtime rejects records one `kV2VBatchToPerEntry` bounce per rejected range instead of one for the whole submit. The count is still one per "batched v2v refused, fell to per-entry" event, but the number is larger for a batch above the cap. `test/rbln/test_profiler.py` passes unchanged.

**Paths exercised: eager only.** The op reaches this kernel through eager dispatch, which is what the tests drive. `test/rbln/test_graph_eager_mode.py` covers add / matmul / linear / layernorm and does not include `index_copy`, so it does not speak to this change; I did not add graph-mode coverage for `index_copy`. Other callers of the changed batch (`cat`, `index_select`) are exercised by the sweep above, including their graph-mode tests in the core suite.

**Observation for the runtime team, not a request in this PR.** `rbln_runtime_api.h` documents the above-cap behaviour as "falls back to a host sync (slow but correct)". It does not mention that the destination entry is left *host-latest*, which is the part that costs the next graph a full re-upload. That residency consequence is worth documenting on the API, or avoiding inside the runtime; either would make the caller-side split unnecessary.

**Not verified.** Whether the runtime accepts a v2v into interior offsets of a large untyped pool allocation, the case `submit_or_fallback` was given its CPU fallback for (#85, e.g. a vLLM KV cache). A rejection there is no worse than the previous path, but the gain would not materialise. Also not established: whether the motivating workload actually reaches this path, as opposed to the three sites in #239.

**One environment-blocked test.** `test/rbln/test_dummy_device.py::test_dummy_compiled_prefill_decode_runs_on_real_npu` failed locally in the `single_worker` pass. It strips `RBLN_DEVICES` through `_clean_env()` and so opens physical NPU 0, which was held by an unrelated process on this host; the failure is at `rbln_register_device_id`, before any copy code runs. Not reproduced as a code failure, and not related to this change.
