### PR TITLE
feat(device): report a device's name, memory and chiplet count

### DIFF
--- a/c10/rbln/RBLNFunctions.cpp
+++ b/c10/rbln/RBLNFunctions.cpp
@@ -266,6 +266,50 @@ c10::DeviceIndex get_device_count() {
   return device_count;
 }
 
+DeviceProperties get_device_properties(c10::DeviceIndex device_index) {
+  RBLN_CHECK(
+      !is_dummy_device(),
+      "get_device_properties() reports what the hardware says, and RBLN_DUMMY_DEVICE has no NPU behind it");
+
+  const auto physical_device_ids = DeviceMappingManager::getInstance().getPhysicalDeviceIds(device_index);
+  RBLN_CHECK(!physical_device_ids.empty(), "no NPU is mapped to rbln:{}", static_cast<int>(device_index));
+
+  DeviceProperties properties;
+  for (const int physical_device_id : physical_device_ids) {
+    RBLNDeviceProperties npu{};
+    RBLN_CHECK(
+        !rbln_get_device_properties(physical_device_id, &npu),
+        "rbln_get_device_properties failed for NPU {} behind rbln:{}; the device may be absent or held by "
+        "another process — check $rbln-smi",
+        physical_device_id,
+        static_cast<int>(device_index));
+
+    if (properties.npu_count == 0) {
+      properties.name = npu.name;
+      properties.memory_per_chiplet = npu.memory_per_chiplet;
+      properties.num_chiplet = npu.num_chiplet;
+    } else {
+      RBLN_CHECK(
+          properties.name == npu.name && properties.num_chiplet == npu.num_chiplet,
+          "rbln:{} aggregates unlike NPUs: {} with {} chiplet(s) and {} with {}",
+          static_cast<int>(device_index),
+          properties.name,
+          properties.num_chiplet,
+          npu.name,
+          npu.num_chiplet);
+    }
+    properties.total_memory += npu.total_memory;
+    properties.npu_count++;
+  }
+  RBLN_LOG_DEBUG(
+      "rbln:{} name={} total_memory={} npu_count={}",
+      static_cast<int>(device_index),
+      properties.name,
+      properties.total_memory,
+      properties.npu_count);
+  return properties;
+}
+
 c10::DeviceIndex get_physical_device_count() {
   if (is_dummy_device()) {
     // Dummy mode must not touch the runtime (the host may have no SDK/driver);

--- a/c10/rbln/RBLNFunctions.h
+++ b/c10/rbln/RBLNFunctions.h
@@ -55,6 +55,27 @@ C10_RBLN_API c10::DeviceIndex get_device_count();
 C10_RBLN_API c10::DeviceIndex get_physical_device_count();
 
 /**
+ * @brief What the NPUs behind one logical device are.
+ *
+ * total_memory sums the device's physical NPUs; num_chiplet and memory_per_chiplet stay per NPU.
+ */
+struct C10_RBLN_API DeviceProperties {
+  std::string name;
+  uint64_t total_memory = 0;
+  uint64_t memory_per_chiplet = 0;
+  uint32_t num_chiplet = 0;
+  uint32_t npu_count = 0;
+};
+
+/**
+ * @brief Reports what the logical device at device_index is, summed over its NPUs.
+ *
+ * Needs real hardware: raises in dummy mode, when no NPU is mapped to the index, when the runtime
+ * cannot answer for one of them, or when the mapping aggregates unlike NPUs.
+ */
+C10_RBLN_API DeviceProperties get_device_properties(c10::DeviceIndex device_index);
+
+/**
  * @brief Returns the currently active RBLN device.
  *
  * This function retrieves the device that is currently set as the active

--- a/constraints-build-dev.txt
+++ b/constraints-build-dev.txt
@@ -1,2 +1,2 @@
 # Build/dev dependency constraints (single source of truth).
-rebel-compiler==0.11.3.dev266+g140f8fa1.prod
+rebel-compiler==0.11.3a1.dev257+g1d8d1065.prod

--- a/test/rbln/test_device_properties.py
+++ b/test/rbln/test_device_properties.py
@@ -7,23 +7,12 @@ Test suite for torch.rbln.get_device_properties / get_device_name.
 import os
 import subprocess
 import sys
-from pathlib import Path
 
 import pytest
 import torch
 from torch.testing._internal.common_utils import run_tests, TestCase
 
-import torch_rbln._C
-
 from ..utils import requires_physical_devices
-
-
-def _sysfs_dram_total(system_device_id):
-    """The driver's own capacity figure for one NPU, or None when sysfs is not readable."""
-    path = Path(f"/sys/class/rebellions/rbln{system_device_id}/dram_total")
-    if not path.exists():
-        return None
-    return int(path.read_text().strip())
 
 
 @pytest.mark.test_set_ci
@@ -37,23 +26,6 @@ class TestDeviceProperties(TestCase):
         self.assertGreater(props.memory_per_chiplet, 0)
         # Reporting the per-chiplet figure as the total understates REBEL 4x, unnoticed on ATOM.
         self.assertEqual(props.total_memory, props.memory_per_chiplet * props.num_chiplet * props.npu_count)
-
-    def test_total_memory_matches_the_driver(self):
-        """dram_total is the driver's own aggregate: an independent check of the summed total."""
-        # The topology reports the ids RBLN_DEVICES leaves visible, while sysfs is named by
-        # system id. The two coincide only under the identity mapping, so this cannot line the
-        # two up when RBLN_DEVICES is set.
-        if os.environ.get("RBLN_DEVICES") or os.environ.get("RBLN_VISIBLE_DEVICES"):
-            self.skipTest("RBLN_DEVICES remaps the ids sysfs is named by")
-
-        entry = next(e for e in torch_rbln._C._get_device_topology().entries if e.logical_device_index == 0)
-        per_npu = [_sysfs_dram_total(pid) for pid in entry.physical_device_ids]
-        if any(total is None for total in per_npu):
-            self.skipTest("/sys/class/rebellions/rbln*/dram_total is not readable on this host")
-
-        props = torch.rbln.get_device_properties(0)
-        self.assertEqual(props.npu_count, len(per_npu))
-        self.assertEqual(props.total_memory, sum(per_npu))
 
     def test_get_device_name_matches_properties(self):
         self.assertEqual(torch.rbln.get_device_name(0), torch.rbln.get_device_properties(0).name)
@@ -126,7 +98,6 @@ print(props.npu_count, props.total_memory, props.memory_per_chiplet, props.num_c
         script = """
 import torch
 import torch_rbln
-import torch_rbln._C
 
 entry = torch_rbln._C._get_device_topology().entries[0]
 print(torch.rbln.device_count(), list(entry.physical_device_ids), torch.rbln.get_device_properties(0).name)

--- a/test/rbln/test_device_properties.py
+++ b/test/rbln/test_device_properties.py
@@ -1,0 +1,162 @@
+# Owner(s): ["module: PrivateUse1"]
+
+"""
+Test suite for torch.rbln.get_device_properties / get_device_name.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+import torch_rbln._C
+
+from ..utils import requires_physical_devices
+
+
+def _sysfs_dram_total(system_device_id):
+    """The driver's own capacity figure for one NPU, or None when sysfs is not readable."""
+    path = Path(f"/sys/class/rebellions/rbln{system_device_id}/dram_total")
+    if not path.exists():
+        return None
+    return int(path.read_text().strip())
+
+
+@pytest.mark.test_set_ci
+class TestDeviceProperties(TestCase):
+    def test_properties_report_hardware(self):
+        props = torch.rbln.get_device_properties(0)
+
+        self.assertRegex(props.name, r"^RBLN-C[AIR]\d\d$")
+        self.assertGreaterEqual(props.num_chiplet, 1)
+        self.assertGreaterEqual(props.npu_count, 1)
+        self.assertGreater(props.memory_per_chiplet, 0)
+        # Reporting the per-chiplet figure as the total understates REBEL 4x, unnoticed on ATOM.
+        self.assertEqual(props.total_memory, props.memory_per_chiplet * props.num_chiplet * props.npu_count)
+
+    def test_total_memory_matches_the_driver(self):
+        """dram_total is the driver's own aggregate: an independent check of the summed total."""
+        # The topology reports the ids RBLN_DEVICES leaves visible, while sysfs is named by
+        # system id. The two coincide only under the identity mapping, so this cannot line the
+        # two up when RBLN_DEVICES is set.
+        if os.environ.get("RBLN_DEVICES") or os.environ.get("RBLN_VISIBLE_DEVICES"):
+            self.skipTest("RBLN_DEVICES remaps the ids sysfs is named by")
+
+        entry = next(e for e in torch_rbln._C._get_device_topology().entries if e.logical_device_index == 0)
+        per_npu = [_sysfs_dram_total(pid) for pid in entry.physical_device_ids]
+        if any(total is None for total in per_npu):
+            self.skipTest("/sys/class/rebellions/rbln*/dram_total is not readable on this host")
+
+        props = torch.rbln.get_device_properties(0)
+        self.assertEqual(props.npu_count, len(per_npu))
+        self.assertEqual(props.total_memory, sum(per_npu))
+
+    def test_get_device_name_matches_properties(self):
+        self.assertEqual(torch.rbln.get_device_name(0), torch.rbln.get_device_properties(0).name)
+
+    def test_device_argument_forms(self):
+        expected = torch.rbln.get_device_properties(0).total_memory
+        for device in (0, "rbln:0", torch.device("rbln", 0)):
+            with self.subTest(device=device):
+                self.assertEqual(torch.rbln.get_device_properties(device).total_memory, expected)
+
+    def test_omitted_device_is_the_current_device(self):
+        torch.rbln.set_device(0)
+        self.assertEqual(torch.rbln.get_device_properties().name, torch.rbln.get_device_properties(0).name)
+
+    def test_rejects_a_non_rbln_device(self):
+        with self.assertRaisesRegex(ValueError, "Expected rbln device"):
+            torch.rbln.get_device_properties("cpu")
+
+    def test_rejects_an_out_of_range_device(self):
+        out_of_range = torch.rbln.device_count()
+        with self.assertRaises(RuntimeError):
+            torch.rbln.get_device_properties(out_of_range)
+
+
+def _run_in_subprocess(env_vars, script):
+    env = dict(os.environ)
+    for key in ("RBLN_DEVICE_MAP", "RBLN_NPUS_PER_DEVICE", "RBLN_DEVICES"):
+        env.pop(key, None)
+    env.update(env_vars)
+    return subprocess.run([sys.executable, "-c", script], capture_output=True, text=True, env=env)
+
+
+@pytest.mark.test_set_ci
+class TestDevicePropertiesEnvVars(TestCase):
+    """Cases that need the device mapping set before import, so they run in a subprocess."""
+
+    @requires_physical_devices(2)
+    def test_an_aggregated_device_sums_its_npus(self):
+        """With two NPUs behind rbln:0, total_memory doubles while the per-chiplet figure does not."""
+        script = """
+import torch
+import torch_rbln
+
+props = torch.rbln.get_device_properties(0)
+print(props.npu_count, props.total_memory, props.memory_per_chiplet, props.num_chiplet)
+"""
+        one = _run_in_subprocess({}, script)
+        two = _run_in_subprocess({"RBLN_NPUS_PER_DEVICE": "2"}, script)
+        self.assertEqual(one.returncode, 0, one.stderr)
+        self.assertEqual(two.returncode, 0, two.stderr)
+
+        one_count, one_total, one_per_chiplet, one_chiplets = map(int, one.stdout.split()[-4:])
+        two_count, two_total, two_per_chiplet, two_chiplets = map(int, two.stdout.split()[-4:])
+
+        self.assertEqual((one_count, two_count), (1, 2))
+        self.assertEqual(two_total, one_total * 2)
+        self.assertEqual(two_per_chiplet, one_per_chiplet)
+        self.assertEqual(two_chiplets, one_chiplets)
+
+    @requires_physical_devices(2)
+    def test_a_narrowed_pool_is_not_remapped_twice(self):
+        """RBLN_VISIBLE_DEVICES renumbers the pool from 0, and the query resolves that once.
+
+        The topology reports pool ids while the runtime query resolves a pool id to a system
+        id, so passing an already-resolved id would either read another card or fall off the
+        end of the mapping. Hiding all but the last NPU makes the difference visible: the pool
+        holds one device at index 0, whose system id is the highest on the host.
+        """
+        last = torch.rbln.physical_device_count() - 1
+        script = """
+import torch
+import torch_rbln
+import torch_rbln._C
+
+entry = torch_rbln._C._get_device_topology().entries[0]
+print(torch.rbln.device_count(), list(entry.physical_device_ids), torch.rbln.get_device_properties(0).name)
+"""
+        result = _run_in_subprocess({"RBLN_VISIBLE_DEVICES": str(last)}, script)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+        count, physical_ids, name = result.stdout.split()[-3:]
+        self.assertEqual(count, "1")
+        self.assertEqual(physical_ids, "[0]")
+        self.assertRegex(name, r"^RBLN-C[AIR]\d\d$")
+
+    def test_dummy_device_is_rejected(self):
+        """Dummy mode is host-backed with no NPU, so there is nothing to report."""
+        script = """
+import torch
+import torch_rbln
+
+try:
+    torch.rbln.get_device_properties(0)
+except RuntimeError as err:
+    print("RAISED", err)
+else:
+    print("NO RAISE")
+"""
+        result = _run_in_subprocess({"RBLN_DUMMY_DEVICE": "1"}, script)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("RAISED", result.stdout)
+        self.assertIn("RBLN_DUMMY_DEVICE", result.stdout)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch_rbln/csrc/rbln/Module.cpp
+++ b/torch_rbln/csrc/rbln/Module.cpp
@@ -109,6 +109,30 @@ void register_public_device_api(py::module_& module) {
       "reset_accumulated_memory_stats", &c10::rbln::reset_accumulated_memory_stats, "Reset accumulated memory stats.");
   module.def("reset_peak_memory_stats", &c10::rbln::reset_peak_memory_stats, "Reset peak memory stats.");
 
+  py::class_<c10::rbln::DeviceProperties>(module, "DeviceProperties")
+      .def_readonly("name", &c10::rbln::DeviceProperties::name)
+      .def_readonly("total_memory", &c10::rbln::DeviceProperties::total_memory)
+      .def_readonly("memory_per_chiplet", &c10::rbln::DeviceProperties::memory_per_chiplet)
+      .def_readonly("num_chiplet", &c10::rbln::DeviceProperties::num_chiplet)
+      .def_readonly("npu_count", &c10::rbln::DeviceProperties::npu_count)
+      .def("__repr__", [](const c10::rbln::DeviceProperties& self) {
+        return c10::str(
+            "DeviceProperties(name='",
+            self.name,
+            "', total_memory=",
+            self.total_memory,
+            ", memory_per_chiplet=",
+            self.memory_per_chiplet,
+            ", num_chiplet=",
+            self.num_chiplet,
+            ", npu_count=",
+            self.npu_count,
+            ")");
+      });
+
+  module.def(
+      "get_device_properties", &c10::rbln::get_device_properties, "Get the hardware properties of a logical device.");
+
   // Register DeviceTopology structures
   py::class_<c10::rbln::DeviceTopologyEntry>(module, "DeviceTopologyEntry")
       .def_property_readonly("logical_device_index", &c10::rbln::DeviceTopologyEntry::getLogicalDeviceIndex)

--- a/torch_rbln/device/device.py
+++ b/torch_rbln/device/device.py
@@ -23,6 +23,8 @@ __all__ = [
     "is_dummy_device",
     "is_initialized",
     "get_amp_supported_dtype",
+    "get_device_properties",
+    "get_device_name",
     "set_device",
     "synchronize",
     "device",
@@ -141,6 +143,43 @@ def get_amp_supported_dtype() -> List[torch.dtype]:
         List[torch.dtype]: A list of data types supported by AMP.
     """
     return list(SupportedDtypes.amp)
+
+
+def get_device_properties(
+    device: Union[int, torch.device, str, None] = None,
+) -> torch_rbln._C.DeviceProperties:
+    """What the NPUs behind an RBLN logical device are (``torch.cuda`` parity).
+
+    A logical device may span several physical NPUs (``RBLN_DEVICE_MAP`` /
+    ``RBLN_NPUS_PER_DEVICE``), so ``total_memory`` sums them and ``npu_count`` says how many.
+    ``num_chiplet`` and ``memory_per_chiplet`` stay per NPU: a device runs out on its heaviest
+    chiplet, which ``total_memory`` hides, so size a pool by ``memory_per_chiplet``.
+
+    Args:
+        device (torch.device or int or str, optional): The device to query. Defaults to the
+            current device.
+
+    Raises:
+        RuntimeError: in ``RBLN_DUMMY_DEVICE`` mode (host-backed, no NPU to report on), when no
+            NPU is mapped to the index, or when the runtime cannot answer for one of them.
+
+    Example::
+        >>> import torch
+        >>> torch.rbln.get_device_properties(0).total_memory
+        150323855360
+    """
+    device_idx = current_device() if device is None else _get_device_index(device)
+    return torch_rbln._C.get_device_properties(device_idx)
+
+
+def get_device_name(device: Union[int, torch.device, str, None] = None) -> str:
+    """The NPU name behind an RBLN logical device, e.g. ``"RBLN-CA25"`` (``torch.cuda`` parity).
+
+    Args:
+        device (torch.device or int or str, optional): The device to query. Defaults to the
+            current device.
+    """
+    return get_device_properties(device).name
 
 
 def synchronize(device: Union[int, torch.device, str, None] = None) -> None:


### PR DESCRIPTION
## Summary

Adds the RBLN equivalents of `torch.cuda.get_device_properties()` and
`torch.cuda.get_device_name()`:

```python
>>> torch.rbln.get_device_properties(0)
DeviceProperties(name='RBLN-CR13', total_memory=150323855360,
                 memory_per_chiplet=37580963840, num_chiplet=4, npu_count=1)
```

The returned properties describe one **logical** `rbln` device, which may span
multiple physical NPUs:

- `name`: NPU model name
- `total_memory`: total memory across all backing NPUs
- `memory_per_chiplet`: memory available to each chiplet
- `num_chiplet`: chiplets per NPU
- `npu_count`: physical NPUs backing the logical device

`memory_per_chiplet` remains separate from `total_memory` because memory pools
are constrained per chiplet, while capacity checks generally need the aggregate.

## Why the aggregation lives here

[`rbln_get_device_properties()`](https://github.com/RBLN-SW/rebel_compiler/pull/13614)
reports one physical NPU at a time. The logical-to-physical mapping belongs to
`DeviceMappingManager` in torch-rbln, so this layer:

1. resolves a logical device to its physical NPU IDs;
2. queries each NPU through the runtime API;
3. sums `total_memory`; and
4. preserves per-NPU values for `name`, `memory_per_chiplet`, and `num_chiplet`.

An aggregation with different NPU names or chiplet counts raises instead of
returning a misleading single set of properties.

The query does not allocate memory or claim a device. It is therefore safe to
use for capacity discovery before runtime initialization. Calls in
`RBLN_DUMMY_DEVICE` mode raise because no hardware exists to describe.

## Implementation

- Adds `c10::rbln::DeviceProperties` and logical-device aggregation.
- Exposes the properties object and query through pybind.
- Adds the public Python APIs with `int`, `str`, `torch.device`, and omitted
  device arguments.
- Updates the rebel-compiler pin to the merged runtime implementation. The new
  entry point requires ABI 5 and is covered by the existing ABI handshake.
- Adds focused tests for argument handling, current-device behavior, memory
  accounting, multi-NPU aggregation, narrowed visible-device pools, invalid
  indices, and dummy mode.

## Review guide

Suggested review order:

1. `c10/rbln/RBLNFunctions.{h,cpp}` — data model and aggregation semantics
2. `torch_rbln/csrc/rbln/Module.cpp` — Python binding
3. `torch_rbln/device/device.py` — public API and documentation
4. `test/rbln/test_device_properties.py` — edge cases and mapping regressions
5. `constraints-build-dev.txt` — runtime dependency pin

## Related work

- Runtime API: [RBLN-SW/rebel_compiler#13614](https://github.com/RBLN-SW/rebel_compiler/pull/13614)
- Per-chiplet memory reporting: [#191](https://github.com/RBLN-SW/torch-rbln/pull/191)

## Validation

```bash
uv run --no-sync pytest test/rbln/test_device_properties.py
uv run --no-sync python test/run_tests.py --suite=core
uv run --no-sync lintrunner -m origin/main
```

Validated on a CR13 8-card host:

- Targeted device-property tests passed.
- Core suite: 4,293 passed, 20 skipped, 3 xfailed, with one unrelated
  environment-specific failure in
  `test_rbln_runtime_lib.py::TestRblnRuntimeLibRecord::test_the_installed_library_is_under_its_recorded_directory`.
- Lint passed.

The regression tests specifically verify that:

- `total_memory == memory_per_chiplet * num_chiplet * npu_count`;
- aggregating two NPUs doubles only `total_memory` and `npu_count`; and
- an `RBLN_VISIBLE_DEVICES` pool ID is resolved exactly once.

## Design notes

- `num_chiplet` is per NPU. The logical device's total chiplet count is
  `num_chiplet * npu_count`.
- Properties are intentionally not cached. Each call performs one runtime query
  per backing NPU, avoiding stale results when device mappings change between
  processes or tests.

## Type of change

- [x] `feature` — New capability or functionality
- [x] `core` — RBLN backend, device layer, or C++ extension

## Affected modules

- [x] Device
- [x] C++ extension (`torch_rbln/csrc`)

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] This PR is linked to a corresponding issue — see [Contributing to torch-rbln](https://github.com/RBLN-SW/torch-rbln/blob/main/docs/CONTRIBUTING.md)
- [x] Linting passes — see [Linting](https://github.com/RBLN-SW/torch-rbln/blob/main/docs/LINTING.md)
- [ ] All CI tests pass — see [CI/CD Workflows](https://github.com/RBLN-SW/torch-rbln/blob/main/docs/WORKFLOWS.md)
- [x] The test method and expected result are described
- [ ] Relevant documentation has been updated (if applicable)
