### PR TITLE
fix(ci): isolate the lint uv cache per job and pin the inference stack from vllm-rbln's lock

### DIFF
--- a/.github/workflows/_lint-source.yaml
+++ b/.github/workflows/_lint-source.yaml
@@ -86,6 +86,13 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
 
+      # Concurrent matrix jobs on one runner share its home directory, and uv
+      # locks the source build of this project per cache entry: with the default
+      # timeout every job but the one holding the lock fails. A cache under the
+      # job's own temp directory keeps the jobs independent.
+      - name: Keep the uv cache private to this job
+        run: echo "UV_CACHE_DIR=${RUNNER_TEMP}/uv-cache" >> "${GITHUB_ENV}"
+
       - name: Install dependencies
         env:
           UV_INDEX: rbln=${{ secrets.INTERNAL_INDEX_URL }}

--- a/.github/workflows/_lint-source.yaml
+++ b/.github/workflows/_lint-source.yaml
@@ -86,10 +86,8 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
 
-      # Concurrent matrix jobs on one runner share its home directory, and uv
-      # locks the source build of this project per cache entry: with the default
-      # timeout every job but the one holding the lock fails. A cache under the
-      # job's own temp directory keeps the jobs independent.
+      # Matrix jobs share the runner's home directory, and uv's per-entry build
+      # lock then serialises them past its timeout.
       - name: Keep the uv cache private to this job
         run: echo "UV_CACHE_DIR=${RUNNER_TEMP}/uv-cache" >> "${GITHUB_ENV}"
 

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ uv.lock
 venv/
 .venv/
 .venv-inference/
+# default checkout location of tools/test/install-test-deps.sh
+/vllm-rbln/
 
 # Compiled objects & libraries
 *.o

--- a/docs/TEST_GUIDE.md
+++ b/docs/TEST_GUIDE.md
@@ -211,6 +211,16 @@ python -m pytest test/rbln/test_graph_eager_mode.py -s -v -x
 UV=1 ./tools/test/install-test-deps.sh
 ```
 
+The inference venv is installed `--no-deps` from `tools/test/requirements-inference.txt`,
+a pinned export of vllm-rbln's `uv.lock` at the commit recorded in that file. torch and
+torch-rbln are absent from it on purpose: the venv shares the test venv's copies, and the
+installer verifies that nothing replaced them. To move the suite to another vllm-rbln
+commit, regenerate the file and review the diff:
+
+```bash
+VLLM_RBLN_REF=<ref> ./tools/test/export-inference-requirements.sh   # needs uv
+```
+
 ### C++ Tests
 
 C++ tests use [Google Test](https://google.github.io/googletest/). They are compiled during the editable install and run via CTest:

--- a/docs/TEST_GUIDE.md
+++ b/docs/TEST_GUIDE.md
@@ -212,10 +212,8 @@ UV=1 ./tools/test/install-test-deps.sh
 ```
 
 The inference venv is installed `--no-deps` from `tools/test/requirements-inference.txt`,
-a pinned export of vllm-rbln's `uv.lock` at the commit recorded in that file. torch and
-torch-rbln are absent from it on purpose: the venv shares the test venv's copies, and the
-installer verifies that nothing replaced them. To move the suite to another vllm-rbln
-commit, regenerate the file and review the diff:
+an export of vllm-rbln's `uv.lock` (minus torch and torch-rbln, which the venv shares with
+the test venv). To move to another vllm-rbln commit:
 
 ```bash
 VLLM_RBLN_REF=<ref> ./tools/test/export-inference-requirements.sh   # needs uv

--- a/test/models/test_vllm_llm.py
+++ b/test/models/test_vllm_llm.py
@@ -12,8 +12,8 @@ hard-coded expected strings.
 
 Environment requirements
 ------------------------
-* ``vllm-rbln`` installed on ``origin/ci/torch-rbln-model-tests`` (what
-  ``tools/test/install-test-deps.sh`` checks out, into ``.venv-inference``;
+* ``vllm-rbln`` at the commit recorded in ``tools/test/requirements-inference.txt``
+  (what ``tools/test/install-test-deps.sh`` checks out, into ``.venv-inference``;
   ``test/run_tests.py`` runs this file with that interpreter).
 
 Matrix

--- a/tools/test/export-inference-requirements.sh
+++ b/tools/test/export-inference-requirements.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# =============================================================================
+# export-inference-requirements.sh — Refresh tools/test/requirements-inference.txt
+# =============================================================================
+#
+# The inference venv that install-test-deps.sh builds for test_vllm_llm.py and
+# test_optimum_llm.py is installed from a pinned requirements file, not from a
+# dependency resolution at install time. This script produces that file from
+# vllm-rbln's own uv.lock at a chosen ref, so the stack under test is exactly
+# the one vllm-rbln tests itself with, and a change to it is a reviewable diff.
+#
+# torch and torch-rbln are left out of the export: the inference venv shares
+# the test venv's copies, and a listed pin would make pip replace the package
+# under test (vllm's own requirement on torch names the release wheel, which a
+# locally built or debug torch never matches). install-test-deps.sh refuses a
+# file that lists either.
+#
+# Usage:
+#   ./tools/test/export-inference-requirements.sh
+#
+# Requires ``uv`` (vllm-rbln's pyproject states the minimum version).
+#
+# Optional environment (shared with install-test-deps.sh):
+#   VLLM_RBLN_REPO       Source repo (default rbln-sw/vllm-rbln).
+#   VLLM_RBLN_REF        Ref to export from (default origin/ci/torch-rbln-model-tests).
+#                        The resolved commit is recorded in the output file and
+#                        is what install-test-deps.sh checks out.
+#   VLLM_RBLN_DIR        Local checkout path (default ``$PROJECT_ROOT/vllm-rbln``).
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(realpath "$(dirname "$0")")"
+readonly SCRIPT_DIR
+PROJECT_ROOT="$(realpath "${SCRIPT_DIR}/../..")"
+readonly PROJECT_ROOT
+OUTPUT="${SCRIPT_DIR}/requirements-inference.txt"
+readonly OUTPUT
+
+repo="${VLLM_RBLN_REPO:-https://github.com/rbln-sw/vllm-rbln.git}"
+ref="${VLLM_RBLN_REF:-origin/ci/torch-rbln-model-tests}"
+dir="${VLLM_RBLN_DIR:-${PROJECT_ROOT}/vllm-rbln}"
+
+# A worktree keeps .git as a file, so ask git rather than test for a directory.
+if ! git -C "${dir}" rev-parse --git-dir >/dev/null 2>&1; then
+  echo "Cloning ${repo} into ${dir}..."
+  git clone "${repo}" "${dir}"
+fi
+echo "Checking out ${ref} in ${dir}..."
+(cd "${dir}" && git fetch origin --prune && git checkout --detach "${ref}")
+commit="$(git -C "${dir}" rev-parse HEAD)"
+readonly commit
+
+tmp="$(mktemp)"
+trap 'rm -f "${tmp}"' EXIT
+
+# --frozen: the lock is vllm-rbln's statement of record; do not re-resolve it.
+# --emit-index-url: the +cpu wheels live on the vLLM and PyTorch indexes, and
+#   pip reads the index options from the requirements file itself.
+(cd "${dir}" && uv export \
+  --frozen \
+  --no-hashes \
+  --no-emit-project \
+  --no-default-groups \
+  --no-editable \
+  --emit-index-url \
+  --no-emit-package torch \
+  --no-emit-package torch-rbln \
+  --output-file "${tmp}")
+
+{
+  echo "# Inference-stack requirements for test/models/test_vllm_llm.py and"
+  echo "# test/models/test_optimum_llm.py (installed into the inference venv by"
+  echo "# tools/test/install-test-deps.sh, --no-deps)."
+  echo "#"
+  echo "# Exported from vllm-rbln's uv.lock. Do not edit by hand; regenerate with"
+  echo "#   tools/test/export-inference-requirements.sh"
+  echo "# vllm-rbln-repo: ${repo}"
+  echo "# vllm-rbln-ref: ${commit}"
+  echo "#"
+  echo "# torch and torch-rbln are deliberately absent: the inference venv shares the"
+  echo "# test venv's copies (see install-test-deps.sh, step 4)."
+  echo
+  # uv writes its own two-line banner (with this machine's temp path) first;
+  # the header above replaces it. Internal mirrors are for developers' own
+  # pip configuration, not for a file external users install from.
+  grep -vE '^#|nexus\.mgmt\.rbln\.in' "${tmp}"
+} > "${OUTPUT}"
+
+if grep -qE '^(torch|torch-rbln)==' "${OUTPUT}"; then
+  echo "export still lists torch or torch-rbln; refusing to write ${OUTPUT}" >&2
+  exit 1
+fi
+
+echo "Wrote ${OUTPUT} from vllm-rbln ${commit}"

--- a/tools/test/export-inference-requirements.sh
+++ b/tools/test/export-inference-requirements.sh
@@ -3,63 +3,44 @@
 # export-inference-requirements.sh — Refresh tools/test/requirements-inference.txt
 # =============================================================================
 #
-# The inference venv that install-test-deps.sh builds for test_vllm_llm.py and
-# test_optimum_llm.py is installed from a pinned requirements file, not from a
-# dependency resolution at install time. This script produces that file from
-# vllm-rbln's own uv.lock at a chosen ref, so the stack under test is exactly
-# the one vllm-rbln tests itself with, and a change to it is a reviewable diff.
-#
-# torch and torch-rbln are left out of the export: the inference venv shares
-# the test venv's copies, and a listed pin would make pip replace the package
-# under test (vllm's own requirement on torch names the release wheel, which a
-# locally built or debug torch never matches). install-test-deps.sh refuses a
-# file that lists either.
+# Exports vllm-rbln's uv.lock at a ref into the pinned requirements file that
+# install-test-deps.sh installs (--no-deps) into the inference venv. torch and
+# torch-rbln are left out: the inference venv shares the test venv's copies.
 #
 # Usage:
-#   ./tools/test/export-inference-requirements.sh
+#   ./tools/test/export-inference-requirements.sh        (needs uv)
 #
-# Requires ``uv`` (vllm-rbln's pyproject states the minimum version).
-#
-# Optional environment (shared with install-test-deps.sh):
-#   VLLM_RBLN_REPO       Source repo (default rbln-sw/vllm-rbln).
-#   VLLM_RBLN_REF        Ref to export from (default origin/ci/torch-rbln-model-tests).
-#                        The resolved commit is recorded in the output file and
-#                        is what install-test-deps.sh checks out.
-#   VLLM_RBLN_DIR        Local checkout path (default ``$PROJECT_ROOT/vllm-rbln``).
+# Optional environment (as in install-test-deps.sh):
+#   VLLM_RBLN_REPO / VLLM_RBLN_REF / VLLM_RBLN_DIR
+#   The default ref is origin/ci/torch-rbln-model-tests; the resolved commit
+#   is recorded in the output and is what install-test-deps.sh checks out.
 # =============================================================================
 
 set -euo pipefail
 
 SCRIPT_DIR="$(realpath "$(dirname "$0")")"
-readonly SCRIPT_DIR
 PROJECT_ROOT="$(realpath "${SCRIPT_DIR}/../..")"
-readonly PROJECT_ROOT
 OUTPUT="${SCRIPT_DIR}/requirements-inference.txt"
-readonly OUTPUT
 
 repo="${VLLM_RBLN_REPO:-https://github.com/rbln-sw/vllm-rbln.git}"
 ref="${VLLM_RBLN_REF:-origin/ci/torch-rbln-model-tests}"
 dir="${VLLM_RBLN_DIR:-${PROJECT_ROOT}/vllm-rbln}"
 
-# A worktree keeps .git as a file, so ask git rather than test for a directory.
 if ! git -C "${dir}" rev-parse --git-dir >/dev/null 2>&1; then
-  echo "Cloning ${repo} into ${dir}..."
   git clone "${repo}" "${dir}"
 fi
-echo "Checking out ${ref} in ${dir}..."
 (cd "${dir}" && git fetch origin --prune && git checkout --detach "${ref}")
 commit="$(git -C "${dir}" rev-parse HEAD)"
-readonly commit
 
 tmp="$(mktemp)"
 trap 'rm -f "${tmp}"' EXIT
 
-# --frozen: the lock is vllm-rbln's statement of record; do not re-resolve it.
-# --emit-index-url: the +cpu wheels live on the vLLM and PyTorch indexes, and
-#   pip reads the index options from the requirements file itself.
+# --locked fails if vllm-rbln's lock is out of date with its pyproject at this
+# ref. pip reads the emitted index options from the requirements file.
 (cd "${dir}" && uv export \
-  --frozen \
+  --locked \
   --no-hashes \
+  --no-annotate \
   --no-emit-project \
   --no-default-groups \
   --no-editable \
@@ -69,21 +50,13 @@ trap 'rm -f "${tmp}"' EXIT
   --output-file "${tmp}")
 
 {
-  echo "# Inference-stack requirements for test/models/test_vllm_llm.py and"
-  echo "# test/models/test_optimum_llm.py (installed into the inference venv by"
-  echo "# tools/test/install-test-deps.sh, --no-deps)."
-  echo "#"
-  echo "# Exported from vllm-rbln's uv.lock. Do not edit by hand; regenerate with"
-  echo "#   tools/test/export-inference-requirements.sh"
+  echo "# Inference venv requirements, exported from vllm-rbln's uv.lock."
+  echo "# Regenerate with tools/test/export-inference-requirements.sh; do not edit."
   echo "# vllm-rbln-repo: ${repo}"
   echo "# vllm-rbln-ref: ${commit}"
-  echo "#"
-  echo "# torch and torch-rbln are deliberately absent: the inference venv shares the"
-  echo "# test venv's copies (see install-test-deps.sh, step 4)."
+  echo "# torch and torch-rbln are omitted: the inference venv shares the test venv's."
   echo
-  # uv writes its own two-line banner (with this machine's temp path) first;
-  # the header above replaces it. Internal mirrors are for developers' own
-  # pip configuration, not for a file external users install from.
+  # Drop uv's banner and the internal mirror; external users install from this file.
   grep -vE '^#|nexus\.mgmt\.rbln\.in' "${tmp}"
 } > "${OUTPUT}"
 
@@ -91,5 +64,4 @@ if grep -qE '^(torch|torch-rbln)==' "${OUTPUT}"; then
   echo "export still lists torch or torch-rbln; refusing to write ${OUTPUT}" >&2
   exit 1
 fi
-
 echo "Wrote ${OUTPUT} from vllm-rbln ${commit}"

--- a/tools/test/install-test-deps.sh
+++ b/tools/test/install-test-deps.sh
@@ -22,12 +22,9 @@
 #                      test_vllm_llm.py with this venv's interpreter. The venv
 #                      sees the test venv's site-packages (torch, torch-rbln,
 #                      rebel-compiler, pytest) through a .pth file and adds
-#                      only the stack on top, installed --no-deps from the
-#                      pinned tools/test/requirements-inference.txt (exported
-#                      from vllm-rbln's uv.lock; see
-#                      export-inference-requirements.sh). The packages under
-#                      test must stay the test venv's copies, so the install
-#                      is verified against that before the script exits.
+#                      only the stack on top, --no-deps from the pinned
+#                      requirements-inference.txt. The install is verified
+#                      to have left the shared packages alone.
 #
 # Usage:
 #   ./tools/test/install-test-deps.sh [--dry-run]
@@ -36,8 +33,7 @@
 #   UV=1                 Use ``uv pip install`` instead of ``python -m pip``.
 #   VLLM_RBLN_REPO       Override the source repo (default rbln-sw/vllm-rbln).
 #   VLLM_RBLN_REF        Override the ref (default: the commit recorded in
-#                        tools/test/requirements-inference.txt, which the
-#                        pins were exported from).
+#                        requirements-inference.txt).
 #   VLLM_RBLN_DIR        Override the local checkout path
 #                        (default ``$PROJECT_ROOT/vllm-rbln``).
 #   INFERENCE_VENV       Override the inference-stack venv path
@@ -136,25 +132,19 @@ install_model_test_deps() {
 # The stack goes into its own venv because it pins transformers 5 (see step 3).
 # The venv layers on this interpreter's site-packages through a .pth file, so
 # torch, torch-rbln, rebel-compiler and pytest are shared and only vllm-rbln
-# plus its runtime dependencies (optimum-rbln among them) are added.
-#
-# Those dependencies come from requirements-inference.txt, a pinned export of
-# vllm-rbln's uv.lock with torch and torch-rbln removed, and are installed
-# --no-deps. No resolver runs, so no requirement at any depth can reach the
-# shared packages: vllm's own pin on torch names the release wheel, and a
-# resolving install replaces a locally built or debug torch with it. The
-# editable vllm-rbln install is --no-deps for the same reason (it bounds
-# torch-rbln to a release line a nightly does not satisfy).
+# plus its dependencies are added, --no-deps from requirements-inference.txt
+# (vllm-rbln's uv.lock minus torch and torch-rbln). With no resolver running,
+# no requirement at any depth can replace the shared packages: vllm pins the
+# release torch wheel, which a debug or locally built torch does not match.
 
 REQUIREMENTS_INFERENCE="${SCRIPT_DIR}/requirements-inference.txt"
 readonly REQUIREMENTS_INFERENCE
 
-# The commit the pins were exported from, recorded by export-inference-requirements.sh.
 recorded_vllm_rbln_ref() {
   local ref
   ref="$(sed -nE 's/^# vllm-rbln-ref: ([0-9a-f]+)$/\1/p' "${REQUIREMENTS_INFERENCE}")"
   if [[ -z "${ref}" ]]; then
-    echo "${REQUIREMENTS_INFERENCE} records no vllm-rbln-ref; regenerate it with export-inference-requirements.sh" >&2
+    echo "${REQUIREMENTS_INFERENCE} records no vllm-rbln-ref; run export-inference-requirements.sh" >&2
     return 1
   fi
   echo "${ref}"
@@ -170,10 +160,8 @@ install_vllm_rbln() {
 
   log_step "Inference stack: vllm-rbln (clone + editable install at ${ref}) into ${venv}"
 
-  # The export drops these; a hand edit that brings one back would make pip
-  # install a second copy next to the package under test.
   if grep -qE '^(torch|torch-rbln)==' "${REQUIREMENTS_INFERENCE}"; then
-    echo "${REQUIREMENTS_INFERENCE} lists torch or torch-rbln; regenerate it with export-inference-requirements.sh" >&2
+    echo "${REQUIREMENTS_INFERENCE} lists torch or torch-rbln; run export-inference-requirements.sh" >&2
     return 1
   fi
 
@@ -205,7 +193,6 @@ pathlib.Path(child, "torch-rbln-test-venv.pth").write_text(
 PY
   fi
 
-  # A worktree keeps .git as a file, so ask git rather than test for a directory.
   if ! git -C "${dir}" rev-parse --git-dir >/dev/null 2>&1; then
     echo "Cloning ${repo} into ${dir}..."
     run git clone "${repo}" "${dir}"
@@ -217,9 +204,8 @@ PY
     (cd "${dir}" && git fetch origin --prune && git checkout --detach "${ref}")
   fi
 
-  # The inference venv's own pip, never uv, whatever UV is set to: the index
-  # options are read from the requirements file, and pip's view of the .pth
-  # layering is what verify_shared_packages checks afterwards.
+  # The inference venv's own pip, whatever UV is set to; the index options are
+  # in the requirements file.
   run "${py}" -m pip install --no-deps --requirement "${REQUIREMENTS_INFERENCE}"
   run "${py}" -m pip install -e "${dir}" --no-deps
 
@@ -261,7 +247,7 @@ for name in ("torch", "torch_rbln", "rebel", "transformers"):
     else:
         path = getattr(mod, "__file__", "") or ""
         out[name] = [getattr(mod, "__version__", None), os.path.realpath(path) if path else ""]
-# Distributions installed in this interpreter's own site-packages (not through a .pth).
+# Distributions in this interpreter's own site-packages, not via a .pth.
 purelib = os.path.realpath(sysconfig.get_paths()["purelib"])
 own = sorted(
     dist.metadata["Name"]
@@ -295,8 +281,8 @@ for name in ("torch", "torch_rbln", "rebel"):
     if here[name][0] is not None and version != here[name][0]:
         problems.append("{}: {} in the inference venv, {} here".format(name, version, here[name][0]))
 
-# An import can resolve to the shared copy while a second distribution sits in
-# the venv (a broken or half-installed one, or a later import order): refuse it.
+# A second distribution in the venv is wrong even while the import still resolves
+# to the shared copy.
 own = {n.lower().replace("_", "-") for n in child["_own_distributions"]}
 for name in ("torch", "torch-rbln"):
     if name in own:

--- a/tools/test/install-test-deps.sh
+++ b/tools/test/install-test-deps.sh
@@ -22,9 +22,12 @@
 #                      test_vllm_llm.py with this venv's interpreter. The venv
 #                      sees the test venv's site-packages (torch, torch-rbln,
 #                      rebel-compiler, pytest) through a .pth file and adds
-#                      only the stack on top. The packages under test must stay
-#                      the test venv's copies, so the install is verified
-#                      against that before the script exits.
+#                      only the stack on top, installed --no-deps from the
+#                      pinned tools/test/requirements-inference.txt (exported
+#                      from vllm-rbln's uv.lock; see
+#                      export-inference-requirements.sh). The packages under
+#                      test must stay the test venv's copies, so the install
+#                      is verified against that before the script exits.
 #
 # Usage:
 #   ./tools/test/install-test-deps.sh [--dry-run]
@@ -32,7 +35,9 @@
 # Optional environment:
 #   UV=1                 Use ``uv pip install`` instead of ``python -m pip``.
 #   VLLM_RBLN_REPO       Override the source repo (default rbln-sw/vllm-rbln).
-#   VLLM_RBLN_REF        Override the ref (default origin/ci/torch-rbln-model-tests).
+#   VLLM_RBLN_REF        Override the ref (default: the commit recorded in
+#                        tools/test/requirements-inference.txt, which the
+#                        pins were exported from).
 #   VLLM_RBLN_DIR        Override the local checkout path
 #                        (default ``$PROJECT_ROOT/vllm-rbln``).
 #   INFERENCE_VENV       Override the inference-stack venv path
@@ -131,50 +136,46 @@ install_model_test_deps() {
 # The stack goes into its own venv because it pins transformers 5 (see step 3).
 # The venv layers on this interpreter's site-packages through a .pth file, so
 # torch, torch-rbln, rebel-compiler and pytest are shared and only vllm-rbln
-# plus its runtime dependencies (optimum-rbln among them) are added. Those
-# dependencies are read from vllm-rbln's pyproject.toml so nothing is re-pinned
-# here. torch-rbln and torch are left out and the editable install is
-# ``--no-deps``: vllm-rbln bounds torch-rbln to a release line that a nightly or
-# editable torch-rbln does not satisfy, and a resolving install would replace
-# the package under test.
+# plus its runtime dependencies (optimum-rbln among them) are added.
+#
+# Those dependencies come from requirements-inference.txt, a pinned export of
+# vllm-rbln's uv.lock with torch and torch-rbln removed, and are installed
+# --no-deps. No resolver runs, so no requirement at any depth can reach the
+# shared packages: vllm's own pin on torch names the release wheel, and a
+# resolving install replaces a locally built or debug torch with it. The
+# editable vllm-rbln install is --no-deps for the same reason (it bounds
+# torch-rbln to a release line a nightly does not satisfy).
 
-vllm_wheel_index_from_pyproject() {
-  # Read the vllm-cpu index URL out of vllm-rbln's pyproject.toml so we don't
-  # have to keep a separate vllm version pinned in this script.
-  local pyproject="$1"
-  python - "${pyproject}" <<'PY'
-import sys, tomllib, pathlib
-data = tomllib.loads(pathlib.Path(sys.argv[1]).read_text())
-for idx in data.get("tool", {}).get("uv", {}).get("index", []):
-    if idx.get("name") == "vllm-cpu":
-        print(idx["url"])
-        sys.exit(0)
-sys.exit(f"vllm-cpu index URL not found in {sys.argv[1]}")
-PY
-}
+REQUIREMENTS_INFERENCE="${SCRIPT_DIR}/requirements-inference.txt"
+readonly REQUIREMENTS_INFERENCE
 
-vllm_rbln_runtime_deps() {
-  # One requirement per line, environment markers kept.
-  local pyproject="$1"
-  python - "${pyproject}" <<'PY'
-import re, sys, tomllib, pathlib
-data = tomllib.loads(pathlib.Path(sys.argv[1]).read_text())
-skip = {"torch-rbln", "torch"}
-for req in data["project"]["dependencies"]:
-    name = re.split(r"[\s\[<>=!~;]", req.strip(), maxsplit=1)[0].lower().replace("_", "-")
-    if name not in skip:
-        print(req)
-PY
+# The commit the pins were exported from, recorded by export-inference-requirements.sh.
+recorded_vllm_rbln_ref() {
+  local ref
+  ref="$(sed -nE 's/^# vllm-rbln-ref: ([0-9a-f]+)$/\1/p' "${REQUIREMENTS_INFERENCE}")"
+  if [[ -z "${ref}" ]]; then
+    echo "${REQUIREMENTS_INFERENCE} records no vllm-rbln-ref; regenerate it with export-inference-requirements.sh" >&2
+    return 1
+  fi
+  echo "${ref}"
 }
 
 install_vllm_rbln() {
   local repo="${VLLM_RBLN_REPO:-https://github.com/rbln-sw/vllm-rbln.git}"
-  local ref="${VLLM_RBLN_REF:-origin/ci/torch-rbln-model-tests}"
+  local ref
+  ref="${VLLM_RBLN_REF:-$(recorded_vllm_rbln_ref)}"
   local dir="${VLLM_RBLN_DIR:-${PROJECT_ROOT}/vllm-rbln}"
   local venv="${INFERENCE_VENV:-${PROJECT_ROOT}/.venv-inference}"
   local py="${venv}/bin/python"
 
   log_step "Inference stack: vllm-rbln (clone + editable install at ${ref}) into ${venv}"
+
+  # The export drops these; a hand edit that brings one back would make pip
+  # install a second copy next to the package under test.
+  if grep -qE '^(torch|torch-rbln)==' "${REQUIREMENTS_INFERENCE}"; then
+    echo "${REQUIREMENTS_INFERENCE} lists torch or torch-rbln; regenerate it with export-inference-requirements.sh" >&2
+    return 1
+  fi
 
   if [[ ! -x "${py}" ]]; then
     run python -m venv "${venv}"
@@ -204,7 +205,8 @@ pathlib.Path(child, "torch-rbln-test-venv.pth").write_text(
 PY
   fi
 
-  if [[ ! -d "${dir}/.git" ]]; then
+  # A worktree keeps .git as a file, so ask git rather than test for a directory.
+  if ! git -C "${dir}" rev-parse --git-dir >/dev/null 2>&1; then
     echo "Cloning ${repo} into ${dir}..."
     run git clone "${repo}" "${dir}"
   fi
@@ -215,33 +217,10 @@ PY
     (cd "${dir}" && git fetch origin --prune && git checkout --detach "${ref}")
   fi
 
-  local vllm_index
-  if [[ "${DRY_RUN}" -eq 1 ]]; then
-    vllm_index="<resolved-from-pyproject-at-runtime>"
-  else
-    vllm_index="$(vllm_wheel_index_from_pyproject "${dir}/pyproject.toml")"
-    echo "Resolved vllm wheel index from vllm-rbln pyproject: ${vllm_index}"
-  fi
-
-  # The rbln index resolves vllm-rbln's ``optimum-rbln`` pin; ordinary PyPI
-  # packages come from the default index.
-  local -a deps
-  if [[ "${DRY_RUN}" -eq 1 ]]; then
-    deps=("<vllm-rbln runtime deps minus torch-rbln/torch, from pyproject at runtime>")
-  else
-    local deps_text
-    deps_text="$(vllm_rbln_runtime_deps "${dir}/pyproject.toml")"
-    mapfile -t deps <<< "${deps_text}"
-  fi
-  # Installed with the inference venv's own pip, never uv, whatever UV is set
-  # to: pip reads the target interpreter's sys.path, so it sees the test venv's
-  # torch and torch-rbln through the .pth above and leaves them alone. uv
-  # resolves against the venv directory only, does not see them, and pulls its
-  # own torch in as a transitive dependency of vllm.
-  run "${py}" -m pip install "${deps[@]}" \
-    --extra-index-url "${vllm_index}" \
-    --extra-index-url https://pypi.rbln.ai/simple/ \
-    --extra-index-url https://download.pytorch.org/whl/cpu
+  # The inference venv's own pip, never uv, whatever UV is set to: the index
+  # options are read from the requirements file, and pip's view of the .pth
+  # layering is what verify_shared_packages checks afterwards.
+  run "${py}" -m pip install --no-deps --requirement "${REQUIREMENTS_INFERENCE}"
   run "${py}" -m pip install -e "${dir}" --no-deps
 
   verify_shared_packages "${py}"
@@ -272,7 +251,7 @@ import tempfile
 # no working directory on sys.path (a torch-rbln checkout has a ``torch`` symlink
 # at its root, and the installer is normally run from there).
 PROBE = r"""
-import json, os
+import importlib.metadata, json, os, sysconfig
 out = {}
 for name in ("torch", "torch_rbln", "rebel", "transformers"):
     try:
@@ -282,6 +261,14 @@ for name in ("torch", "torch_rbln", "rebel", "transformers"):
     else:
         path = getattr(mod, "__file__", "") or ""
         out[name] = [getattr(mod, "__version__", None), os.path.realpath(path) if path else ""]
+# Distributions installed in this interpreter's own site-packages (not through a .pth).
+purelib = os.path.realpath(sysconfig.get_paths()["purelib"])
+own = sorted(
+    dist.metadata["Name"]
+    for dist in importlib.metadata.distributions()
+    if os.path.realpath(str(dist.locate_file(""))).startswith(purelib)
+)
+out["_own_distributions"] = own
 print(json.dumps(out))
 """
 
@@ -307,6 +294,13 @@ for name in ("torch", "torch_rbln", "rebel"):
         problems.append("{}: {} in the inference venv, {} here".format(name, path, here[name][1]))
     if here[name][0] is not None and version != here[name][0]:
         problems.append("{}: {} in the inference venv, {} here".format(name, version, here[name][0]))
+
+# An import can resolve to the shared copy while a second distribution sits in
+# the venv (a broken or half-installed one, or a later import order): refuse it.
+own = {n.lower().replace("_", "-") for n in child["_own_distributions"]}
+for name in ("torch", "torch-rbln"):
+    if name in own:
+        problems.append("{}: a distribution is installed in the inference venv itself".format(name))
 
 # The whole point of the split: the inference venv must bring its own transformers.
 if child["transformers"][0] is None:

--- a/tools/test/requirements-inference.txt
+++ b/tools/test/requirements-inference.txt
@@ -1,0 +1,671 @@
+# Inference-stack requirements for test/models/test_vllm_llm.py and
+# test/models/test_optimum_llm.py (installed into the inference venv by
+# tools/test/install-test-deps.sh, --no-deps).
+#
+# Exported from vllm-rbln's uv.lock. Do not edit by hand; regenerate with
+#   tools/test/export-inference-requirements.sh
+# vllm-rbln-repo: https://github.com/rbln-sw/vllm-rbln.git
+# vllm-rbln-ref: db9f0025e9fd5bf8a09fcb86b2465aab702b6281
+#
+# torch and torch-rbln are deliberately absent: the inference venv shares the
+# test venv's copies (see install-test-deps.sh, step 4).
+
+--index-url https://pypi.org/simple
+--extra-index-url https://pypi.rbln.ai/simple/
+--extra-index-url https://wheels.vllm.ai/0.24.0/cpu
+--extra-index-url https://download.pytorch.org/whl/cpu
+
+accelerate==1.14.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via optimum-rbln
+aiohappyeyeballs==2.7.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via aiohttp
+aiohttp==3.14.3 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   fsspec
+    #   vllm
+aiosignal==1.4.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via aiohttp
+annotated-doc==0.0.4 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   fastapi
+    #   typer
+annotated-types==0.8.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via pydantic
+anthropic==0.119.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via vllm
+anyio==4.14.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   anthropic
+    #   httpx
+    #   mcp
+    #   openai
+    #   sse-starlette
+    #   starlette
+    #   watchfiles
+apache-tvm-ffi==0.1.12 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via xgrammar
+astor==0.8.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via depyf
+async-timeout==5.0.1 ; python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via aiohttp
+attrs==26.1.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   aiohttp
+    #   jsonschema
+    #   referencing
+av==17.1.0 ; python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via qwen-vl-utils
+av==18.0.0 ; python_full_version >= '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via qwen-vl-utils
+blake3==1.0.9 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via vllm
+cachetools==7.1.6 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via vllm
+cbor2==6.1.3 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via vllm
+certifi==2026.7.22 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   httpcore
+    #   httpx
+    #   requests
+    #   sentry-sdk
+cffi==2.1.0 ; (implementation_name == 'pypy' and platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux')
+    # via
+    #   cryptography
+    #   pyzmq
+charset-normalizer==3.4.9 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via requests
+click==8.4.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   huggingface-hub
+    #   rich-toolkit
+    #   uvicorn
+cloudpickle==3.1.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via vllm
+compressed-tensors==0.17.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via vllm
+cryptography==49.0.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via pyjwt
+datasets==5.0.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via vllm-rbln
+depyf==0.20.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via vllm
+detect-installer==0.1.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via fastapi-cloud-cli
+diffusers==0.38.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via optimum-rbln
+dill==0.4.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   datasets
+    #   depyf
+    #   multiprocess
+diskcache==5.6.3 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via vllm
+distro==1.9.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   anthropic
+    #   openai
+dnspython==2.8.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via email-validator
+docstring-parser==0.18.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via anthropic
+einops==0.8.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via vllm
+email-validator==2.3.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   fastapi
+    #   pydantic
+exceptiongroup==1.3.1 ; python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via anyio
+fastapi==0.136.3 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   model-hosting-container-standards
+    #   vllm
+    #   vllm-rbln
+fastapi-cli==0.0.32 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via fastapi
+fastapi-cloud-cli==0.22.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via fastapi-cli
+fastar==0.11.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   fastapi
+    #   fastapi-cloud-cli
+filelock==3.32.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   datasets
+    #   diffusers
+    #   huggingface-hub
+    #   torch
+    #   vllm
+frozenlist==1.8.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   aiohttp
+    #   aiosignal
+fsspec==2026.4.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   datasets
+    #   huggingface-hub
+    #   torch
+googleapis-common-protos==1.75.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.83.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via opentelemetry-exporter-otlp-proto-grpc
+h11==0.16.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   httpcore
+    #   uvicorn
+hf-xet==1.5.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via huggingface-hub
+httpcore==1.0.9 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via httpx
+httptools==0.8.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via uvicorn
+httpx==0.28.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   anthropic
+    #   datasets
+    #   diffusers
+    #   fastapi
+    #   fastapi-cloud-cli
+    #   huggingface-hub
+    #   mcp
+    #   model-hosting-container-standards
+    #   openai
+httpx-sse==0.4.3 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via mcp
+huggingface-hub==1.24.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   accelerate
+    #   datasets
+    #   diffusers
+    #   tokenizers
+    #   transformers
+idna==3.18 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   anyio
+    #   email-validator
+    #   httpx
+    #   requests
+    #   yarl
+ijson==3.5.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via vllm
+importlib-metadata==9.0.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via diffusers
+intel-openmp==2024.2.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via vllm
+interegular==0.3.3 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via lm-format-enforcer
+jinja2==3.1.6 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   fastapi
+    #   torch
+jiter==0.16.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   anthropic
+    #   openai
+jmespath==1.1.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via model-hosting-container-standards
+jsonschema==4.26.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   mcp
+    #   mistral-common
+    #   vllm
+jsonschema-specifications==2025.9.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via jsonschema
+lark==1.2.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via vllm
+libcst==1.8.6 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via torch-rbln
+llguidance==1.7.6 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via vllm
+llvmlite==0.47.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via numba
+lm-format-enforcer==0.11.3 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via vllm
+loguru==0.7.3 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via compressed-tensors
+markdown-it-py==4.2.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via rich
+markupsafe==3.0.3 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via jinja2
+mcp==1.28.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via vllm
+mdurl==0.1.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via markdown-it-py
+mistral-common==1.11.7 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via vllm
+model-hosting-container-standards==0.1.16 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via vllm
+mpmath==1.3.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via sympy
+msgspec==0.21.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via vllm
+multidict==6.7.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   aiohttp
+    #   yarl
+multiprocess==0.70.19 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via datasets
+networkx==3.4.2 ; python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via torch
+networkx==3.6.1 ; python_full_version >= '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via torch
+ninja==1.13.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via vllm
+numba==0.65.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via vllm
+numpy==2.2.6 ; python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   accelerate
+    #   datasets
+    #   diffusers
+    #   mistral-common
+    #   numba
+    #   opencv-python-headless
+    #   pandas
+    #   scipy
+    #   torchvision
+    #   transformers
+    #   vllm
+    #   xgrammar
+numpy==2.3.5 ; python_full_version >= '3.11' and python_full_version < '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   accelerate
+    #   datasets
+    #   diffusers
+    #   mistral-common
+    #   numba
+    #   opencv-python-headless
+    #   pandas
+    #   scipy
+    #   torchvision
+    #   transformers
+    #   vllm
+    #   xgrammar
+numpy==2.4.6 ; python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   accelerate
+    #   datasets
+    #   diffusers
+    #   mistral-common
+    #   numba
+    #   opencv-python-headless
+    #   pandas
+    #   scipy
+    #   torchvision
+    #   transformers
+    #   vllm
+    #   xgrammar
+openai==2.48.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via vllm
+openai-harmony==0.0.8 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via vllm
+opencv-python-headless==5.0.0.93 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   mistral-common
+    #   vllm
+opentelemetry-api==1.44.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+    #   vllm
+opentelemetry-exporter-otlp==1.44.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via vllm
+opentelemetry-exporter-otlp-proto-common==1.44.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.44.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via opentelemetry-exporter-otlp
+opentelemetry-exporter-otlp-proto-http==1.44.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via opentelemetry-exporter-otlp
+opentelemetry-proto==1.44.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.44.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-semantic-conventions-ai
+    #   vllm
+opentelemetry-semantic-conventions==0.65b0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions-ai
+opentelemetry-semantic-conventions-ai==0.5.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via vllm
+optimum-rbln==0.11.3a1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via vllm-rbln
+outlines-core==0.2.14 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via vllm
+packaging==26.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   accelerate
+    #   datasets
+    #   huggingface-hub
+    #   lm-format-enforcer
+    #   optimum-rbln
+    #   qwen-vl-utils
+    #   setuptools-scm
+    #   transformers
+    #   vcs-versioning
+pandas==2.3.3 ; python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via datasets
+pandas==3.0.5 ; python_full_version >= '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via datasets
+partial-json-parser==0.2.1.1.post7 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via vllm
+pillow==12.3.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   diffusers
+    #   mistral-common
+    #   qwen-vl-utils
+    #   torchvision
+    #   vllm
+prometheus-client==0.25.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   prometheus-fastapi-instrumentator
+    #   vllm
+prometheus-fastapi-instrumentator==8.0.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via vllm
+propcache==0.5.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   aiohttp
+    #   yarl
+protobuf==7.35.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   googleapis-common-protos
+    #   opentelemetry-proto
+    #   vllm
+psutil==7.2.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   accelerate
+    #   vllm
+py-cpuinfo==9.0.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via vllm
+pyarrow==25.0.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via datasets
+pybase64==1.4.3 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via vllm
+pycountry==26.2.16 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via pydantic-extra-types
+pycparser==3.0 ; (implementation_name != 'PyPy' and platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (implementation_name == 'pypy' and platform_machine == 'x86_64' and platform_python_implementation == 'PyPy' and sys_platform == 'linux')
+    # via cffi
+pydantic==2.13.4 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   anthropic
+    #   compressed-tensors
+    #   fastapi
+    #   fastapi-cloud-cli
+    #   lm-format-enforcer
+    #   mcp
+    #   mistral-common
+    #   model-hosting-container-standards
+    #   openai
+    #   openai-harmony
+    #   pydantic-extra-types
+    #   pydantic-settings
+    #   vllm
+    #   xgrammar
+pydantic-core==2.46.4 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via pydantic
+pydantic-extra-types==2.11.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   fastapi
+    #   mistral-common
+pydantic-settings==2.14.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   fastapi
+    #   mcp
+pygments==2.20.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via rich
+pyjwt==2.13.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via mcp
+python-dateutil==2.9.0.post0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via pandas
+python-dotenv==1.2.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   pydantic-settings
+    #   uvicorn
+python-json-logger==4.1.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via vllm
+python-multipart==0.0.32 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   fastapi
+    #   mcp
+pytz==2026.2 ; python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via pandas
+pyyaml==6.0.3 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   accelerate
+    #   datasets
+    #   huggingface-hub
+    #   libcst
+    #   lm-format-enforcer
+    #   torch-rbln
+    #   transformers
+    #   uvicorn
+    #   vllm
+    #   vllm-rbln
+pyyaml-ft==8.0.0 ; python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via libcst
+pyzmq==27.1.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via vllm
+qwen-vl-utils==0.0.14 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via vllm-rbln
+referencing==0.37.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   jsonschema
+    #   jsonschema-specifications
+regex==2026.7.19 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   diffusers
+    #   tiktoken
+    #   transformers
+    #   vllm
+requests==2.34.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   datasets
+    #   diffusers
+    #   mistral-common
+    #   opentelemetry-exporter-otlp-proto-http
+    #   qwen-vl-utils
+    #   tiktoken
+    #   vllm
+rich==15.0.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   rich-toolkit
+    #   typer
+rich-toolkit==0.20.3 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   fastapi-cli
+    #   fastapi-cloud-cli
+rignore==0.8.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via fastapi-cloud-cli
+rpds-py==0.30.0 ; python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   jsonschema
+    #   referencing
+rpds-py==2026.6.3 ; python_full_version >= '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   jsonschema
+    #   referencing
+safetensors==0.8.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   accelerate
+    #   diffusers
+    #   transformers
+    #   vllm
+scipy==1.15.3 ; python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via torch-rbln
+scipy==1.17.1 ; python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via torch-rbln
+scipy==1.18.0 ; python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via torch-rbln
+sentencepiece==0.2.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via vllm
+sentry-sdk==2.66.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via fastapi-cloud-cli
+setproctitle==1.3.7 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via vllm
+setuptools==77.0.3 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   model-hosting-container-standards
+    #   setuptools-scm
+    #   torch
+    #   vllm
+    #   vllm-rbln
+setuptools-scm==10.2.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via vllm-rbln
+shellingham==1.5.4 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via typer
+six==1.17.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   python-dateutil
+    #   vllm
+sniffio==1.3.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   anthropic
+    #   openai
+sse-starlette==3.4.6 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via mcp
+starlette==1.3.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   fastapi
+    #   mcp
+    #   model-hosting-container-standards
+    #   prometheus-fastapi-instrumentator
+    #   sse-starlette
+    #   vllm
+supervisor==4.3.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via model-hosting-container-standards
+sympy==1.14.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via torch
+tiktoken==0.13.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   mistral-common
+    #   vllm
+tokenizers==0.22.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   optimum-rbln
+    #   transformers
+    #   vllm
+tomli==2.4.1 ; python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   fastapi-cli
+    #   setuptools-scm
+    #   vcs-versioning
+torchaudio==2.11.0+cpu ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   optimum-rbln
+    #   vllm
+    #   vllm-rbln
+torchcodec==0.11.0+cpu ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   optimum-rbln
+    #   vllm-rbln
+torchvision==0.26.0+cpu ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   optimum-rbln
+    #   vllm
+    #   vllm-rbln
+tqdm==4.69.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   datasets
+    #   huggingface-hub
+    #   openai
+    #   transformers
+    #   vllm
+transformers==5.15.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   compressed-tensors
+    #   optimum-rbln
+    #   vllm
+    #   xgrammar
+triton==3.7.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via xgrammar
+typer==0.27.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   fastapi-cli
+    #   fastapi-cloud-cli
+    #   transformers
+typing-extensions==4.16.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   aiohttp
+    #   aiosignal
+    #   anthropic
+    #   anyio
+    #   apache-tvm-ffi
+    #   blake3
+    #   cryptography
+    #   exceptiongroup
+    #   fastapi
+    #   grpcio
+    #   huggingface-hub
+    #   mcp
+    #   mistral-common
+    #   multidict
+    #   openai
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+    #   pydantic
+    #   pydantic-core
+    #   pydantic-extra-types
+    #   pyjwt
+    #   referencing
+    #   rich-toolkit
+    #   setuptools-scm
+    #   starlette
+    #   torch
+    #   typing-inspection
+    #   uvicorn
+    #   vcs-versioning
+    #   vllm
+    #   xgrammar
+typing-inspection==0.4.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   fastapi
+    #   mcp
+    #   pydantic
+    #   pydantic-settings
+tzdata==2026.3 ; python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via pandas
+urllib3==2.7.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   requests
+    #   sentry-sdk
+uvicorn==0.51.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   fastapi
+    #   fastapi-cli
+    #   fastapi-cloud-cli
+    #   mcp
+uvloop==0.22.1 ; platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux'
+    # via uvicorn
+vcs-versioning==2.2.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via setuptools-scm
+vllm==0.24.0+cpu ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via vllm-rbln
+watchfiles==1.2.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via
+    #   uvicorn
+    #   vllm
+websockets==16.1.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via uvicorn
+xgrammar==0.2.3 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via vllm
+xxhash==3.8.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via datasets
+yarl==1.24.5 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via aiohttp
+zipp==4.1.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+    # via importlib-metadata

--- a/tools/test/requirements-inference.txt
+++ b/tools/test/requirements-inference.txt
@@ -1,14 +1,8 @@
-# Inference-stack requirements for test/models/test_vllm_llm.py and
-# test/models/test_optimum_llm.py (installed into the inference venv by
-# tools/test/install-test-deps.sh, --no-deps).
-#
-# Exported from vllm-rbln's uv.lock. Do not edit by hand; regenerate with
-#   tools/test/export-inference-requirements.sh
+# Inference venv requirements, exported from vllm-rbln's uv.lock.
+# Regenerate with tools/test/export-inference-requirements.sh; do not edit.
 # vllm-rbln-repo: https://github.com/rbln-sw/vllm-rbln.git
 # vllm-rbln-ref: db9f0025e9fd5bf8a09fcb86b2465aab702b6281
-#
-# torch and torch-rbln are deliberately absent: the inference venv shares the
-# test venv's copies (see install-test-deps.sh, step 4).
+# torch and torch-rbln are omitted: the inference venv shares the test venv's.
 
 --index-url https://pypi.org/simple
 --extra-index-url https://pypi.rbln.ai/simple/
@@ -16,656 +10,179 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 
 accelerate==1.14.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via optimum-rbln
 aiohappyeyeballs==2.7.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via aiohttp
 aiohttp==3.14.3 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   fsspec
-    #   vllm
 aiosignal==1.4.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via aiohttp
 annotated-doc==0.0.4 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   fastapi
-    #   typer
 annotated-types==0.8.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via pydantic
 anthropic==0.119.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via vllm
 anyio==4.14.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   anthropic
-    #   httpx
-    #   mcp
-    #   openai
-    #   sse-starlette
-    #   starlette
-    #   watchfiles
 apache-tvm-ffi==0.1.12 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via xgrammar
 astor==0.8.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via depyf
 async-timeout==5.0.1 ; python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via aiohttp
 attrs==26.1.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   aiohttp
-    #   jsonschema
-    #   referencing
 av==17.1.0 ; python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via qwen-vl-utils
 av==18.0.0 ; python_full_version >= '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via qwen-vl-utils
 blake3==1.0.9 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via vllm
 cachetools==7.1.6 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via vllm
 cbor2==6.1.3 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via vllm
 certifi==2026.7.22 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   httpcore
-    #   httpx
-    #   requests
-    #   sentry-sdk
 cffi==2.1.0 ; (implementation_name == 'pypy' and platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux')
-    # via
-    #   cryptography
-    #   pyzmq
 charset-normalizer==3.4.9 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via requests
 click==8.4.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   huggingface-hub
-    #   rich-toolkit
-    #   uvicorn
 cloudpickle==3.1.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via vllm
 compressed-tensors==0.17.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via vllm
 cryptography==49.0.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via pyjwt
 datasets==5.0.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via vllm-rbln
 depyf==0.20.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via vllm
 detect-installer==0.1.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via fastapi-cloud-cli
 diffusers==0.38.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via optimum-rbln
 dill==0.4.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   datasets
-    #   depyf
-    #   multiprocess
 diskcache==5.6.3 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via vllm
 distro==1.9.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   anthropic
-    #   openai
 dnspython==2.8.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via email-validator
 docstring-parser==0.18.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via anthropic
 einops==0.8.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via vllm
 email-validator==2.3.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   fastapi
-    #   pydantic
 exceptiongroup==1.3.1 ; python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via anyio
 fastapi==0.136.3 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   model-hosting-container-standards
-    #   vllm
-    #   vllm-rbln
 fastapi-cli==0.0.32 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via fastapi
 fastapi-cloud-cli==0.22.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via fastapi-cli
 fastar==0.11.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   fastapi
-    #   fastapi-cloud-cli
 filelock==3.32.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   datasets
-    #   diffusers
-    #   huggingface-hub
-    #   torch
-    #   vllm
 frozenlist==1.8.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   aiohttp
-    #   aiosignal
 fsspec==2026.4.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   datasets
-    #   huggingface-hub
-    #   torch
 googleapis-common-protos==1.75.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
 grpcio==1.83.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via opentelemetry-exporter-otlp-proto-grpc
 h11==0.16.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   httpcore
-    #   uvicorn
 hf-xet==1.5.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via huggingface-hub
 httpcore==1.0.9 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via httpx
 httptools==0.8.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via uvicorn
 httpx==0.28.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   anthropic
-    #   datasets
-    #   diffusers
-    #   fastapi
-    #   fastapi-cloud-cli
-    #   huggingface-hub
-    #   mcp
-    #   model-hosting-container-standards
-    #   openai
 httpx-sse==0.4.3 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via mcp
 huggingface-hub==1.24.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   accelerate
-    #   datasets
-    #   diffusers
-    #   tokenizers
-    #   transformers
 idna==3.18 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   anyio
-    #   email-validator
-    #   httpx
-    #   requests
-    #   yarl
 ijson==3.5.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via vllm
 importlib-metadata==9.0.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via diffusers
 intel-openmp==2024.2.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via vllm
 interegular==0.3.3 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via lm-format-enforcer
 jinja2==3.1.6 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   fastapi
-    #   torch
 jiter==0.16.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   anthropic
-    #   openai
 jmespath==1.1.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via model-hosting-container-standards
 jsonschema==4.26.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   mcp
-    #   mistral-common
-    #   vllm
 jsonschema-specifications==2025.9.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via jsonschema
 lark==1.2.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via vllm
 libcst==1.8.6 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via torch-rbln
 llguidance==1.7.6 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via vllm
 llvmlite==0.47.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via numba
 lm-format-enforcer==0.11.3 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via vllm
 loguru==0.7.3 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via compressed-tensors
 markdown-it-py==4.2.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via rich
 markupsafe==3.0.3 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via jinja2
 mcp==1.28.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via vllm
 mdurl==0.1.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via markdown-it-py
 mistral-common==1.11.7 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via vllm
 model-hosting-container-standards==0.1.16 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via vllm
 mpmath==1.3.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via sympy
 msgspec==0.21.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via vllm
 multidict==6.7.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   aiohttp
-    #   yarl
 multiprocess==0.70.19 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via datasets
 networkx==3.4.2 ; python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via torch
 networkx==3.6.1 ; python_full_version >= '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via torch
 ninja==1.13.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via vllm
 numba==0.65.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via vllm
 numpy==2.2.6 ; python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   accelerate
-    #   datasets
-    #   diffusers
-    #   mistral-common
-    #   numba
-    #   opencv-python-headless
-    #   pandas
-    #   scipy
-    #   torchvision
-    #   transformers
-    #   vllm
-    #   xgrammar
 numpy==2.3.5 ; python_full_version >= '3.11' and python_full_version < '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   accelerate
-    #   datasets
-    #   diffusers
-    #   mistral-common
-    #   numba
-    #   opencv-python-headless
-    #   pandas
-    #   scipy
-    #   torchvision
-    #   transformers
-    #   vllm
-    #   xgrammar
 numpy==2.4.6 ; python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   accelerate
-    #   datasets
-    #   diffusers
-    #   mistral-common
-    #   numba
-    #   opencv-python-headless
-    #   pandas
-    #   scipy
-    #   torchvision
-    #   transformers
-    #   vllm
-    #   xgrammar
 openai==2.48.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via vllm
 openai-harmony==0.0.8 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via vllm
 opencv-python-headless==5.0.0.93 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   mistral-common
-    #   vllm
 opentelemetry-api==1.44.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-    #   opentelemetry-sdk
-    #   opentelemetry-semantic-conventions
-    #   vllm
 opentelemetry-exporter-otlp==1.44.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via vllm
 opentelemetry-exporter-otlp-proto-common==1.44.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-exporter-otlp-proto-grpc==1.44.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via opentelemetry-exporter-otlp
 opentelemetry-exporter-otlp-proto-http==1.44.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via opentelemetry-exporter-otlp
 opentelemetry-proto==1.44.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.44.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-    #   opentelemetry-semantic-conventions-ai
-    #   vllm
 opentelemetry-semantic-conventions==0.65b0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   opentelemetry-sdk
-    #   opentelemetry-semantic-conventions-ai
 opentelemetry-semantic-conventions-ai==0.5.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via vllm
 optimum-rbln==0.11.3a1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via vllm-rbln
 outlines-core==0.2.14 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via vllm
 packaging==26.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   accelerate
-    #   datasets
-    #   huggingface-hub
-    #   lm-format-enforcer
-    #   optimum-rbln
-    #   qwen-vl-utils
-    #   setuptools-scm
-    #   transformers
-    #   vcs-versioning
 pandas==2.3.3 ; python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via datasets
 pandas==3.0.5 ; python_full_version >= '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via datasets
 partial-json-parser==0.2.1.1.post7 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via vllm
 pillow==12.3.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   diffusers
-    #   mistral-common
-    #   qwen-vl-utils
-    #   torchvision
-    #   vllm
 prometheus-client==0.25.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   prometheus-fastapi-instrumentator
-    #   vllm
 prometheus-fastapi-instrumentator==8.0.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via vllm
 propcache==0.5.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   aiohttp
-    #   yarl
 protobuf==7.35.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   googleapis-common-protos
-    #   opentelemetry-proto
-    #   vllm
 psutil==7.2.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   accelerate
-    #   vllm
 py-cpuinfo==9.0.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via vllm
 pyarrow==25.0.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via datasets
 pybase64==1.4.3 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via vllm
 pycountry==26.2.16 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via pydantic-extra-types
 pycparser==3.0 ; (implementation_name != 'PyPy' and platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (implementation_name == 'pypy' and platform_machine == 'x86_64' and platform_python_implementation == 'PyPy' and sys_platform == 'linux')
-    # via cffi
 pydantic==2.13.4 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   anthropic
-    #   compressed-tensors
-    #   fastapi
-    #   fastapi-cloud-cli
-    #   lm-format-enforcer
-    #   mcp
-    #   mistral-common
-    #   model-hosting-container-standards
-    #   openai
-    #   openai-harmony
-    #   pydantic-extra-types
-    #   pydantic-settings
-    #   vllm
-    #   xgrammar
 pydantic-core==2.46.4 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via pydantic
 pydantic-extra-types==2.11.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   fastapi
-    #   mistral-common
 pydantic-settings==2.14.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   fastapi
-    #   mcp
 pygments==2.20.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via rich
 pyjwt==2.13.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via mcp
 python-dateutil==2.9.0.post0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via pandas
 python-dotenv==1.2.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   pydantic-settings
-    #   uvicorn
 python-json-logger==4.1.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via vllm
 python-multipart==0.0.32 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   fastapi
-    #   mcp
 pytz==2026.2 ; python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via pandas
 pyyaml==6.0.3 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   accelerate
-    #   datasets
-    #   huggingface-hub
-    #   libcst
-    #   lm-format-enforcer
-    #   torch-rbln
-    #   transformers
-    #   uvicorn
-    #   vllm
-    #   vllm-rbln
 pyyaml-ft==8.0.0 ; python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via libcst
 pyzmq==27.1.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via vllm
 qwen-vl-utils==0.0.14 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via vllm-rbln
 referencing==0.37.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   jsonschema
-    #   jsonschema-specifications
 regex==2026.7.19 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   diffusers
-    #   tiktoken
-    #   transformers
-    #   vllm
 requests==2.34.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   datasets
-    #   diffusers
-    #   mistral-common
-    #   opentelemetry-exporter-otlp-proto-http
-    #   qwen-vl-utils
-    #   tiktoken
-    #   vllm
 rich==15.0.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   rich-toolkit
-    #   typer
 rich-toolkit==0.20.3 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   fastapi-cli
-    #   fastapi-cloud-cli
 rignore==0.8.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via fastapi-cloud-cli
 rpds-py==0.30.0 ; python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   jsonschema
-    #   referencing
 rpds-py==2026.6.3 ; python_full_version >= '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   jsonschema
-    #   referencing
 safetensors==0.8.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   accelerate
-    #   diffusers
-    #   transformers
-    #   vllm
 scipy==1.15.3 ; python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via torch-rbln
 scipy==1.17.1 ; python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via torch-rbln
 scipy==1.18.0 ; python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via torch-rbln
 sentencepiece==0.2.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via vllm
 sentry-sdk==2.66.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via fastapi-cloud-cli
 setproctitle==1.3.7 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via vllm
 setuptools==77.0.3 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   model-hosting-container-standards
-    #   setuptools-scm
-    #   torch
-    #   vllm
-    #   vllm-rbln
 setuptools-scm==10.2.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via vllm-rbln
 shellingham==1.5.4 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via typer
 six==1.17.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   python-dateutil
-    #   vllm
 sniffio==1.3.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   anthropic
-    #   openai
 sse-starlette==3.4.6 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via mcp
 starlette==1.3.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   fastapi
-    #   mcp
-    #   model-hosting-container-standards
-    #   prometheus-fastapi-instrumentator
-    #   sse-starlette
-    #   vllm
 supervisor==4.3.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via model-hosting-container-standards
 sympy==1.14.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via torch
 tiktoken==0.13.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   mistral-common
-    #   vllm
 tokenizers==0.22.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   optimum-rbln
-    #   transformers
-    #   vllm
 tomli==2.4.1 ; python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   fastapi-cli
-    #   setuptools-scm
-    #   vcs-versioning
 torchaudio==2.11.0+cpu ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   optimum-rbln
-    #   vllm
-    #   vllm-rbln
 torchcodec==0.11.0+cpu ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   optimum-rbln
-    #   vllm-rbln
 torchvision==0.26.0+cpu ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   optimum-rbln
-    #   vllm
-    #   vllm-rbln
 tqdm==4.69.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   datasets
-    #   huggingface-hub
-    #   openai
-    #   transformers
-    #   vllm
 transformers==5.15.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   compressed-tensors
-    #   optimum-rbln
-    #   vllm
-    #   xgrammar
 triton==3.7.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via xgrammar
 typer==0.27.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   fastapi-cli
-    #   fastapi-cloud-cli
-    #   transformers
 typing-extensions==4.16.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   aiohttp
-    #   aiosignal
-    #   anthropic
-    #   anyio
-    #   apache-tvm-ffi
-    #   blake3
-    #   cryptography
-    #   exceptiongroup
-    #   fastapi
-    #   grpcio
-    #   huggingface-hub
-    #   mcp
-    #   mistral-common
-    #   multidict
-    #   openai
-    #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-    #   opentelemetry-sdk
-    #   opentelemetry-semantic-conventions
-    #   pydantic
-    #   pydantic-core
-    #   pydantic-extra-types
-    #   pyjwt
-    #   referencing
-    #   rich-toolkit
-    #   setuptools-scm
-    #   starlette
-    #   torch
-    #   typing-inspection
-    #   uvicorn
-    #   vcs-versioning
-    #   vllm
-    #   xgrammar
 typing-inspection==0.4.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   fastapi
-    #   mcp
-    #   pydantic
-    #   pydantic-settings
 tzdata==2026.3 ; python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via pandas
 urllib3==2.7.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   requests
-    #   sentry-sdk
 uvicorn==0.51.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   fastapi
-    #   fastapi-cli
-    #   fastapi-cloud-cli
-    #   mcp
 uvloop==0.22.1 ; platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux'
-    # via uvicorn
 vcs-versioning==2.2.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via setuptools-scm
 vllm==0.24.0+cpu ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via vllm-rbln
 watchfiles==1.2.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   uvicorn
-    #   vllm
 websockets==16.1.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via uvicorn
 xgrammar==0.2.3 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via vllm
 xxhash==3.8.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via datasets
 yarl==1.24.5 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via aiohttp
 zipp==4.1.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via importlib-metadata


### PR DESCRIPTION
## Summary of Changes

Two independent failures in the nightly Release checks, fixed in one PR because they land in the same gate (RBLN-SW/torch-rbln runs 34244905641, 34370190775; fsw-integration 34370281828).

**1. `lint / lint_source` matrix: uv cache lock contention** (`.github/workflows/_lint-source.yaml`)

The release matrix runs ten lint jobs at once on runners that share a home directory, so they share uv's cache. `uv sync` locks the source build of this project per cache entry, the build outlasts uv's default lock timeout, and every job but the one holding the lock fails (`Failed to acquire lock on the distribution cache ... is another uv process running?`). Two of ten survived on both nights. Pre-merge and post-merge run a one-job matrix and never contended. The job now points `UV_CACHE_DIR` at its own `RUNNER_TEMP`, which is what setup-uv's cache mode does on its own when enabled.

**2. Model suite, Debug lineups: a second torch in the inference venv** (`tools/test/`)

`install-test-deps.sh` read vllm-rbln's direct dependencies from its pyproject at install time, dropped `torch` and `torch-rbln`, and let pip resolve the rest. That only shields the shared packages from vllm-rbln's own requirements. vllm's requirement on torch names the release wheel exactly, so whenever the test venv's torch is not that wheel (the Debug lineup's torch, a local build) pip installs a second torch into the inference venv and `verify_shared_packages` fails:

```
torch: 2.11.0+cpu in the inference venv, 2.11.0+cpu.debug here
```

Before #245 the same lineups passed because optimum-rbln downgraded the venv's torch outright; the verification made the mismatch visible rather than introducing it.

The inference venv is now installed `--no-deps` from `tools/test/requirements-inference.txt`, an export of vllm-rbln's `uv.lock` at a recorded commit with `torch` and `torch-rbln` left out. No resolver runs, so no requirement at any depth can reach the packages under test, and the stack the suite runs on is the one vllm-rbln tests itself with, fixed until a reviewed regeneration.

* `tools/test/requirements-inference.txt`: the export (index URLs included; pip reads them from the file). Header records the vllm-rbln commit the pins came from, which is also what the installer checks out.
* `tools/test/export-inference-requirements.sh`: regenerates it (`uv export --frozen ... --no-emit-package torch --no-emit-package torch-rbln`). Moving the suite to another vllm-rbln commit is `VLLM_RBLN_REF=<ref> ./tools/test/export-inference-requirements.sh` and a diff to review.
* `tools/test/install-test-deps.sh`: step 4 installs from the file; the runtime pyproject parsing is gone. Refuses a requirements file that lists either shared package, and `verify_shared_packages` now also rejects a torch / torch-rbln distribution installed in the inference venv itself (an import can still resolve to the shared copy while a stray one sits there). The clone check uses git so a worktree works as `VLLM_RBLN_DIR`.
* `.gitignore`: the installer's default clone directory.
* `docs/TEST_GUIDE.md`, `test/models/test_vllm_llm.py` docstring.

The pinned optimum-rbln is the one vllm-rbln's lock names, which is older than what the nightly resolution picked last night; the Release lineups will show whether the suite's cases hold on it.

Layer: CI workflow and test tooling. No runtime code.

---

## Related Issues / Tickets

* Follow-up to #245 (Debug lineup failure surfaced by its verification step).
* Failing runs: RBLN-SW/torch-rbln 34370190775 (lint), rebellions-sw/fsw-integration 34370281828 (Debug × atom model tests).
* No linked issue: nightly gate breakage, fixed directly.

---

## Type of Change

- [x] `ci` — workflow fix
- [x] `fix(test)` — test tooling

---

## Affected Modules

- [x] Build/Tools
- [x] CI

---

## How to Test

1. Release checks (`workflow_dispatch` on this branch or the next nightly): all ten `lint_source` jobs finish; none reports the uv lock timeout.
2. `bash tools/test/install-test-deps.sh` in a venv holding torch-rbln: pip's install log shows no `torch` download; the verification prints the shared torch / torch-rbln / rebel and transformers 5 in the inference venv. Adding a fake `torch-*.dist-info` to the inference venv and rerunning makes the verification fail with `a distribution is installed in the inference venv itself`.
3. `.venv-inference/bin/python -m pytest test/models/test_vllm_llm.py test/models/test_optimum_llm.py --collect-only`: 40 tests collected.
4. fsw-integration Release: `Run release tests (Debug, 3.12, atom, *) / Run model tests` gets past `install-test-deps.sh`.

Done on an RBLN-CR03 host against a torch 2.11 test venv (steps 2, 3). On device, `test_optimum_llm.py -k "test_tp1_eager_input_ids and llama_1b"` passes for both dtypes on the pinned optimum-rbln. The vllm cases pin physical NPU 0, which another job held on this host, so those runs are left to CI.

---

## Checklist

* [x] PR title follows Conventional Commits
* [x] Linked to a corresponding issue
* [x] Linting passes (shellcheck `enable=all`, actionlint, zizmor, flake8)
* [ ] All CI tests pass
* [x] Test method and expected result described
* [x] Relevant documentation updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
